### PR TITLE
🧹 change format for the 'replaces' field in OLM bundle

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,10 +13,10 @@ Ensure the following software is installed before running the release script:
 
 Run the release script:
 
-1. Run the `release.sh` script from the root of the mondoo-operator repo with the version of the operator as the first parameter and the version of the helm chart as the second parameter (without any leading 'v' in the version string). For example:
+1. Run the `release.sh` script from the root of the mondoo-operator repo with the previous version of the operator as the first parameter and the new version of the operator as the second parameter (without any leading 'v' in the version string). For example:
 
 ```bash
-$ ./release.sh 0.2.0 0.2.0
+$ ./release.sh 0.2.0 0.2.1
 ```
 
 ### Helm Chart and Operator bundle

--- a/release.sh
+++ b/release.sh
@@ -13,4 +13,4 @@ yq -i ".version = \"${VERSION}\"" charts/mondoo-operator/Chart.yaml
 yq -i ".controllerManager.manager.image.tag = \"v${VERSION}\"" charts/mondoo-operator/values.yaml
 CHART_NAME=charts/mondoo-operator make helm
 make bundle IMG="ghcr.io/mondoohq/mondoo-operator:v${VERSION}" VERSION="${VERSION}"
-yq -i ".spec.replaces = \"v${PREV_VERSION}\"" ./bundle/manifests/mondoo-operator.clusterserviceversion.yaml 
+yq -i ".spec.replaces = \"mondoo-operator.v${PREV_VERSION}\"" ./bundle/manifests/mondoo-operator.clusterserviceversion.yaml 


### PR DESCRIPTION
And update docs to reflect new 'release.sh' behavior of taking first
parameter as previous version and second parameters as new version.

The 'replaces' field in the ClusterServiceVersion should reference the
name of the previous ClusterServiceVersion object (ie the .metadata.name
field).

See some examples:
https://github.com/k8s-operatorhub/community-operators/blob/081ab9a4e33e4a4ff4472275d16ada512a7e6510/operators/couchbase-enterprise/2.1.0/manifests/couchbase-v2.1.0.clusterserviceversion.yaml#L1127
https://github.com/k8s-operatorhub/community-operators/blob/081ab9a4e33e4a4ff4472275d16ada512a7e6510/operators/prometheus/0.47.0/prometheusoperator.0.47.0.clusterserviceversion.yaml#L491
https://github.com/k8s-operatorhub/community-operators/blob/081ab9a4e33e4a4ff4472275d16ada512a7e6510/operators/jenkins-operator/0.3.0/jenkins-operator.v0.3.0.clusterserviceversion.yaml#L224
https://github.com/k8s-operatorhub/community-operators/blob/081ab9a4e33e4a4ff4472275d16ada512a7e6510/operators/dell-csi-operator/1.4.0/dell-csi-operator.v1.4.0.clusterserviceversion.yaml#L1857

So update the release.sh script to make sure that the 'release' field
contains the right content.

Signed-off-by: Joel Diaz <joel@mondoo.com>