### PR TITLE
Default Inventory for Deployment changed to use namespace

### DIFF
--- a/controllers/inventory-deploy.yaml
+++ b/controllers/inventory-deploy.yaml
@@ -9,3 +9,5 @@ spec:
     - id: api
       connections:
         - backend: k8s
+          options:
+            namespace: kube-system


### PR DESCRIPTION
Changed Default inventory to use namespace for deployment. Currently scans kubesystem namespace if inventory is not mentioned in customresource
fixes #31 
Signed-off-by: Harsha <harshaisgud@gmail.com>