### PR TITLE
WIP: 🐛 record mondoo-operator image as env var

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,16 +1,17 @@
 resources:
-  - manager.yaml
+- namespace.yaml
+- manager.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-  - files:
-      - controller_manager_config.yaml
-    name: manager-config
+- files:
+  - controller_manager_config.yaml
+  name: manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: controller
-    newName: ghcr.io/mondoohq/mondoo-operator
-    newTag: v0.0.10
+- name: controller
+  newName: ghcr.io/mondoohq/mondoo-operator
+  newTag: v0.0.10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,32 +18,35 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
-        - --leader-elect
-        image: controller:latest
-        name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 200m
-            memory: 100Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
+        - command:
+            - /manager
+          args:
+            - --leader-elect
+          env:
+            - name: MONDOO_OPERATOR_IMAGE
+              value: ghcr.io/mondoohq/mondoo-operator:v0.0.10
+          image: controller:latest
+          name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 200m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system


### PR DESCRIPTION
The mondoo-operator is responsible for launching "itself" when running the webhook Pod. The operator needs a way to know which image it has been built for, so store this an the env var MONDOO_OPERATOR_IMAGE.

Use this env var when getting ready to deploy the webhook to set the container image properly.

Signed-off-by: Joel Diaz <joel@mondoo.com>