### PR TITLE
🐛 create namespace before installing operator bundle

### DIFF
--- a/.github/workflows/e2e-olm.yaml
+++ b/.github/workflows/e2e-olm.yaml
@@ -47,8 +47,8 @@ jobs:
       - name: Install olm
         run: |
           operator-sdk olm install
-          operator-sdk run bundle '${{ inputs.bundle-img }}' --namespace mondoo-operator
           kubectl create ns mondoo-operator
+          operator-sdk run bundle '${{ inputs.bundle-img }}' --namespace mondoo-operator
           kubectl create secret generic mondoo-client --namespace mondoo-operator --from-file=config=creds.yaml
           kubectl apply -f config/samples/k8s_v1alpha1_mondooauditconfig.yaml
       - name: Install mondoo and run e2e test with olm


### PR DESCRIPTION
The attempt to install mondoo-operator with operator-sdk using the bundle fails because the namespace mondoo-operator doesn't exists.

Move the creation of mondoo-operator Namespace to before the 'operator-sdk run bundle' command.

Signed-off-by: Joel Diaz <joel@mondoo.com>