### PR TITLE
⭐️ updates to allow building with buildah

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ testbin/*
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/library/golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
+buildah-build: test ## Build container image
+	buildah build -t ${IMG} .
+
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 


### PR DESCRIPTION
Add new makefile target 'buildah-build' to allow using 'buildah' for
building the container image locally.

As part of that work, buildah gets confused and starts asking questions
about where to fetch the golang:1.17 build container image from. Clarify
that by using a fully qualified name/path for the image
s|golang:1.17|docker.io/library/golang:1.17|

Lastly, add '.vscode' to the .gitignore file for the VSCode users of the
world.