### PR TITLE
increase olm timeout

### DIFF
--- a/.github/workflows/e2e-olm.yaml
+++ b/.github/workflows/e2e-olm.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           operator-sdk olm install
           kubectl create ns mondoo-operator
-          operator-sdk run bundle '${{ inputs.bundle-img }}' --namespace mondoo-operator
+          operator-sdk run bundle '${{ inputs.bundle-img }}' --namespace mondoo-operator --timeout 5m0s
           echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
           kubectl create secret generic mondoo-client --namespace mondoo-operator --from-file=config=creds.json
           rm creds.json


### PR DESCRIPTION
Seeing timeout messages during e2e of the type:

time="2022-03-30T18:37:24Z" level=fatal msg="Failed to run bundle:
install plan is not available for the subscription
mondoo-operator-v0-2-1-sub: timed out waiting for the condition\n"

The default is 2m0s, so increase to 5m.

Signed-off-by: Joel Diaz <joel@mondoo.com>