### PR TITLE
🧹 switch to the new mondoo client image

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	mondooImage = "docker.io/mondoolabs/mondoo"
+	mondooImage = "docker.io/mondoo/client"
 	mondooTag   = "latest"
 )
 


### PR DESCRIPTION
We moved the primary container image for Mondoo Client from `mondoolabs/mondoo` to `mondoo/client`. This change uses the new image in the operator.


Signed-off-by: Christoph Hartmann <chris@lollyrock.com>