### PR TITLE
:star: Add linting step

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,31 +1,25 @@
----
-name: Spell Checking
-
+name: Lint
 on:
   pull_request:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
-      - main
+      - "main"
+    tags: ["v*.*.*"]
 
 jobs:
-  spelling:
-    name: Run spell check
+  lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
-      - name: checkout-merge
-        if: "contains(github.event_name, 'pull_request')"
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
         with:
-          ref: refs/pull/${{github.event.pull_request.number}}/merge
-      - name: checkout
-        if: ${{ github.event_name == 'push' ||
-          (
-          contains(github.event.comment.body, '@check-spelling-bot apply')
-          ) }}
-        uses: actions/checkout@v2
-      - uses: check-spelling/check-spelling@main
-        id: spelling
+          go-version: "${{ env.golang-version }}"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
-          post_comment: 0
-          extra_dictionaries: cspell:aws/aws.txt
-            cspell:filetypes/filetypes.txt
+          version: v1.45

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -1,0 +1,31 @@
+---
+name: Spell Checking
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  spelling:
+    name: Run spell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout-merge
+        if: "contains(github.event_name, 'pull_request')"
+        uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{github.event.pull_request.number}}/merge
+      - name: checkout
+        if: ${{ github.event_name == 'push' ||
+          (
+          contains(github.event.comment.body, '@check-spelling-bot apply')
+          ) }}
+        uses: actions/checkout@v2
+      - uses: check-spelling/check-spelling@main
+        id: spelling
+        with:
+          post_comment: 0
+          extra_dictionaries: cspell:aws/aws.txt
+            cspell:filetypes/filetypes.txt

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+lint: golangci-lint
+	$(GOLANGCI_LINT) run
+
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test $(UNIT_TEST_PACKAGES) -coverprofile cover.out
 
@@ -177,6 +180,10 @@ envtest: ## Download envtest-setup locally if necessary.
 GOTESTSUM = $(shell pwd)/bin/gotestsum
 gotestsum: ## Download gotestsum locally if necessary.
 	$(call go-get-tool,$(GOTESTSUM),gotest.tools/gotestsum@latest)
