### PR TITLE
🧹 update daemonset example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -7,15 +7,22 @@ In Kubernetes, we support running in two ways:
 
 ## Preparation
 
-1. Download service account from Mondooo (Integration -> Managed Clients -> Add Client, Download Credentials)
+1. Download service account from mondooo
 2. Convert json to yaml via `yq e -P creds.json`
-3. Update the `deamonset-config.yaml` and/or `job-config.yaml` with the service account
+3. Update the `daemonset-config.yaml` and/or `job-config.yaml` with the service account
 
 ## Deploy job
 
 ```bash
 # run job
 kubectl apply -f job.yaml -f job-config.yaml
+# list job
+kubectl get jobs
+NAME         COMPLETIONS   DURATION   AGE
+mondoo-job   0/1           11s        11s
+# describe pod
+kubectl describe jobs mondoo-job  
+
 # delete job
 kubectl delete jobs mondoo-job 
 ```
@@ -24,7 +31,7 @@ kubectl delete jobs mondoo-job
 
 ```bash
 # install daemonset
-kubectl apply -f daemonset.yaml -f deamonset-config.yaml
+kubectl apply -f daemonset.yaml -f daemonset-config.yaml 
 # delete daemonset
 kubectl delete daemonsets.apps mondoo-daemonset
 ```

--- a/example/daemonset.yaml
+++ b/example/daemonset.yaml
@@ -45,3 +45,5 @@ spec:
             items:
               - key: config
                 path: mondoo.yml
+              - key: inventory
+                path: inventory.yml

--- a/example/deamonset-config.yaml
+++ b/example/deamonset-config.yaml
@@ -5,10 +5,6 @@ metadata:
   name: mondoo-daemonset-config
 data:
   config: |
-    # configuration to scan mounted host
-    assets:
-    - connection: "fs:///mnt/host"
-    # service account configuration
     mrn: //agents.api.mondoo.app/spaces/test-infallible-taussig-796596/serviceaccounts/1u20vCfgWqaxOjGmWFFCH4qi2se
     space_mrn: //captain.api.mondoo.app/spaces/test-infallible-taussig-796596
     private_key: |
@@ -23,4 +19,17 @@ data:
       ...
       Rc3OFH5K0IWA0yDdL5QVoQ==
       -----END CERTIFICATE-----
-    api_endpoint: http://eb6668cdfec2.ngrok.io
+    api_endpoint: https://api.mondoo.app
+  inventory: |
+    apiVersion: v1
+    kind: Inventory
+    metadata:
+      name: mondoo-k8s-inventory
+      labels:
+        environment: production
+    spec:
+      assets:
+        - id: host
+          connections:
+            - host: /mnt/host
+              backend: fs


### PR DESCRIPTION
This PR updates the configuration for the daemonset

- adds the inventory configuration
- removes old asset information, so mondoo.yml just includes the service account now

Tested on minikube and k3s
