### PR TITLE
🧹 manually remove MondooAuditConfig for helm e2e

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -49,6 +49,7 @@ jobs:
           curl -sSL http://mondoo.io/download.sh | bash
           mv mondoo /usr/local/bin/ 
           make test/deployment
+          kubectl delete -f config/samples/k8s_v1alpha1_mondooauditconfig.yaml
           helm uninstall mondoo-operator  --namespace mondoo-operator
       - name: Run chart-releaser
         # switch back to helm/chart-releaser-action when #60 is fixed


### PR DESCRIPTION
Just like we manually add the MondooAuditConfig, add a step to remove it before doing 'helm uninstall'.

Otherwise, the MondooAuditConfig resource doesn't get cleaned up because the finalizer sticks around, and because it doesn't get removed, then the node/workload scanning resources also stick around.

Signed-off-by: Joel Diaz <joel@mondoo.com>