### PR TITLE
🐛 fake some event data when running via act

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,8 +250,14 @@ test/fmt:
 
 .PHONY: test/github-actions
 test/github-actions:
-	act -n --container-architecture linux/amd64 
+	$(eval TMP_ACT_JSON := $(shell mktemp -t act-json.XXXXX))
+	echo '{ "comment": { "body": "not_nil" } }' > $(TMP_ACT_JSON)
+	act -n --container-architecture linux/amd64 --eventpath $(TMP_ACT_JSON)
+	rm /tmp/act-json.*
 
 .PHONY: test/spell-check
 test/spell-check:
-	act -j spelling --container-architecture linux/amd64
+	$(eval TMP_ACT_JSON := $(shell mktemp -t act-json.XXXXX))
+	echo '{ "comment": { "body": "not_nil" } }' > $(TMP_ACT_JSON)
+	act -j spelling --container-architecture linux/amd64 --eventpath $(TMP_ACT_JSON)
+	rm /tmp/act-json.*


### PR DESCRIPTION
It appears that act doesn't set up enough of a fake environment which
can cause some github action workflows that work on the real github to
fail when run through act.

Create some fake event data so that the checks against specific comments
in the spell-check workflow can succeed when run locally.

Signed-off-by: Joel Diaz <joel@mondoo.com>