### PR TITLE
🧹 fixes doc config and command references

### DIFF
--- a/docs/user-manual-helm.md
+++ b/docs/user-manual-helm.md
@@ -73,7 +73,7 @@ mondooauditconfigs.k8s.mondoo.com   2022-01-14T14:07:28Z
 Then make sure a configuration for the Mondoo Client is deployed:
 
 ```bash
-kubectl get mondooauditconfigs
+kubectl get mondooauditconfigs -A
 NAME                  AGE
 mondoo-client   2m44s
 ```

--- a/docs/user-manual-kubectl.md
+++ b/docs/user-manual-kubectl.md
@@ -77,6 +77,7 @@ And create/modify/delete a Pod in another window:
 2. Update MondooAuditConfig so that the webhook section requests TLS certificates from cert-manager:
 
 ```yaml
+apiVersion: k8s.mondoo.com/v1alpha1
 kind: MondooAuditConfig
 metadata:
   name: mondoo-client
@@ -181,7 +182,7 @@ mondooauditconfigs.k8s.mondoo.com   2022-01-14T14:07:28Z
 Then make sure a configuration for the Mondoo Client is deployed:
 
 ```bash
-kubectl get mondooauditconfigs
+kubectl get mondooauditconfigs -A
 NAME                  AGE
 mondoo-client        2m44s
 ```


### PR DESCRIPTION
This PR fixes a couple of issues I ran into while following the docs...

## error validating data: apiVersion not set

```bash
kubectl apply -f mondoo-config.yaml
error: error validating "mondoo-config.yaml": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false
```
Missing `apiVersion: admissionregistration.k8s.io/v1`. 

## No resources found in default namespace.

```bash
kubectl get mondooauditconfigs
No resources found in default namespace.
```

Missing `-A`

```bash
kubectl get mondooauditconfigs -A
NAME            AGE
mondoo-client   20m
```

Signed-off-by: Scott Ford <scott@scottford.io>