### PR TITLE
set Version variable during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o manager main.go
+ARG VERSION
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o manager -ldflags "-X go.mondoo.com/mondoo-operator/controllers.Version=$VERSION" main.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o webhook pkg/webhooks/main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,14 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o bin/manager -ldflags "-s -w -X go.mondoo.com/mondoo-operator/controllers.Version=${VERSION}" main.go
 	go build -o bin/webhook pkg/webhooks/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg VERSION=${VERSION} -t ${IMG} .
 
 buildah-build: test ## Build container image
 	buildah build -t ${IMG} .


### PR DESCRIPTION
Take the $VERSION varaible and use it to set the Version variable in controllers/webhooks.go.

This will be used to store the version/tag of the mondoo-operator so that the Deployment/Pod for the webhook is in sync with the mondoo-operator version/tag by default.

You can of course override this by setting MondooAuditConfig.Spec.Webhooks.Image.Tag. And if you were to do a manual 'go build' without setting $VERSION, then it will default to just using the 'latest' tag.

Signed-off-by: Joel Diaz <joel@mondoo.com>