### PR TITLE
🧹 increase timeout during helm e2e

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Verify Mondoo Operator Helm Chart
         run: |
           kubectl wait --for=condition=Ready pod -l control-plane=controller-manager --namespace mondoo-operator 
-          kubectl wait --for=condition=Ready pod -l mondoo_cr=mondoo-client --namespace mondoo-operator --timeout=400s
+          kubectl wait --for=condition=Ready pod -l mondoo_cr=mondoo-client --namespace mondoo-operator --timeout=600s
           curl -sSL http://mondoo.io/download.sh | bash
           mv mondoo /usr/local/bin/ 
           make test/deployment


### PR DESCRIPTION
Saw some e2e timeouts that were not reproducable locally. Raise timeout from 400s to 600s

Signed-off-by: Joel Diaz <joel@mondoo.com>