### PR TITLE
enable go 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
As of go 1.18, `go get` no longer installs binaries ( https://tip.golang.org/doc/go1.18#go-command ). Use `go install` where needed.

closes #243 

Signed-off-by: Joel Diaz <joel@mondoo.com>