### PR TITLE
0.0.12

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,8 +2,7 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - "main"
+    tags: ["v*.*.*"]
 
 jobs:
   release:
@@ -33,7 +32,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: 'v3.8.0' # default is latest stable
+          version: "v3.8.0" # default is latest stable
         id: install
 
       - name: Create and Install Helm chart
@@ -51,7 +50,7 @@ jobs:
           curl -sSL http://mondoo.io/download.sh | bash
           mv mondoo /usr/local/bin/ 
           make test/deployment
-          helm uninstall mondoo-operator  --namespace mondoo-operator 
+          helm uninstall mondoo-operator  --namespace mondoo-operator
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.3.0

--- a/charts/mondoo-operator/Chart.yaml
+++ b/charts/mondoo-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.11"
+appVersion: "0.0.12"

--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -6,7 +6,7 @@ controllerManager:
   manager:
     image:
       repository: ghcr.io/mondoohq/mondoo-operator
-      tag: v0.0.11
+      tag: v0.0.12
     resources:
       limits:
         cpu: 200m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/mondoohq/mondoo-operator
-  newTag: v0.0.11
+  newTag: v0.0.12

--- a/config/manifests/bases/mondoo-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/mondoo-operator.clusterserviceversion.yaml
@@ -2,13 +2,12 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: "[]"
+    alm-examples: '[]'
     capabilities: Basic Install
     categories: Security
     certified: "false"
     containerImage: ghcr.io/mondoohq/mondoo-operator:v0.0.11
-    description:
-      Mondoo is a cloud security platform for infrastructure developers.
+    description: Mondoo is a cloud security platform for infrastructure developers.
       Using Mondoo, your team will get automated risk assessment and real-time insights
       into all of your business critical infrastructure, across all of your infrastructure
       platforms.
@@ -20,117 +19,116 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: MondooAuditConfig is the Schema for the mondooauditconfigs API
-        displayName: Mondoo Audit Config
-        kind: MondooAuditConfig
-        name: mondooauditconfigs.k8s.mondoo.com
-        version: v1alpha1
+    - description: MondooAuditConfig is the Schema for the mondooauditconfigs API
+      displayName: Mondoo Audit Config
+      kind: MondooAuditConfig
+      name: mondooauditconfigs.k8s.mondoo.com
+      version: v1alpha1
   description: A Kubernetes Operator for creating and managing Mondoo controller instances.
   displayName: mondoo-operator
   icon:
