### PR TITLE
On parse errors use normal image string

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -74,7 +74,7 @@ func resolveMondooOperatorImage(log logr.Logger, userImageName, userImageTag str
 
 	if err != nil {
 		log.Error(err, "Failed to parse reference")
-		return "", err
+		return mondooContainer, err
 	}
 	return imageUrl, nil
 }


### PR DESCRIPTION
Signed-off-by: jensgrnb <jens.grunborg@endocode.com>

closes #198 