### PR TITLE
🧹 Allowed mocking the function for retrieving the container image from a remote registry

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,10 +18,15 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -54,6 +59,19 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// Mock the retrieval of the actual image from the remote registry
+	getRemoteImage = func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error) {
+		h := sha1.New()
+		h.Write([]byte(ref.Identifier()))
+		hash, _ := v1.NewHash(hex.EncodeToString(h.Sum(nil))) // should never fail
+
+		return &remote.Descriptor{
+			Descriptor: v1.Descriptor{
+				Digest: hash,
+			},
+		}, nil
+	}
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,15 +18,10 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -61,17 +56,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	// Mock the retrieval of the actual image from the remote registry
-	getRemoteImage = func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error) {
-		h := sha1.New()
-		h.Write([]byte(ref.Identifier()))
-		hash, _ := v1.NewHash(hex.EncodeToString(h.Sum(nil))) // should never fail
-
-		return &remote.Descriptor{
-			Descriptor: v1.Descriptor{
-				Digest: hash,
-			},
-		}, nil
-	}
+	getRemoteImage = fakeGetRemoteImageFunc
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -38,6 +38,10 @@ const (
 	mondooOperatorTag   = "latest"
 )
 
+type getRemoteImageFunc func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error)
+
+var getRemoteImage getRemoteImageFunc = remote.Get
+
 func resolveMondooImage(log logr.Logger, userImageName, userImageTag string, skipResolveImage bool) (string, error) {
 	useImage := mondooImage
 	useTag := mondooTag
@@ -95,7 +99,7 @@ func parseReference(log logr.Logger, container string) (string, error) {
 		return "", err
 	}
 
-	desc, err := remote.Get(ref)
+	desc, err := getRemoteImage(ref)
 	if err != nil {
 		log.Error(err, "Failed to get container reference")
 		return "", err


### PR DESCRIPTION
Fixes #198 