### PR TITLE
⭐️ add support for OpenShift TLS certificate injection

### DIFF
--- a/api/v1alpha1/mondooauditconfig_types.go
+++ b/api/v1alpha1/mondooauditconfig_types.go
@@ -51,10 +51,11 @@ type InjectionStyle string
 
 const (
 	CertManager InjectionStyle = "cert-manager"
+	OpenShift   InjectionStyle = "openshift"
 )
 
 type WebhookCertificateConfig struct {
-	// +kubebuilder:validation:Enum="";cert-manager
+	// +kubebuilder:validation:Enum="";cert-manager;openshift
 	InjectionStyle string `json:"injectionStyle,omitempty"`
 }
 

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -60,6 +60,7 @@ spec:
                         enum:
                         - ""
                         - cert-manager
+                        - openshift
                         type: string
                     type: object
                   enable:


### PR DESCRIPTION
This just involves annotating the Service fronting the webhook and
annotating the ValidatingWebhookConfiguration to inject the CA data.