### PR TITLE
fixes for setting ControllerRef, error/requeue handing, and Status() updates

### DIFF
--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -96,6 +96,8 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	result, err := nodes.Reconcile(ctx, r.Client, r.Scheme, req, string(dsInventoryyaml))
 	if err != nil {
 		log.Error(err, "Failed to declare nodes")
+	}
+	if err != nil || result.Requeue {
 		return result, err
 	}
 
@@ -107,6 +109,8 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	result, err = workloads.Reconcile(ctx, r.Client, r.Scheme, req, string(deployInventoryyaml))
 	if err != nil {
 		log.Error(err, "Failed to declare workloads")
+	}
+	if err != nil || result.Requeue {
 		return result, err
 	}
 

--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -232,8 +232,14 @@ func (n *Nodes) deamonsetForMondoo(m *v1alpha1.MondooAuditConfig, cmName string)
 
 func (n *Nodes) Reconcile(ctx context.Context, clt client.Client, scheme *runtime.Scheme, req ctrl.Request, inventory string) (ctrl.Result, error) {
 	if n.Enable {
-		n.declareConfigMap(ctx, clt, scheme, req, inventory)
-		n.declareDaemonSet(ctx, clt, scheme, req, true)
+		result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
+		if err != nil || result.Requeue {
+			return result, err
+		}
+		result, err = n.declareDaemonSet(ctx, clt, scheme, req, true)
+		if err != nil || result.Requeue {
+			return result, err
+		}
 	} else {
 		n.down(ctx, clt, req)
 	}

--- a/controllers/workloads.go
+++ b/controllers/workloads.go
@@ -55,13 +55,17 @@ func (n *Workloads) declareConfigMap(ctx context.Context, clt client.Client, sch
 		found.Data = map[string]string{
 			"inventory": inventory,
 		}
+		if err := ctrl.SetControllerReference(&n.Mondoo, found, scheme); err != nil {
+			log.Error(err, "Failed to set ControllerReference", "ConfigMap.Namespace", found.Namespace, "ConfigMap.Name", found.Name)
+			return ctrl.Result{}, err
+		}
+
 		err := clt.Create(ctx, found)
 		if err != nil {
 			log.Error(err, "Failed to create new Configmap", "ConfigMap.Namespace", found.Namespace, "ConfigMap.Name", found.Name)
 			return ctrl.Result{}, err
 		}
 
-		ctrl.SetControllerReference(&n.Mondoo, found, scheme)
 		return ctrl.Result{Requeue: true}, err
 
 	} else if err != nil {
@@ -92,12 +96,16 @@ func (n *Workloads) declareDeployment(ctx context.Context, clt client.Client, sc
 	if err != nil && errors.IsNotFound(err) {
 
 		declared := n.deploymentForMondoo(&n.Mondoo, n.Mondoo.Name+"-deploy")
+		if err := ctrl.SetControllerReference(&n.Mondoo, declared, scheme); err != nil {
+			log.Error(err, "Failed to set ControllerReference", "Deployment.Namespace", declared.Namespace, "Deployment.Name", declared.Name)
+			return ctrl.Result{}, err
+		}
+
 		err := clt.Create(ctx, declared)
 		if err != nil {
 			log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", declared.Namespace, "Deployment.Name", declared.Name)
 			return ctrl.Result{}, err
 		}
-		ctrl.SetControllerReference(&n.Mondoo, declared, scheme)
 		return ctrl.Result{Requeue: true}, err
 
 	} else if err != nil {

--- a/controllers/workloads.go
+++ b/controllers/workloads.go
@@ -236,8 +236,14 @@ func (n *Workloads) deploymentForMondoo(m *v1alpha1.MondooAuditConfig, cmName st
 
 func (n *Workloads) Reconcile(ctx context.Context, clt client.Client, scheme *runtime.Scheme, req ctrl.Request, inventory string) (ctrl.Result, error) {
 	if n.Enable {
-		n.declareConfigMap(ctx, clt, scheme, req, inventory)
-		n.declareDeployment(ctx, clt, scheme, req, true)
+		result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
+		if err != nil || result.Requeue {
+			return result, err
+		}
+		result, err = n.declareDeployment(ctx, clt, scheme, req, true)
+		if err != nil || result.Requeue {
+			return result, err
+		}
 	} else {
 		n.down(ctx, clt, req)
 	}


### PR DESCRIPTION
- [x] Move SetControllerReference() to before Create() so the ControllerReference is actually set on the resource(s)
- [x] Improve requeue/error checking when creating ConfigMaps/Deployments/DaemonSets to bubble up any errors and requeue the controller if requested.
- [x] Check if Status() updates are needed via Set() comparison instead of DeepEquals() to avoid potential hotloop if the order of Pods keeps changing between Reconcile() calls.