### PR TITLE
⭐️ webhook mode of permissive/enforcing

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -1,0 +1,5 @@
+package v1alpha1
+
+const (
+	WebhookModeEnvVar = "MONDOO_WEBHOOK_MODE"
+)

--- a/api/v1alpha1/mondooauditconfig_types.go
+++ b/api/v1alpha1/mondooauditconfig_types.go
@@ -68,8 +68,16 @@ type WebhookCertificateConfig struct {
 	InjectionStyle string `json:"injectionStyle,omitempty"`
 }
 
+// WebhookMode specifies the allowed modes of operation for the webhook admission controller
+type WebhookMode string
+
+const (
+	Permissive WebhookMode = "permissive"
+	Enforcing  WebhookMode = "enforcing"
+)
+
 type Webhooks struct {
-	Enable bool `json:"enable,omitemmpty"`
+	Enable bool `json:"enable,omitempty"`
 
 	// CertificateConfig allows defining which certificate system to use.
 	// Leaving it as the empty string will mean the user will be responsible
@@ -77,6 +85,11 @@ type Webhooks struct {
 	// into the ValidatingWebhookConfigurations as well.
 	CertificateConfig WebhookCertificateConfig `json:"certificateConfig,omitempty"`
 	Image             Image                    `json:"image,omitempty"`
+	// Mode represents whether the webhook will behave in a "permissive" mode (the default) which
+	// will only scan and report on k8s resources or "enforcing" mode where depending
+	// on the scan results may reject the k8s resource creation/modification.
+	// +kubebuilder:validation:Enum="";permissive;enforcing
+	Mode string `json:"mode,omitempty"`
 }
 
 // MondooAuditConfigStatus defines the observed state of MondooAuditConfig

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -106,8 +106,16 @@ spec:
                       tag:
                         type: string
                     type: object
-                required:
-                - enable
+                  mode:
+                    description: Mode represents whether the webhook will behave in
+                      a "permissive" mode (the default) which will only scan and report
+                      on k8s resources or "enforcing" mode where depending on the
+                      scan results may reject the k8s resource creation/modification.
+                    enum:
+                    - ""
+                    - permissive
+                    - enforcing
+                    type: string
                 type: object
               workloads:
                 properties:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/samples/k8s_v1alpha1_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha1_mondooauditconfig.yaml
@@ -10,5 +10,7 @@ spec:
     enable: true
   webhooks:
     enable: false
+    certificateConfig:
+      injectionStyle: cert-manager # <--- remember to install cert-manager first
   mondooSecretRef: mondoo-client
   

--- a/config/samples/k8s_v1alpha1_mondoooperatorconfig.yaml
+++ b/config/samples/k8s_v1alpha1_mondoooperatorconfig.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   metrics:
     enable: false
+  skipContainerResolution: false

--- a/pkg/webhooks/core/webhook.go
+++ b/pkg/webhooks/core/webhook.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	mondoov1alpha1 "go.mondoo.com/mondoo-operator/api/v1alpha1"
+	"go.mondoo.com/mondoo-operator/pkg/webhooks/utils"
 )
 
 // Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com-core that watches Pod creation/updates
