### PR TITLE
🐛 clean up generated CRD Description

### DIFF
--- a/api/v1alpha1/mondooauditconfig_types.go
+++ b/api/v1alpha1/mondooauditconfig_types.go
@@ -83,7 +83,8 @@ type Webhooks struct {
 type MondooAuditConfigStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	// Nodes store the name of the pods which are running mondoo instances
+
+	// Pods store the name of the pods which are running mondoo instances
 	Pods []string `json:"pods,omitempty"`
 }
 

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -159,10 +159,8 @@ spec:
             description: MondooAuditConfigStatus defines the observed state of MondooAuditConfig
             properties:
               pods:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file Nodes store the name of the pods which are running mondoo
-                  instances'
+                description: Pods store the name of the pods which are running mondoo
+                  instances
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
It was picking up unrelated comment lines, so seperate them such that only the lines we want are in the generated Description.

Signed-off-by: Joel Diaz <joel@mondoo.com>