### PR TITLE
🧹 update development docs and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/webhook pkg/webhooks/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	MONDOO_OPERATOR_NAMESPACE=mondoo-operator go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
 	docker build --build-arg VERSION=${VERSION} -t ${IMG} .

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,10 @@ minikube start
 Run the operator:
 
 ```bash
+# configure crd
 make install
+
+# run the operator locally
 make run
 ```
 
@@ -56,7 +59,12 @@ make deploy-olm
 
 Now, we completed the setup for the operator. To start the service, we need to configure the client:
 
-1. Create namespace using `kubectl create namespace mondoo-operator`
+1. Create namespace using
+
+```bash
+kubectl create namespace mondoo-operator
+```
+
 2. Configure the Mondoo secret:
 
 - Create a new Mondoo service account to report assessments to [Mondoo Platform](https://mondoo.com/docs/platform/service_accounts)


### PR DESCRIPTION
The `make run` command was missing the new namespace. This change adds the default namespace so that the out-of-the-box setup is ready for development. In addition it updates the docs to ensure that all the required manifests are going to be deployed beforehand.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>