### PR TITLE
just force-update webhook image:tag

### DIFF
--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - command:
         - /webhook
-        image: ghcr.io/mondoohq/mondoo-operator:v0.0.1
+        image: ghcr.io/mondoohq/mondoo-operator:v0.0.11
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Until we come up with a way to keep the operator and the webhook image in sync by default.