### PR TITLE
🧹 move github actions needs to main workflow

### DIFF
--- a/.github/workflows/e2e-olm.yaml
+++ b/.github/workflows/e2e-olm.yaml
@@ -6,8 +6,6 @@ on:
 jobs:
   e2e-olm:
     name: E2E tests
-    needs:
-      - build-bundle
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -188,6 +188,8 @@ jobs:
   # run olm e2e tests
   run-olm-e2e:
     uses: ./.github/workflows/e2e-olm.yaml
+    needs:
+      - build-bundle
 
   # publish kubectl manifests
   run-release-manifests:


### PR DESCRIPTION
since the olm workflow is external now, the dependency needs to be defined in the main workflow

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>