### PR TITLE
:star: extend webhook watching to Deployments

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -26,3 +26,23 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-mondoo-com-apps
+  failurePolicy: Ignore
+  name: apps-policy.k8s.mondoo.com
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,9 +12,9 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-k8s-mondoo-com-core
+      path: /validate-k8s-mondoo-com
   failurePolicy: Ignore
-  name: core-policy.k8s.mondoo.com
+  name: policy.k8s.mondoo.com
   rules:
   - apiGroups:
     - ""

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -18,25 +18,6 @@ webhooks:
   rules:
   - apiGroups:
     - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pods
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-k8s-mondoo-com-apps
-  failurePolicy: Ignore
-  name: apps-policy.k8s.mondoo.com
-  rules:
-  - apiGroups:
     - apps
     apiVersions:
     - v1
@@ -44,5 +25,6 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
+    - pods
     - deployments
   sideEffects: None

--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -16,25 +16,6 @@ webhooks:
   rules:
   - apiGroups:
     - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pods
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-k8s-mondoo-com-apps
-  failurePolicy: Ignore
-  name: apps-policy.k8s.mondoo.com
-  rules:
-  - apiGroups:
     - apps
     apiVersions:
     - v1
@@ -42,5 +23,6 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
+    - pods
     - deployments
   sideEffects: None

--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -10,9 +10,9 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-k8s-mondoo-com-core
+      path: /validate-k8s-mondoo-com
   failurePolicy: Ignore
-  name: core-policy.k8s.mondoo.com
+  name: policy.k8s.mondoo.com
   rules:
   - apiGroups:
     - ""

--- a/controllers/webhook-manifests.yaml
+++ b/controllers/webhook-manifests.yaml
@@ -24,3 +24,23 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-mondoo-com-apps
+  failurePolicy: Ignore
+  name: apps-policy.k8s.mondoo.com
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None

--- a/controllers/webhooks.go
+++ b/controllers/webhooks.go
@@ -171,6 +171,10 @@ func deepEqualsValidatingWebhookConfiguration(existing, desired *webhooksv1.Vali
 		if existing.Webhooks[i].ClientConfig.Service != desired.Webhooks[i].ClientConfig.Service {
 			return false
 		}
+
+		if existing.Webhooks[i].Name != desired.Webhooks[i].Name {
+			return false
+		}
 	}
 
 	return true

--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -12,10 +12,8 @@ import (
 	"go.mondoo.com/mondoo-operator/pkg/webhooks/utils"
 )
 
-// Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com-core that watches Pod creation/updates
-//+kubebuilder:webhook:path=/validate-k8s-mondoo-com-core,mutating=false,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=core-policy.k8s.mondoo.com,admissionReviewVersions=v1
-// Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com-apps that watches Deployment creation/updates
-//+kubebuilder:webhook:path=/validate-k8s-mondoo-com-apps,mutating=false,failurePolicy=ignore,sideEffects=None,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=apps-policy.k8s.mondoo.com,admissionReviewVersions=v1
+// Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com that watches Pod/Deployment creation/updates
+//+kubebuilder:webhook:path=/validate-k8s-mondoo-com-core,mutating=false,failurePolicy=ignore,sideEffects=None,groups="";apps,resources=pods;deployments,verbs=create;update,versions=v1,name=core-policy.k8s.mondoo.com,admissionReviewVersions=v1
 
 var handlerlog = logf.Log.WithName("webhook-validator")
 

--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com that watches Pod/Deployment creation/updates
-//+kubebuilder:webhook:path=/validate-k8s-mondoo-com-core,mutating=false,failurePolicy=ignore,sideEffects=None,groups="";apps,resources=pods;deployments,verbs=create;update,versions=v1,name=core-policy.k8s.mondoo.com,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-k8s-mondoo-com,mutating=false,failurePolicy=ignore,sideEffects=None,groups="";apps,resources=pods;deployments,verbs=create;update,versions=v1,name=policy.k8s.mondoo.com,admissionReviewVersions=v1
 
 var handlerlog = logf.Log.WithName("webhook-validator")
 