-    - base64data:
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjwh
-        LS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoK
-        PHN2ZwogICB3aWR0aD0iODUuMDYzNTUzbW0iCiAgIGhlaWdodD0iMTguMzYxODM0bW0iCiAgIHZp
-        ZXdCb3g9IjAgMCA4NS4wNjM1NTMgMTguMzYxODM0IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJz
-        dmcxMzMwIgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWVkNzQsIDIwMjEtMDUtMjQp
-        IgogICBzb2RpcG9kaTpkb2NuYW1lPSJtb25kb28gLSBub2ljb24gLSBibGFjay5zdmciCiAgIHht
-        bG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBl
-        IgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQv
-        c29kaXBvZGktMC5kdGQiCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAg
-        eG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHNvZGlwb2RpOm5hbWVk
-        dmlldwogICAgIGlkPSJuYW1lZHZpZXcxMzMyIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAg
-        ICBib3JkZXJjb2xvcj0iI2VlZWVlZSIKICAgICBib3JkZXJvcGFjaXR5PSIxIgogICAgIGlua3Nj
-        YXBlOnBhZ2VzaGFkb3c9IjAiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAiCiAgICAgaW5r
-        c2NhcGU6cGFnZWNoZWNrZXJib2FyZD0iMCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0i
-        bW0iCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIxIgogICAgIGZp
-        dC1tYXJnaW4tbGVmdD0iMSIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIxIgogICAgIGZpdC1tYXJn
-        aW4tYm90dG9tPSIxIgogICAgIGlua3NjYXBlOnpvb209IjEiCiAgICAgaW5rc2NhcGU6Y3g9IjIy
-        LjUiCiAgICAgaW5rc2NhcGU6Y3k9IjY2LjUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIx
-        OTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwNjIiCiAgICAgaW5rc2NhcGU6d2lu
-        ZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjE4IgogICAgIGlua3NjYXBlOndpbmRv
-        dy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0ibGF5ZXIxIiAvPgog
-        IDxkZWZzCiAgICAgaWQ9ImRlZnMxMzI3IiAvPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9Ikxh
-        eWVyIDEiCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpZD0ibGF5ZXIxIgog
-        ICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKC00Ni43Mzk4ODIsLTU1LjAyNjAxNikiPgogICAgPGcK
-        ICAgICAgIGlkPSJnOTQwIgogICAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4yNjQ1ODMzMywwLDAs
-        MC4yNjQ1ODMzMywtMTI0OS4zOTE4LC05NS42ODE4KSI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9
-        Im0gNDk3OC42MDUsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOTEsLTIxLjQ3
-        IDExLjYxLDAgMjEuOTEsOC41NSAyMS45MSwyMS40NyAwLDEyLjkyIC0xMC4zLDIxLjM5IC0yMS45
-        MSwyMS4zOSAtMTEuNjEsMCAtMjEuOTEsLTguNTQgLTIxLjkxLC0yMS4zOSB6IG0gMzIuMjEsMCBj
-        IDAsLTYuMzcgLTQuNjMsLTEwLjgyIC0xMC4zLC0xMC44MiAtNS42NywwIC0xMC4zLDQuNDUgLTEw
-        LjMsMTAuODIgMCw2LjM3IDQuNjMsMTAuNzQgMTAuMywxMC43NCA1LjY3LDAgMTAuMzIsLTQuNDUg
-        MTAuMzIsLTEwLjc0IHoiCiAgICAgICAgIGZpbGw9IiMyMjIyMjIiCiAgICAgICAgIGlkPSJwYXRo
-        OTI4IgogICAgICAgICBzdHlsZT0iZmlsbDojMmEyYTJhO2ZpbGwtb3BhY2l0eToxIiAvPgogICAg
-        ICA8cGF0aAogICAgICAgICBkPSJtIDQ5NzUuMDg1LDYzNC4zODM4OCBoIC0xMi40IGwgLTQuMzYs
-        LTM3LjI3IC0xNC42NywzMC40NiBoIC05LjUxIGwgLTE0Ljg0LC0zMC40NiAtNC4zNiwzNy4yNyBo
-        IC0xMi40IGwgNy40MiwtNjEgaCA2LjIxIGMgMS4yMjMsMCAyLjQyMSwwLjM0NSAzLjQ1MywxLjAw
-        MSAxLjAzMywwLjY1NSAxLjg1NywxLjU5MSAyLjM3NywyLjY5OSBsIDE2LjgzLDM2LjYgMTYuNjgs
-        LTM2LjU3IGMgMC41MTksLTEuMTEzIDEuMzQ2LC0yLjA1NCAyLjM4MiwtMi43MTMgMS4wMzcsLTAu
-        NjU5IDIuMjQsLTEuMDA5IDMuNDY4LC0xLjAwNyBoIDYuMzYgeiIKICAgICAgICAgZmlsbD0iIzIy
-        MjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzAiCiAgICAgICAgIHN0eWxlPSJmaWxsOiMyYTJhMmE7
-        ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTA2OC4xMDQsNjEx
-        LjgyMzg4IHYgMjIuMzUgaCAtMTEuNDQgdiAtMjEuNzMgYyAwLC02LjM4IC0zLjg0LC05LjI2IC03
-        Ljc2LC05LjI2IC00LjExLDAgLTkuMTcsMi4xOSAtOS4xNyw5LjYgdiAyMS4zOSBoIC0xMS40MyB2
-        IC00MC43NiBoIDQuNTMgYyAwLjkwNiwwIDEuODAzLDAuMTc2IDIuNjQsMC41MjEgMC44MzcsMC4z
-        NDYgMS41OTgsMC44NTMgMi4yMzksMS40OTMgMC42NDEsMC42NCAxLjE0OSwxLjQgMS40OTYsMi4y
-        MzcgMC4zNDcsMC44MzYgMC41MjUsMS43MzMgMC41MjUsMi42MzkgMS43NSwtNS41IDguMiwtNy45
-        NCAxMi4yMiwtNy45NCAxMC42NSwwIDE2LjI0LDcuMjQgMTYuMTUsMTkuNDYgeiIKICAgICAgICAg
-        ZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzIiCiAgICAgICAgIHN0eWxlPSJmaWxs
-        OiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTEx
-        NC43MTQsNTczLjQxMzg4IGggMy43OCB2IDYwLjc2IGggLTExLjQzIHYgLTUuMDYgYyAtMi44OCw0
-        LjE5IC04LjU2LDYuMTEgLTEzLjEsNi4xMSAtMTAuNDcsMCAtMjAsLTguMzggLTIwLC0yMS40OCAw
-        LC0xMy4xIDkuNTIsLTIxLjM4IDIwLC0yMS4zOCA0LjcyLDAgMTAuMjIsMS44MyAxMy4xLDYgdiAt
-        MTcuMyBjIDAsLTIuMDI5IDAuODA2LC0zLjk3NSAyLjI0MSwtNS40MSAxLjQzNSwtMS40MzQgMy4z
-        ODEsLTIuMjQgNS40MDksLTIuMjQgeiBtIC04LDQwLjMzIGMgMCwtMi44MTcgLTEuMTE1LC01LjUx
-        OSAtMy4wOTEsLTcuNTI2IC0xLjk3NywtMi4wMDYgLTQuNjYyLC0zLjE1NyAtNy40NzgsLTMuMjA0
-        IC0xLjM5OSwwLjAxIC0yLjc4MiwwLjI5NCAtNC4wNywwLjgzOCAtMS4yODgsMC41NDUgLTIuNDU2
-        LDEuMzM4IC0zLjQzNywyLjMzNSAtMC45ODEsMC45OTcgLTEuNzU2LDIuMTc4IC0yLjI4LDMuNDc0
-        IC0wLjUyNCwxLjI5NyAtMC43ODcsMi42ODQgLTAuNzc0LDQuMDgzIC0wLjA0MywxLjQxNCAwLjE5
-        OCwyLjgyNCAwLjcwOSw0LjE0MyAwLjUxMiwxLjMyIDEuMjgzLDIuNTI0IDIuMjY4LDMuNTQgMC45
-        ODYsMS4wMTYgMi4xNjUsMS44MjQgMy40NjksMi4zNzYgMS4zMDMsMC41NTEgMi43MDQsMC44MzYg
-        NC4xMTksMC44MzYgMS40MTYsMCAyLjgxNywtMC4yODUgNC4xMiwtMC44MzYgMS4zMDQsLTAuNTUy
-        IDIuNDgzLC0xLjM2IDMuNDY5LC0yLjM3NiAwLjk4NSwtMS4wMTYgMS43NTYsLTIuMjIgMi4yNjgs
-        LTMuNTQgMC41MTEsLTEuMzE5IDAuNzUyLC0yLjcyOSAwLjcwOCwtNC4xNDMgeiIKICAgICAgICAg
-        ZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzQiCiAgICAgICAgIHN0eWxlPSJmaWxs
-        OiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTEy
-        NC4zNzUsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOSwtMjEuNDcgMTEuNiww
-        IDIxLjkxLDguNTUgMjEuOTEsMjEuNDcgMCwxMi45MiAtMTAuMywyMS4zOSAtMjEuOTEsMjEuMzkg
-        LTExLjYxLDAgLTIxLjksLTguNTQgLTIxLjksLTIxLjM5IHogbSAzMi4yLDAgYyAwLC02LjM3IC00
-        LjYyLC0xMC44MiAtMTAuMywtMTAuODIgLTUuNjgsMCAtMTAuMyw0LjQ1IC0xMC4zLDEwLjgyIDAs
-        Ni4zNyA0LjYzLDEwLjc0IDEwLjMsMTAuNzQgNS42NywwIDEwLjMsLTQuNDUgMTAuMywtMTAuNzQg
-        eiIKICAgICAgICAgZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzYiCiAgICAgICAg
-        IHN0eWxlPSJmaWxsOiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAg
-        ICAgIGQ9Im0gNTE3Mi42NjYsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOTEs
-        LTIxLjQ3IDExLjYxLDAgMjEuOTEsOC41NSAyMS45MSwyMS40NyAwLDEyLjkyIC0xMC4zLDIxLjM5
-        IC0yMS45MSwyMS4zOSAtMTEuNjEsMCAtMjEuOTEsLTguNTQgLTIxLjkxLC0yMS4zOSB6IG0gMzIu
-        MjEsMCBjIDAsLTYuMzcgLTQuNjIsLTEwLjgyIC0xMC4zLC0xMC44MiAtNS42OCwwIC0xMC4zLDQu
-        NDUgLTEwLjMsMTAuODIgMCw2LjM3IDQuNjMsMTAuNzQgMTAuMywxMC43NCA1LjY3LDAgMTAuMjYs
-        LTQuNDUgMTAuMjYsLTEwLjc0IHoiCiAgICAgICAgIGZpbGw9IiMyMjIyMjIiCiAgICAgICAgIGlk
-        PSJwYXRoOTM4IgogICAgICAgICBzdHlsZT0iZmlsbDojMmEyYTJhO2ZpbGwtb3BhY2l0eToxIiAv
-        PgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==
-      mediatype: image/svg+xml
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjwh
+      LS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoK
+      PHN2ZwogICB3aWR0aD0iODUuMDYzNTUzbW0iCiAgIGhlaWdodD0iMTguMzYxODM0bW0iCiAgIHZp
+      ZXdCb3g9IjAgMCA4NS4wNjM1NTMgMTguMzYxODM0IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJz
+      dmcxMzMwIgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWVkNzQsIDIwMjEtMDUtMjQp
+      IgogICBzb2RpcG9kaTpkb2NuYW1lPSJtb25kb28gLSBub2ljb24gLSBibGFjay5zdmciCiAgIHht
+      bG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBl
+      IgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQv
+      c29kaXBvZGktMC5kdGQiCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAg
+      eG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHNvZGlwb2RpOm5hbWVk
+      dmlldwogICAgIGlkPSJuYW1lZHZpZXcxMzMyIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAg
+      ICBib3JkZXJjb2xvcj0iI2VlZWVlZSIKICAgICBib3JkZXJvcGFjaXR5PSIxIgogICAgIGlua3Nj
+      YXBlOnBhZ2VzaGFkb3c9IjAiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAiCiAgICAgaW5r
+      c2NhcGU6cGFnZWNoZWNrZXJib2FyZD0iMCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0i
+      bW0iCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIxIgogICAgIGZp
+      dC1tYXJnaW4tbGVmdD0iMSIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIxIgogICAgIGZpdC1tYXJn
+      aW4tYm90dG9tPSIxIgogICAgIGlua3NjYXBlOnpvb209IjEiCiAgICAgaW5rc2NhcGU6Y3g9IjIy
+      LjUiCiAgICAgaW5rc2NhcGU6Y3k9IjY2LjUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIx
+      OTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwNjIiCiAgICAgaW5rc2NhcGU6d2lu
+      ZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjE4IgogICAgIGlua3NjYXBlOndpbmRv
+      dy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0ibGF5ZXIxIiAvPgog
+      IDxkZWZzCiAgICAgaWQ9ImRlZnMxMzI3IiAvPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9Ikxh
+      eWVyIDEiCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpZD0ibGF5ZXIxIgog
+      ICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKC00Ni43Mzk4ODIsLTU1LjAyNjAxNikiPgogICAgPGcK
+      ICAgICAgIGlkPSJnOTQwIgogICAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4yNjQ1ODMzMywwLDAs
+      MC4yNjQ1ODMzMywtMTI0OS4zOTE4LC05NS42ODE4KSI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9
+      Im0gNDk3OC42MDUsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOTEsLTIxLjQ3
+      IDExLjYxLDAgMjEuOTEsOC41NSAyMS45MSwyMS40NyAwLDEyLjkyIC0xMC4zLDIxLjM5IC0yMS45
+      MSwyMS4zOSAtMTEuNjEsMCAtMjEuOTEsLTguNTQgLTIxLjkxLC0yMS4zOSB6IG0gMzIuMjEsMCBj
+      IDAsLTYuMzcgLTQuNjMsLTEwLjgyIC0xMC4zLC0xMC44MiAtNS42NywwIC0xMC4zLDQuNDUgLTEw
+      LjMsMTAuODIgMCw2LjM3IDQuNjMsMTAuNzQgMTAuMywxMC43NCA1LjY3LDAgMTAuMzIsLTQuNDUg
+      MTAuMzIsLTEwLjc0IHoiCiAgICAgICAgIGZpbGw9IiMyMjIyMjIiCiAgICAgICAgIGlkPSJwYXRo
+      OTI4IgogICAgICAgICBzdHlsZT0iZmlsbDojMmEyYTJhO2ZpbGwtb3BhY2l0eToxIiAvPgogICAg
+      ICA8cGF0aAogICAgICAgICBkPSJtIDQ5NzUuMDg1LDYzNC4zODM4OCBoIC0xMi40IGwgLTQuMzYs
+      LTM3LjI3IC0xNC42NywzMC40NiBoIC05LjUxIGwgLTE0Ljg0LC0zMC40NiAtNC4zNiwzNy4yNyBo
+      IC0xMi40IGwgNy40MiwtNjEgaCA2LjIxIGMgMS4yMjMsMCAyLjQyMSwwLjM0NSAzLjQ1MywxLjAw
+      MSAxLjAzMywwLjY1NSAxLjg1NywxLjU5MSAyLjM3NywyLjY5OSBsIDE2LjgzLDM2LjYgMTYuNjgs
+      LTM2LjU3IGMgMC41MTksLTEuMTEzIDEuMzQ2LC0yLjA1NCAyLjM4MiwtMi43MTMgMS4wMzcsLTAu
+      NjU5IDIuMjQsLTEuMDA5IDMuNDY4LC0xLjAwNyBoIDYuMzYgeiIKICAgICAgICAgZmlsbD0iIzIy
+      MjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzAiCiAgICAgICAgIHN0eWxlPSJmaWxsOiMyYTJhMmE7
+      ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTA2OC4xMDQsNjEx
+      LjgyMzg4IHYgMjIuMzUgaCAtMTEuNDQgdiAtMjEuNzMgYyAwLC02LjM4IC0zLjg0LC05LjI2IC03
+      Ljc2LC05LjI2IC00LjExLDAgLTkuMTcsMi4xOSAtOS4xNyw5LjYgdiAyMS4zOSBoIC0xMS40MyB2
+      IC00MC43NiBoIDQuNTMgYyAwLjkwNiwwIDEuODAzLDAuMTc2IDIuNjQsMC41MjEgMC44MzcsMC4z
+      NDYgMS41OTgsMC44NTMgMi4yMzksMS40OTMgMC42NDEsMC42NCAxLjE0OSwxLjQgMS40OTYsMi4y
+      MzcgMC4zNDcsMC44MzYgMC41MjUsMS43MzMgMC41MjUsMi42MzkgMS43NSwtNS41IDguMiwtNy45
+      NCAxMi4yMiwtNy45NCAxMC42NSwwIDE2LjI0LDcuMjQgMTYuMTUsMTkuNDYgeiIKICAgICAgICAg
+      ZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzIiCiAgICAgICAgIHN0eWxlPSJmaWxs
+      OiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTEx
+      NC43MTQsNTczLjQxMzg4IGggMy43OCB2IDYwLjc2IGggLTExLjQzIHYgLTUuMDYgYyAtMi44OCw0
+      LjE5IC04LjU2LDYuMTEgLTEzLjEsNi4xMSAtMTAuNDcsMCAtMjAsLTguMzggLTIwLC0yMS40OCAw
+      LC0xMy4xIDkuNTIsLTIxLjM4IDIwLC0yMS4zOCA0LjcyLDAgMTAuMjIsMS44MyAxMy4xLDYgdiAt
+      MTcuMyBjIDAsLTIuMDI5IDAuODA2LC0zLjk3NSAyLjI0MSwtNS40MSAxLjQzNSwtMS40MzQgMy4z
+      ODEsLTIuMjQgNS40MDksLTIuMjQgeiBtIC04LDQwLjMzIGMgMCwtMi44MTcgLTEuMTE1LC01LjUx
+      OSAtMy4wOTEsLTcuNTI2IC0xLjk3NywtMi4wMDYgLTQuNjYyLC0zLjE1NyAtNy40NzgsLTMuMjA0
+      IC0xLjM5OSwwLjAxIC0yLjc4MiwwLjI5NCAtNC4wNywwLjgzOCAtMS4yODgsMC41NDUgLTIuNDU2
+      LDEuMzM4IC0zLjQzNywyLjMzNSAtMC45ODEsMC45OTcgLTEuNzU2LDIuMTc4IC0yLjI4LDMuNDc0
+      IC0wLjUyNCwxLjI5NyAtMC43ODcsMi42ODQgLTAuNzc0LDQuMDgzIC0wLjA0MywxLjQxNCAwLjE5
+      OCwyLjgyNCAwLjcwOSw0LjE0MyAwLjUxMiwxLjMyIDEuMjgzLDIuNTI0IDIuMjY4LDMuNTQgMC45
+      ODYsMS4wMTYgMi4xNjUsMS44MjQgMy40NjksMi4zNzYgMS4zMDMsMC41NTEgMi43MDQsMC44MzYg
+      NC4xMTksMC44MzYgMS40MTYsMCAyLjgxNywtMC4yODUgNC4xMiwtMC44MzYgMS4zMDQsLTAuNTUy
+      IDIuNDgzLC0xLjM2IDMuNDY5LC0yLjM3NiAwLjk4NSwtMS4wMTYgMS43NTYsLTIuMjIgMi4yNjgs
+      LTMuNTQgMC41MTEsLTEuMzE5IDAuNzUyLC0yLjcyOSAwLjcwOCwtNC4xNDMgeiIKICAgICAgICAg
+      ZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzQiCiAgICAgICAgIHN0eWxlPSJmaWxs
+      OiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gNTEy
+      NC4zNzUsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOSwtMjEuNDcgMTEuNiww
+      IDIxLjkxLDguNTUgMjEuOTEsMjEuNDcgMCwxMi45MiAtMTAuMywyMS4zOSAtMjEuOTEsMjEuMzkg
+      LTExLjYxLDAgLTIxLjksLTguNTQgLTIxLjksLTIxLjM5IHogbSAzMi4yLDAgYyAwLC02LjM3IC00
+      LjYyLC0xMC44MiAtMTAuMywtMTAuODIgLTUuNjgsMCAtMTAuMyw0LjQ1IC0xMC4zLDEwLjgyIDAs
+      Ni4zNyA0LjYzLDEwLjc0IDEwLjMsMTAuNzQgNS42NywwIDEwLjMsLTQuNDUgMTAuMywtMTAuNzQg
+      eiIKICAgICAgICAgZmlsbD0iIzIyMjIyMiIKICAgICAgICAgaWQ9InBhdGg5MzYiCiAgICAgICAg
+      IHN0eWxlPSJmaWxsOiMyYTJhMmE7ZmlsbC1vcGFjaXR5OjEiIC8+CiAgICAgIDxwYXRoCiAgICAg
+      ICAgIGQ9Im0gNTE3Mi42NjYsNjEzLjgzMzg4IGMgMCwtMTIuOTIgMTAuMywtMjEuNDcgMjEuOTEs
+      LTIxLjQ3IDExLjYxLDAgMjEuOTEsOC41NSAyMS45MSwyMS40NyAwLDEyLjkyIC0xMC4zLDIxLjM5
+      IC0yMS45MSwyMS4zOSAtMTEuNjEsMCAtMjEuOTEsLTguNTQgLTIxLjkxLC0yMS4zOSB6IG0gMzIu
+      MjEsMCBjIDAsLTYuMzcgLTQuNjIsLTEwLjgyIC0xMC4zLC0xMC44MiAtNS42OCwwIC0xMC4zLDQu
+      NDUgLTEwLjMsMTAuODIgMCw2LjM3IDQuNjMsMTAuNzQgMTAuMywxMC43NCA1LjY3LDAgMTAuMjYs
+      LTQuNDUgMTAuMjYsLTEwLjc0IHoiCiAgICAgICAgIGZpbGw9IiMyMjIyMjIiCiAgICAgICAgIGlk
+      PSJwYXRoOTM4IgogICAgICAgICBzdHlsZT0iZmlsbDojMmEyYTJhO2ZpbGwtb3BhY2l0eToxIiAv
+      PgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
   install:
     spec:
       deployments: null
     strategy: ""
   installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
-    - policy-as-code
+  - policy-as-code
   links:
-    - name: Mondoo
-      url: https://mondoo.com
+  - name: Mondoo
+    url: https://mondoo.com
   maintainers:
-    - email: hello@mondoo.com
-      name: Mondoo
+  - email: hello@mondoo.com
+    name: Mondoo
   maturity: alpha
   provider:
     name: Mondoo, Inc

--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - command:
         - /webhook
-        image: ghcr.io/mondoohq/mondoo-operator:v0.0.11
+        image: ghcr.io/mondoohq/mondoo-operator:v0.0.12
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+VERSION=0.0.12
+CHART_VERSION=0.1.5
+make manifests
+yq -i ".appVersion = \"${VERSION}\"" charts/mondoo-operator/Chart.yaml
+yq -i ".version = \"${CHART_VERSION}\"" charts/mondoo-operator/Chart.yaml
+CHART_NAME=charts/mondoo-operator make helm
+make bundle IMG="ghcr.io/mondoohq/mondoo-operator:v${VERSION}" VERSION="${VERSION}"
+# TODO: update controllers/webhook-manifests.yaml


### PR DESCRIPTION
- fixes the helm release chart publish since it will be pushed on tagged releases now instead of master
- add simple release.sh script to simplify the release process