### PR TITLE
⭐️ test the operator deployment with Mondoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,3 +199,8 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# Verify the operator deployment
+.PHONY: test/deployment
+test/deployment:
+	mondoo scan -t k8s test/deployment-policy.yaml --incognito

--- a/test/deployment-policy.yaml
+++ b/test/deployment-policy.yaml
@@ -1,0 +1,41 @@
+policies:
+  - uid: mondoo-operator
+    name: Mondoo Operator Policy
+    version: "1.0.0"
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.io
+    specs:
+      - title: General
+        asset_filter:
+          query: platform.name == "kubernetes"
+        scoring_queries:
+          # namespace-exists: # deactivated since there is a bug with namespaces
+          crd-created:
+          controller-deployed:
+      - title: Node Scan
+        asset_filter:
+          query: platform.name == "kubernetes"
+        scoring_queries:
+          daemonset-exists:
+      - title: Resource Scan
+        asset_filter:
+          query: platform.name == "kubernetes"
+        scoring_queries:
+          deployment-exists:
+queries:
+  - uid: namespace-exists
+    title: Ensure the namespace exists
+    query: k8s.namespaces.one ( name == "mondoo-operator-system")
+  - uid: crd-created
+    title: Ensure the CRD for MondooScanConfig exitsts
+    query: k8s.apiResources.one( kind == "MondooClient")
+  - uid: controller-deployed
+    title: Ensure the Controller is deployed
+    query: k8s.deployments.one( name == "mondoo-operator-controller-manager" && namespace == "mondoo-operator-system" )
+  - uid: deployment-exists
+    title: Ensure the deployment is configured
+    query: k8s.deployments.one( name == "mondoo-client" && namespace == "mondoo-operator-system" )
+  - uid: daemonset-exists
+    title: Ensure the daemonset is configured
+    query: k8s.daemonsets.one( name == "mondoo-client" && namespace == "mondoo-operator-system" )


### PR DESCRIPTION
Adds a new initial policy to test the deployment for the Mondoo Operator

<img width="712" alt="Screenshot 2022-02-02 at 12 38 16" src="https://user-images.githubusercontent.com/1178413/152147160-2efe0877-bbda-4e98-8b8f-ecfce2bcd334.png">

You can run the policy locally via:

```bash
make test/deployment
# or
mondoo scan -t k8s test/deployment-policy.yaml --incognito
```

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>