--- a/pkg/webhooks/handler/webhook_test.go
+++ b/pkg/webhooks/handler/webhook_test.go
@@ -1,4 +1,4 @@
-package corewebhook
+package webhookhandler
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func TestCoreValidate(t *testing.T) {
+func TestWebhookValidate(t *testing.T) {
 
 	decoder := setupDecoder(t)
 	tests := []struct {
@@ -30,12 +31,18 @@ func TestCoreValidate(t *testing.T) {
 			expectReason:  "PASSED",
 			object:        testExamplePod(),
 		},
+		{
+			name:          "example Deployment",
+			expectAllowed: true,
+			expectReason:  "PASSED",
+			object:        testExampleDeployment(),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Arrange
-			validator := &coreValidator{
+			validator := &webhookValidator{
 				decoder: decoder,
 			}
 
@@ -71,6 +78,19 @@ func testExamplePod() runtime.RawExtension {
 
 	return runtime.RawExtension{
 		Object: pod,
+	}
+}
+
+func testExampleDeployment() runtime.RawExtension {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testDeployment",
+			Namespace: "testNamespace",
+		},
+	}
+
+	return runtime.RawExtension{
+		Object: dep,
 	}
 }
 

--- a/pkg/webhooks/main.go
+++ b/pkg/webhooks/main.go
@@ -68,7 +68,6 @@ func main() {
 		os.Exit(1)
 	}
 	hookServer.Register("/validate-k8s-mondoo-com-core", &webhook.Admission{Handler: webhookValidator})
-	hookServer.Register("/validate-k8s-mondoo-com-apps", &webhook.Admission{Handler: webhookValidator})
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		webhookLog.Error(err, "unable to set up health check")

--- a/pkg/webhooks/main.go
+++ b/pkg/webhooks/main.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	mondoov1alpha1 "go.mondoo.com/mondoo-operator/api/v1alpha1"
-	corewebhook "go.mondoo.com/mondoo-operator/pkg/webhooks/core"
+	webhookhandler "go.mondoo.com/mondoo-operator/pkg/webhooks/handler"
 )
 
 func init() {
@@ -62,12 +62,13 @@ func main() {
 
 	webhookLog.Info("registering webhooks to the webhook server")
 
-	coreValidator, err := corewebhook.NewCoreWebhook(mgr.GetClient(), mode)
+	webhookValidator, err := webhookhandler.NewWebhookValidator(mgr.GetClient(), mode)
 	if err != nil {
 		webhookLog.Error(err, "failed to setup Core Webhook")
 		os.Exit(1)
 	}
-	hookServer.Register("/validate-k8s-mondoo-com-core", &webhook.Admission{Handler: coreValidator})
+	hookServer.Register("/validate-k8s-mondoo-com-core", &webhook.Admission{Handler: webhookValidator})
+	hookServer.Register("/validate-k8s-mondoo-com-apps", &webhook.Admission{Handler: webhookValidator})
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		webhookLog.Error(err, "unable to set up health check")

--- a/pkg/webhooks/main.go
+++ b/pkg/webhooks/main.go
@@ -67,7 +67,7 @@ func main() {
 		webhookLog.Error(err, "failed to setup Core Webhook")
 		os.Exit(1)
 	}
-	hookServer.Register("/validate-k8s-mondoo-com-core", &webhook.Admission{Handler: webhookValidator})
+	hookServer.Register("/validate-k8s-mondoo-com", &webhook.Admission{Handler: webhookValidator})
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		webhookLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
- [x] use existing webhook to also watch for appsv1/Deployments
- [x] rename files to reflect more generic handling of resources
- [x] register new endpoint for receiving appsv1 resources
- [x] generate updated manifests

Additionally, implement a custom deepEquals() for knowing when an existing webhook needs updating.

On update of an existing webhook, be sure to clear out any previous annotations to cover the case where a runtime change was made to handing TLS certs for the webhook.

closes #249  