### PR TITLE
🐛 explicitly remove MondooAuditConfig during teardown

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,6 +40,7 @@ jobs:
           curl -sSL http://mondoo.io/download.sh | bash
           mv mondoo /usr/local/bin/ 
           make test/deployment
+          kubectl delete -f config/samples/k8s_v1alpha1_mondooauditconfig.yaml
           make undeploy
 
   # Added to summarize the matrix and allow easy branch protection rules setup


### PR DESCRIPTION
'make undeploy' will delete the mondoo-operator Deployment/Pod.

This means the operator will never get a chance to clean up the
finalizer. This means 'make undeploy' hangs waiting for the
namespace to be deleted. And the namespace can't be cleaned up
because the MondooAuditConfig resource is waiting for the finalizer
to be removed.

Add an explicit step to delete the MondooAuditConfig to give the
operator a chance to remove the finalizer, and keep things from
hanging.

Signed-off-by: Joel Diaz <joel@mondoo.com>