### PR TITLE
⭐️simplify release process

### DIFF
--- a/.github/workflows/e2e-olm.yaml
+++ b/.github/workflows/e2e-olm.yaml
@@ -1,0 +1,53 @@
+name: Release Charts
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-olm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: E2E tests
+    needs:
+      - build-bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.golang-version }}"
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+      - name: Try the cluster !
+        run: kubectl get pods -A
+      - name: Install operator-sdk
+        id: operator-sdk
+        run: |
+          export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+          export OS=$(uname | awk '{print tolower($0)}')
+          export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.17.0
+          curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+          gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
+          curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt
+          curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
+          gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
+          grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
+          chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+      - name: Install olm and mondoo
+        run: |
+          operator-sdk olm install
+          operator-sdk run bundle '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ env.RELEASE}}' --namespace mondoo-operator
+          kubectl create ns mondoo-operator
+          kubectl create secret generic mondoo-client --namespace mondoo-operator --from-file=config=creds.yaml
+          kubectl apply -f config/samples/k8s_v1alpha1_mondooauditconfig.yaml
+      - name: Run e2e test with olm
+        run: |
+          curl -sSL http://mondoo.io/download.sh | bash
+          mv mondoo /usr/local/bin/ 
+          echo ${{ secrets.MONDOO_CLIENT }} > creds.yaml
+          make test/deployment
+      - name: Clean up
+          operator-sdk cleanup mondoo-operator --namespace mondoo-operator
+          operator-sdk olm uninstall

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Docker
+name: Publish Container Images
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -67,7 +67,7 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      
+
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push operator image
@@ -91,7 +91,7 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push-operator.outputs.digest }}
-  
+
   build-bundle:
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
@@ -159,7 +159,7 @@ jobs:
         id: meta-bundle
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle'
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle"
 
       # Build and push Docker image bundle with Buildx
       - name: Build and push bundle image
@@ -185,50 +185,14 @@ jobs:
         # against the sigstore community Fulcio instance.
         run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push-bundle.outputs.digest }}
 
-  e2e-olm:
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: E2E tests
-    needs:
-      - build-bundle
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "${{ env.golang-version }}"
-      - name: Start minikube
-        uses: medyagh/setup-minikube@master
-      - name: Try the cluster !
-        run: kubectl get pods -A
-      - name: Install operator-sdk 
-        id: operator-sdk 
-        run: |
-          export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-          export OS=$(uname | awk '{print tolower($0)}')
-          export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.17.0
-          curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
-          gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
-          curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt
-          curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
-          gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
-          grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
-          chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
-      - name: Install olm and mondoo
-        run: |
-          operator-sdk olm install
-          curl -sSL http://mondoo.io/download.sh | bash
-          mv mondoo /usr/local/bin/ 
-          echo ${{ secrets.MONDOO_CLIENT }} > creds.yaml
-          kubectl create ns mondoo-operator
-          kubectl create secret generic mondoo-client --namespace mondoo-operator --from-file=config=creds.yaml
-      - name: Run e2e test with olm
-        run: |
-          operator-sdk run bundle '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ env.RELEASE}}' --namespace mondoo-operator
-          kubectl apply -f config/samples/k8s_v1alpha1_mondooauditconfig.yaml
-          make test/deployment
-          operator-sdk cleanup mondoo-operator --namespace mondoo-operator
-          operator-sdk olm uninstall 
+  # run olm e2e tests
+  run-olm-e2e:
+    uses: ./.github/workflows/e2e-olm.yaml
 
+  # publish kubectl manifests
+  run-release-manifests:
+    uses: ./.github/workflows/release-manifests.yaml
+
+  # publish helm chart after the release of container images is complete
+  run-release-helm:
+    uses: ./.github/workflows/release-helm-chart.yaml

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,8 +1,7 @@
 name: Release Charts
 
 on:
-  push:
-    tags: ["v*.*.*"]
+  workflow_call:
 
 jobs:
   release:

--- a/.github/workflows/release-manifests.yaml
+++ b/.github/workflows/release-manifests.yaml
@@ -1,7 +1,7 @@
 name: generate-manifests
+
 on:
-  push:
-    tags: ["v*.*.*"]
+  workflow_call:
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "${{ env.golang-version }}"
-      - name: Generate manifests 
-        run: make generate-manifests IMG='${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}' 
+      - name: Generate manifests
+        run: make generate-manifests IMG='${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}'
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/charts/mondoo-operator/Chart.yaml
+++ b/charts/mondoo-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.12"
+appVersion: "0.0.13"

--- a/charts/mondoo-operator/templates/nodes-rbac.yaml
+++ b/charts/mondoo-operator/templates/nodes-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mondoo-operator.fullname" . }}-nodes
+  labels:
+  {{- include "mondoo-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mondoo-operator.fullname" . }}-nodes
+  labels:
+  {{- include "mondoo-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "mondoo-operator.fullname" . }}-nodes'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "mondoo-operator.fullname" . }}-nodes'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -6,7 +6,7 @@ controllerManager:
   manager:
     image:
       repository: ghcr.io/mondoohq/mondoo-operator
-      tag: v0.0.12
+      tag: v0.0.13
     resources:
       limits:
         cpu: 200m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/mondoohq/mondoo-operator
-  newTag: v0.0.12
+  newTag: v0.0.13

--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - command:
         - /webhook
-        image: ghcr.io/mondoohq/mondoo-operator:v0.0.12
+        image: ghcr.io/mondoohq/mondoo-operator:v0.0.13
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-VERSION=0.0.12
-CHART_VERSION=0.1.5
+# This script updates all the versions to do a release:
+# ./release.sh 0.0.13 0.1.6
+echo "Version: $1";
+VERSION=$1
+echo "Chart-Version: $2";
+CHART_VERSION=$2
+
 make manifests
 yq -i ".appVersion = \"${VERSION}\"" charts/mondoo-operator/Chart.yaml
 yq -i ".version = \"${CHART_VERSION}\"" charts/mondoo-operator/Chart.yaml
+yq -i ".controllerManager.manager.image.tag = \"v${VERSION}\"" charts/mondoo-operator/values.yaml
 CHART_NAME=charts/mondoo-operator make helm
 make bundle IMG="ghcr.io/mondoohq/mondoo-operator:v${VERSION}" VERSION="${VERSION}"
 # TODO: update controllers/webhook-manifests.yaml


### PR DESCRIPTION
- reorganise GitHub workflows
- include `release.sh` to simplify updating all the files
- helm chart job runs after the container image build
- elm-olm test runs after the bundle build but is externalised to its own workflow file

It does not fully include the updating of the web hook manifest which is a followup task