+
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+golangci-lint: ## Download golangci-lint locally if necessary.
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -271,23 +271,23 @@ func (n *Nodes) Reconcile(ctx context.Context, clt client.Client, scheme *runtim
 
 	log := ctrllog.FromContext(ctx)
 
-	if n.Enable {
-		skipResolveImage := n.MondooOperatorConfig.Spec.SkipContainerResolution
-		mondooImage, err := resolveMondooImage(log, n.Mondoo.Spec.Nodes.Image.Name, n.Mondoo.Spec.Nodes.Image.Tag, skipResolveImage)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		n.Image = mondooImage
-		result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
-		if err != nil || result.Requeue {
-			return result, err
-		}
-		result, err = n.declareDaemonSet(ctx, clt, scheme, req, true)
-		if err != nil || result.Requeue {
-			return result, err
-		}
-	} else {
-		n.down(ctx, clt, req)
+	if !n.Enable {
+		return n.down(ctx, clt, req)
+	}
+
+	skipResolveImage := n.MondooOperatorConfig.Spec.SkipContainerResolution
+	mondooImage, err := resolveMondooImage(log, n.Mondoo.Spec.Nodes.Image.Name, n.Mondoo.Spec.Nodes.Image.Tag, skipResolveImage)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	n.Image = mondooImage
+	result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
+	if err != nil || result.Requeue {
+		return result, err
+	}
+	result, err = n.declareDaemonSet(ctx, clt, scheme, req, true)
+	if err != nil || result.Requeue {
+		return result, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/nodes_test.go
+++ b/controllers/nodes_test.go
@@ -39,7 +39,6 @@ var _ = Describe("nodes", func() {
 		name      = "nodes"
 		namespace = "nodes-namespace"
 		timeout   = time.Second * 10
-		duration  = time.Second * 10
 		interval  = time.Millisecond * 250
 	)
 	BeforeEach(func() {
@@ -90,29 +89,20 @@ var _ = Describe("nodes", func() {
 			foundMondoo := &k8sv1alpha1.MondooAuditConfig{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundMondoo)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking that the daemonset is found")
 			foundDaemonset := &appsv1.DaemonSet{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDaemonset)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By("Updating the daemonset to be false")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundMondoo)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			foundMondoo.Spec.Nodes.Enable = false
 			Expect(k8sClient.Update(ctx, foundMondoo)).Should(Succeed())
@@ -120,10 +110,7 @@ var _ = Describe("nodes", func() {
 			By("Checking that the daemonset is NOT found")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDaemonset)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeFalse())
 
 		})

--- a/controllers/service_monitor.go
+++ b/controllers/service_monitor.go
@@ -148,7 +148,7 @@ func (s *ServiceMonitor) Reconcile(ctx context.Context, clt client.Client, schem
 		}
 	} else {
 		if found {
-			s.down(ctx, clt)
+			return s.down(ctx, clt)
 		}
 	}
 	return ctrl.Result{}, nil

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,7 +39,6 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client // You'll be using this client in your tests.
 	testEnv   *envtest.Environment
 	ctx       context.Context

--- a/controllers/workloads.go
+++ b/controllers/workloads.go
@@ -292,24 +292,24 @@ func (n *Workloads) Reconcile(ctx context.Context, clt client.Client, scheme *ru
 		return ctrl.Result{}, err
 	}
 
-	if n.Enable {
-		skipResolveImage := n.MondooOperatorConfig.Spec.SkipContainerResolution
-		mondooImage, err := resolveMondooImage(log, n.Mondoo.Spec.Workloads.Image.Name, n.Mondoo.Spec.Workloads.Image.Tag, skipResolveImage)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		n.Image = mondooImage
+	if !n.Enable {
+		return n.down(ctx, clt, req)
+	}
 
-		result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
-		if err != nil || result.Requeue {
-			return result, err
-		}
-		result, err = n.declareDeployment(ctx, clt, scheme, req, true)
-		if err != nil || result.Requeue {
-			return result, err
-		}
-	} else {
-		n.down(ctx, clt, req)
+	skipResolveImage := n.MondooOperatorConfig.Spec.SkipContainerResolution
+	mondooImage, err := resolveMondooImage(log, n.Mondoo.Spec.Workloads.Image.Name, n.Mondoo.Spec.Workloads.Image.Tag, skipResolveImage)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	n.Image = mondooImage
+
+	result, err := n.declareConfigMap(ctx, clt, scheme, req, inventory)
+	if err != nil || result.Requeue {
+		return result, err
+	}
+	result, err = n.declareDeployment(ctx, clt, scheme, req, true)
+	if err != nil || result.Requeue {
+		return result, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/workloads_test.go
+++ b/controllers/workloads_test.go
@@ -39,7 +39,6 @@ var _ = Describe("workloads", func() {
 		name      = "workloads"
 		namespace = "workloads-namespace"
 		timeout   = time.Second * 10
-		duration  = time.Second * 10
 		interval  = time.Millisecond * 250
 	)
 	BeforeEach(func() {
@@ -100,29 +99,20 @@ var _ = Describe("workloads", func() {
 			foundMondoo := &k8sv1alpha1.MondooAuditConfig{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundMondoo)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking that the deployment is found")
 			foundDeployment := &appsv1.Deployment{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDeployment)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By("Updating the deployment to be false")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundMondoo)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			foundMondoo.Spec.Workloads.Enable = false
 			Expect(k8sClient.Update(ctx, foundMondoo)).Should(Succeed())
@@ -130,10 +120,7 @@ var _ = Describe("workloads", func() {
 			By("Checking that the deployment is NOT found")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundDeployment)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeFalse())
 
 		})

--- a/pkg/webhooks/core/webhooks_test.go
+++ b/pkg/webhooks/core/webhooks_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -75,7 +76,7 @@ func testExamplePod() runtime.RawExtension {
 
 func setupDecoder(t *testing.T) *admission.Decoder {
 	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
 	decoder, err := admission.NewDecoder(scheme)
 	require.NoError(t, err, "Failed to setup decoder for testing")
 

--- a/tests/integration/test_cluster.go
+++ b/tests/integration/test_cluster.go
@@ -28,7 +28,9 @@ func StartTestCluster(settings installer.Settings, t func() *testing.T) *TestClu
 			cluster.GatherAllMondooLogs(t().Name(), installer.MondooNamespace)
 		}
 		t().Fail()
-		cluster.UninstallOperator()
+		if err := cluster.UninstallOperator(); err != nil {
+			zap.S().Errorf("Failed to uninstall Mondoo operator. %v", err)
+		}
 		t().FailNow()
 	}
 


### PR DESCRIPTION
I noticed there is no linting step for the code base (only a spell checker). This PR adds [golangci-lint](https://golangci-lint.run/) action to the repo and extends the `Makefile` with a lint target