### PR TITLE
fixing ci

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -95,7 +95,8 @@ jobs:
           context: .
           file: bundle.Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          labels: ${{ steps.meta.outputs-bundle.labels }}
+          push: true
+          labels: ${{ steps.meta-bundle.outputs.labels }}
           tags: ${{ steps.meta-bundle.outputs.tags }}
 
       # Sign the resulting Docker image digest except on PRs.


### PR DESCRIPTION
Signed-off-by: jensgrnb <jens.grunborg@endocode.com>

the bundle is not being pushed because of missing flag