### PR TITLE
🧹 scale back the resource requests for Pods

### DIFF
--- a/controllers/resources_requirements.go
+++ b/controllers/resources_requirements.go
@@ -11,10 +11,10 @@ var defaultMondooClientResources corev1.ResourceRequirements = corev1.ResourceRe
 		corev1.ResourceMemory: resource.MustParse("1G"),
 		corev1.ResourceCPU:    resource.MustParse("500m"),
 	},
-	// 75% of the limits
+
 	Requests: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("750M"),
-		corev1.ResourceCPU:    resource.MustParse("375m"),
+		corev1.ResourceMemory: resource.MustParse("500M"), // 50% of the limit
+		corev1.ResourceCPU:    resource.MustParse("50m"),  // 10% of the limit
 	},
 }
 

--- a/controllers/resources_requirements_test.go
+++ b/controllers/resources_requirements_test.go
@@ -17,8 +17,8 @@ func TestRquriementComparison(t *testing.T) {
 		},
 		// 75% of the limits
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("750M"),
-			corev1.ResourceCPU:    resource.MustParse("375m"),
+			corev1.ResourceMemory: resource.MustParse("500M"),
+			corev1.ResourceCPU:    resource.MustParse("50m"),
 		},
 	}))
 }


### PR DESCRIPTION
As CPU is a very compressible resource, we can ask for far less than 375m (which is really basically saying we need 1/3 of a full CPU). Bring that way back to 50m (5% of a CPU). Still allowing the Pod access to a full 1/2 a CPU in the event that a particular scan was CPU intensive.

For Memory, scale it back a bit from requesting 750M (which was 75% of the Pod Memory limit), down to 500M (50% of the limit). This should guarantee a minimum of .5GB with a bit of "overscheduling" the underlying cluster memory-wise).

closes #256 

Signed-off-by: Joel Diaz <joel@mondoo.com>