@@ -19,7 +20,21 @@ var corelog = logf.Log.WithName("core-validator")
 type CoreValidator struct {
 	Client  client.Client
 	decoder *admission.Decoder
-	Mode    string
+	mode    mondoov1alpha1.WebhookMode
+}
+
+// NewCoreWebhook will initialize a CoreValidator with the provided k8s Client and
+// set it to the provided mode. Returns error if mode is invalid.
+func NewCoreWebhook(client client.Client, mode string) (*CoreValidator, error) {
+	webhookMode, err := utils.ModeStringToWebhookMode(mode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CoreValidator{
+		Client: client,
+		mode:   webhookMode,
+	}, nil
 }
 
 var _ admission.Handler = &CoreValidator{}
@@ -31,10 +46,10 @@ func (a *CoreValidator) Handle(ctx context.Context, req admission.Request) admis
 
 	// Depending on the mode, we either just allow the resource through no matter the scan result
 	// or allow/deny based on the scan result
-	switch a.Mode {
-	case string(mondoov1alpha1.Permissive):
+	switch a.mode {
+	case mondoov1alpha1.Permissive:
 		return admission.Allowed("PASSED")
-	case string(mondoov1alpha1.Enforcing):
+	case mondoov1alpha1.Enforcing:
 		// FIXME: when we start calling the Scan Service, use the result of the scan
 		// to decide whether to ALLOW/DENY the resource
 		// For now, just allow

--- a/pkg/webhooks/core/webhook.go
+++ b/pkg/webhooks/core/webhook.go
@@ -17,29 +17,29 @@ import (
 
 var corelog = logf.Log.WithName("core-validator")
 
-type CoreValidator struct {
-	Client  client.Client
+type coreValidator struct {
+	client  client.Client
 	decoder *admission.Decoder
 	mode    mondoov1alpha1.WebhookMode
 }
 
 // NewCoreWebhook will initialize a CoreValidator with the provided k8s Client and
 // set it to the provided mode. Returns error if mode is invalid.
-func NewCoreWebhook(client client.Client, mode string) (*CoreValidator, error) {
+func NewCoreWebhook(client client.Client, mode string) (admission.Handler, error) {
 	webhookMode, err := utils.ModeStringToWebhookMode(mode)
 	if err != nil {
 		return nil, err
 	}
 
-	return &CoreValidator{
-		Client: client,
+	return &coreValidator{
+		client: client,
 		mode:   webhookMode,
 	}, nil
 }
 
-var _ admission.Handler = &CoreValidator{}
+var _ admission.Handler = &coreValidator{}
 
-func (a *CoreValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (a *coreValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	corelog.Info("Webhook triggered", "Details", req)
 
 	// TODO: call into Mondoo Scan Service to scan the resource
@@ -61,7 +61,9 @@ func (a *CoreValidator) Handle(ctx context.Context, req admission.Request) admis
 	}
 }
 
-func (a *CoreValidator) InjectDecoder(d *admission.Decoder) error {
+var _ admission.DecoderInjector = &coreValidator{}
+
+func (a *coreValidator) InjectDecoder(d *admission.Decoder) error {
 	a.decoder = d
 	return nil
 }

--- a/pkg/webhooks/core/webhooks_test.go
+++ b/pkg/webhooks/core/webhooks_test.go
@@ -34,7 +34,7 @@ func TestCoreValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Arrange
-			validator := &CoreValidator{
+			validator := &coreValidator{
 				decoder: decoder,
 			}
 

--- a/pkg/webhooks/main.go
+++ b/pkg/webhooks/main.go
@@ -84,12 +84,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-func validMode(mode string) bool {
-	switch mode {
-	case string(mondoov1alpha1.Permissive), string(mondoov1alpha1.Enforcing):
-		return true
-	default:
-		return false
-	}
-}

--- a/pkg/webhooks/utils/modes.go
+++ b/pkg/webhooks/utils/modes.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+
+	mondoov1alpha1 "go.mondoo.com/mondoo-operator/api/v1alpha1"
+)
+
+// ModeStringToWebhookMode will take a string and convert it to a known
+// webhook mode, or sets an error on return if it is an unknown/invalid mode.
+func ModeStringToWebhookMode(mode string) (mondoov1alpha1.WebhookMode, error) {
+	switch mode {
+	case string(mondoov1alpha1.Enforcing):
+		return mondoov1alpha1.Enforcing, nil
+	case string(mondoov1alpha1.Permissive):
+		return mondoov1alpha1.Permissive, nil
+	default:
+		return mondoov1alpha1.Permissive, fmt.Errorf("mode %s is not valid", mode)
+	}
+}


### PR DESCRIPTION
- [x] Add new MondooAuditConfig.Spec.Webhooks.Mode that can be set to "";permissive;enforcing
- [x] Use the new Mode field to set MONDOO_WEBHOOK_MODE on the Deployment for the webhook
- [x] Test cases to cover a proper-looking webhook Deployment
- [x]  Random cleanups to make local testing easier

Not specific to #246, but still worth fixing:
- [x] Make sure we clean up Status when scanning is disabled for a specific component

closes #246 