### PR TITLE
🧹 make resource comments reflect reality

### DIFF
--- a/controllers/resources_requirements_test.go
+++ b/controllers/resources_requirements_test.go
@@ -15,10 +15,9 @@ func TestRquriementComparison(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("1G"),
 			corev1.ResourceCPU:    resource.MustParse("0.5"), // used instead of 500m
 		},
-		// 75% of the limits
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("500M"),
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("500M"), // 50% of the limit
+			corev1.ResourceCPU:    resource.MustParse("50m"),  // 10% of the limit
 		},
 	}))
 }


### PR DESCRIPTION
Recently updated the resource requests/limits (in #258 ). Test case had old comment about what the percentages were. Make comments in test reflect reality.

Hat tip @tas50 

Signed-off-by: Joel Diaz <joel@mondoo.com>