### PR TITLE
🧹 descriptive names for DaemonSet and Deployment

### DIFF
--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	daemonSetConfigMapNameTemplate = `%s-ds`
-	daemonSetNameTemplate          = `%s-node`
+	NodeDaemonSetNameTemplate      = `%s-node`
 )
 
 type Nodes struct {
@@ -107,7 +107,7 @@ func (n *Nodes) declareDaemonSet(ctx context.Context, clt client.Client, scheme 
 	log := ctrllog.FromContext(ctx)
 
 	found := &appsv1.DaemonSet{}
-	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(daemonSetNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
+	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(NodeDaemonSetNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 
 		declared := n.daemonsetForMondoo()
@@ -180,7 +180,7 @@ func (n *Nodes) daemonsetForMondoo() *appsv1.DaemonSet {
 	ls["audit"] = "node"
 	dep := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf(daemonSetNameTemplate, n.Mondoo.Name),
+			Name:      fmt.Sprintf(NodeDaemonSetNameTemplate, n.Mondoo.Name),
 			Namespace: n.Mondoo.Namespace,
 			Labels:    ls,
 		},
@@ -312,7 +312,7 @@ func (n *Nodes) down(ctx context.Context, clt client.Client, req ctrl.Request) (
 	log := ctrllog.FromContext(ctx)
 
 	found := &appsv1.DaemonSet{}
-	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(daemonSetNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
+	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(NodeDaemonSetNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
 
 	if err != nil && errors.IsNotFound(err) {
 		return ctrl.Result{}, nil

--- a/controllers/nodes_test.go
+++ b/controllers/nodes_test.go
@@ -93,7 +93,7 @@ var _ = Describe("nodes", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			daemonSetName := fmt.Sprintf(daemonSetNameTemplate, name)
+			daemonSetName := fmt.Sprintf(NodeDaemonSetNameTemplate, name)
 			By("Checking that the daemonset is found")
 			foundDaemonset := &appsv1.DaemonSet{}
 			Eventually(func() bool {

--- a/controllers/nodes_test.go
+++ b/controllers/nodes_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -92,10 +93,11 @@ var _ = Describe("nodes", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
+			daemonSetName := fmt.Sprintf(daemonSetNameTemplate, name)
 			By("Checking that the daemonset is found")
 			foundDaemonset := &appsv1.DaemonSet{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDaemonset)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: daemonSetName, Namespace: namespace}, foundDaemonset)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -109,7 +111,7 @@ var _ = Describe("nodes", func() {
 
 			By("Checking that the daemonset is NOT found")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDaemonset)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: daemonSetName, Namespace: namespace}, foundDaemonset)
 				return err == nil
 			}, timeout, interval).Should(BeFalse())
 

--- a/controllers/workloads.go
+++ b/controllers/workloads.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	workloadDeploymentConfigMapNameTemplate = `%s-deploy`
-	workloadDeploymentNameTemplate          = `%s-workload`
+	WorkloadDeploymentNameTemplate          = `%s-workload`
 )
 
 type Workloads struct {
@@ -178,7 +178,7 @@ func (n *Workloads) deploymentForMondoo() *appsv1.Deployment {
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf(workloadDeploymentNameTemplate, n.Mondoo.Name),
+			Name:      fmt.Sprintf(WorkloadDeploymentNameTemplate, n.Mondoo.Name),
 			Namespace: n.Mondoo.Namespace,
 			Labels:    ls,
 		},
@@ -328,7 +328,7 @@ func (n *Workloads) down(ctx context.Context, clt client.Client, req ctrl.Reques
 	log := ctrllog.FromContext(ctx)
 
 	found := &appsv1.Deployment{}
-	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(workloadDeploymentNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
+	err := clt.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(WorkloadDeploymentNameTemplate, n.Mondoo.Name), Namespace: n.Mondoo.Namespace}, found)
 
 	if err != nil && errors.IsNotFound(err) {
 		return ctrl.Result{}, nil

--- a/controllers/workloads.go
+++ b/controllers/workloads.go
@@ -293,6 +293,10 @@ func (n *Workloads) Reconcile(ctx context.Context, clt client.Client, scheme *ru
 		return ctrl.Result{}, err
 	}
 
+	if !n.Enable {
+		return n.down(ctx, clt, req)
+	}
+
 	if n.Mondoo.Spec.Workloads.ServiceAccount == "" && n.Mondoo.Namespace == namespace {
 		n.Mondoo.Spec.Workloads.ServiceAccount = defaultServiceAccount
 	}
@@ -300,10 +304,6 @@ func (n *Workloads) Reconcile(ctx context.Context, clt client.Client, scheme *ru
 		err := fmt.Errorf("MondooAuditConfig.spec.workloads.serviceAccount cannot be empty when running in a different namespace than mondoo-operator")
 		log.Error(err, "ServiceAccount cannot be empty")
 		return ctrl.Result{}, err
-	}
-
-	if !n.Enable {
-		return n.down(ctx, clt, req)
 	}
 
 	skipResolveImage := n.MondooOperatorConfig.Spec.SkipContainerResolution

--- a/controllers/workloads_test.go
+++ b/controllers/workloads_test.go
@@ -103,7 +103,7 @@ var _ = Describe("workloads", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			workloadDeploymentName := fmt.Sprintf(workloadDeploymentNameTemplate, name)
+			workloadDeploymentName := fmt.Sprintf(WorkloadDeploymentNameTemplate, name)
 			By("Checking that the deployment is found")
 			foundDeployment := &appsv1.Deployment{}
 			Eventually(func() bool {

--- a/controllers/workloads_test.go
+++ b/controllers/workloads_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -102,10 +103,11 @@ var _ = Describe("workloads", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
+			workloadDeploymentName := fmt.Sprintf(workloadDeploymentNameTemplate, name)
 			By("Checking that the deployment is found")
 			foundDeployment := &appsv1.Deployment{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDeployment)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: workloadDeploymentName, Namespace: namespace}, foundDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -119,7 +121,7 @@ var _ = Describe("workloads", func() {
 
 			By("Checking that the deployment is NOT found")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDeployment)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: workloadDeploymentName, Namespace: namespace}, foundDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeFalse())
 

--- a/tests/integration/mondoo_installation_test.go
+++ b/tests/integration/mondoo_installation_test.go
@@ -2,15 +2,19 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.mondoo.com/mondoo-operator/tests/framework/installer"
-	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 	"go.uber.org/zap"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mondoocontrollers "go.mondoo.com/mondoo-operator/controllers"
+	"go.mondoo.com/mondoo-operator/tests/framework/installer"
+	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 )
 
 type MondooInstallationSuite struct {
@@ -70,7 +74,8 @@ func (s *MondooInstallationSuite) testMondooInstallation() {
 	// Verify there is just 1 deployment that its name matches the name of the CR and that the
 	// replica size is 1.
 	s.Equalf(1, len(deployments.Items), "Deployments count in Mondoo namespace is incorrect.")
-	s.Equalf(auditConfig.Name, deployments.Items[0].Name, "Deployment name does not match audit config name.")
+	expectedWorkloadDeploymentName := fmt.Sprintf(mondoocontrollers.WorkloadDeploymentNameTemplate, auditConfig.Name)
+	s.Equalf(expectedWorkloadDeploymentName, deployments.Items[0].Name, "Deployment name does not match expected name based from audit config name.")
 	s.Equalf(int32(1), *deployments.Items[0].Spec.Replicas, "Deployment does not have 1 replica.")
 
 	zap.S().Info("Enable nodes auditing.")
@@ -99,7 +104,8 @@ func (s *MondooInstallationSuite) testMondooInstallation() {
 
 	// Verify there is just 1 daemon set and that its name matches the name of the CR.
 	s.Equalf(1, len(daemonSets.Items), "DaemonSets count in Mondoo namespace is incorrect.")
-	s.Equalf(auditConfig.Name, daemonSets.Items[0].Name, "DaemonSet name does not match audit config name.")
+	expectedDaemonSetName := fmt.Sprintf(mondoocontrollers.NodeDaemonSetNameTemplate, auditConfig.Name)
+	s.Equalf(expectedDaemonSetName, daemonSets.Items[0].Name, "DaemonSet name does not match expected name based from audit config name.")
 }
 
 func TestMondooInstallationSuite(t *testing.T) {


### PR DESCRIPTION
Add the postfix '-node' to the DaemonSet so that the Pods can be more easily identified by name.

Add the postfix '-workload' to the Deployment (for workloads) so that the Pod can be more easily identified.

closes #242 