### PR TITLE
⭐ e2e for webhook

### DIFF
--- a/controllers/webhooks.go
+++ b/controllers/webhooks.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	webhookLabelKey   = "control-plane"
-	webhookLabelValue = "webhook-manager"
+	WebhookLabelKey   = "control-plane"
+	WebhookLabelValue = "webhook-manager"
 
 	webhookTLSSecretName = "webhook-server-cert"
 
@@ -196,7 +196,7 @@ func (n *Webhooks) syncWebhookService(ctx context.Context) error {
 				},
 			},
 			Selector: map[string]string{
-				webhookLabelKey: webhookLabelValue,
+				WebhookLabelKey: WebhookLabelValue,
 			},
 		},
 	}
@@ -276,20 +276,20 @@ func (n *Webhooks) syncWebhookDeployment(ctx context.Context) error {
 			Name:      getWebhookDeploymentName(n.Mondoo.Name),
 			Namespace: n.TargetNamespace,
 			Labels: map[string]string{
-				webhookLabelKey: webhookLabelValue,
+				WebhookLabelKey: WebhookLabelValue,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					webhookLabelKey: webhookLabelValue,
+					WebhookLabelKey: WebhookLabelValue,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						webhookLabelKey: webhookLabelValue,
+						WebhookLabelKey: WebhookLabelValue,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -13,6 +13,7 @@ import (
 	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -68,6 +69,16 @@ func (i *MondooInstaller) InstallOperator() error {
 
 	if !i.K8sHelper.IsPodReady("control-plane=controller-manager", i.Settings.Namespace) {
 		return fmt.Errorf("Mondoo operator is not in a ready state.")
+	}
+
+	// Create a MondooOperatorConfig with default values
+	operatorConfig := &mondoov1.MondooOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mondoov1.MondooOperatorConfigName,
+		},
+	}
+	if err := i.K8sHelper.Clientset.Create(i.ctx, operatorConfig); err != nil {
+		return fmt.Errorf("failed to create default MondooOperatorConfig: %s", err)
 	}
 	zap.S().Info("Mondoo operator is ready.")
 

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -175,4 +176,36 @@ func (i *MondooInstaller) readManifestWithNamespace(manifest string) string {
 		updatedNamespace,
 		"namespace: mondoo-operator",
 		fmt.Sprintf("namespace: %s", i.Settings.Namespace))
+}
+
+// GenerateServiceCerts will generate a CA along with signed certificates for the provided dnsNames, and save
+// it into secretName. It will return the CA certificate and any error encountered.
+func (i *MondooInstaller) GenerateServiceCerts(auditConfig *mondoov1.MondooAuditConfig, secretName string, serviceDNSNames []string) (*bytes.Buffer, error) {
+	if auditConfig == nil {
+		return nil, fmt.Errorf("cannot generate certificates for a nil MondooAuditConfig")
+	}
+
+	caCert, serverCert, serverPrivKey, err := utils.GenerateTLSCerts(serviceDNSNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate certificates: %s", err)
+	}
+
+	// Save cert/key to the Secret name the Webhook Deployment will expect
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: auditConfig.Namespace,
+		},
+		StringData: map[string]string{
+			"ca.crt":  caCert.String(),
+			"tls.crt": serverCert.String(),
+			"tls.key": serverPrivKey.String(),
+		},
+	}
+
+	if err := i.K8sHelper.Clientset.Create(i.ctx, secret); err != nil {
+		return nil, fmt.Errorf("failed to create Secret with certificate data: %s", err)
+	}
+
+	return caCert, nil
 }

--- a/tests/framework/utils/certificate_utils.go
+++ b/tests/framework/utils/certificate_utils.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// Webhook generation approach from https://gist.github.com/velotiotech/2e0cfd15043513d253cad7c9126d2026#file-initcontainer_main-go
+
+// GenerateWebhookCerts will return the CA certificate, the Server certificate, and the Server private key
+func GenerateWebhookCerts(s suite.Suite, dnsNames []string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2222),
+		Subject: pkix.Name{
+			Organization: []string{"Mondoo Operator E2E CA"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(0, 0, 5),
+		IsCA:      true,
+		//ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.NoError(err, "Failed to generate private key for CA")
+
+	caCert, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	s.NoError(err, "Failed to create self-sign certificate for CA")
+
+	pemEncodedCA := new(bytes.Buffer)
+	s.NoError(pem.Encode(pemEncodedCA, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCert,
+	}))
+
+	serverCert := &x509.Certificate{
+		DNSNames:     dnsNames,
+		SerialNumber: big.NewInt(3333),
+		Subject: pkix.Name{
+			CommonName:   "Admission Webhook for Mondoo",
+			Organization: []string{"mondoo.com"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(0, 0, 4),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+
+	serverPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.NoError(err, "Failed to generate private key for webhook Service")
+
+	serverCertBytes, err := x509.CreateCertificate(rand.Reader, serverCert, ca, &serverPrivKey.PublicKey, caPrivKey)
+	s.NoError(err, "Failed to sign webhook server certificate")
+
+	pemEncodedServerCert := new(bytes.Buffer)
+	s.NoError(pem.Encode(pemEncodedServerCert, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverCertBytes,
+	}))
+
+	pemEncodedServerPrivKey := new(bytes.Buffer)
+	s.NoError(pem.Encode(pemEncodedServerPrivKey, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey),
+	}))
+
+	return pemEncodedCA, pemEncodedServerCert, pemEncodedServerPrivKey
+
+}

--- a/tests/framework/utils/certificate_utils.go
+++ b/tests/framework/utils/certificate_utils.go
@@ -7,40 +7,42 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"time"
-
-	"github.com/stretchr/testify/suite"
 )
 
-// Webhook generation approach from https://gist.github.com/velotiotech/2e0cfd15043513d253cad7c9126d2026#file-initcontainer_main-go
+// Certificate generation approach from https://gist.github.com/velotiotech/2e0cfd15043513d253cad7c9126d2026#file-initcontainer_main-go
 
-// GenerateWebhookCerts will return the CA certificate, the Server certificate, and the Server private key
-func GenerateWebhookCerts(s suite.Suite, dnsNames []string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+// GenerateTLSCerts will return create a CA and return the CA certificate, the Server certificate, and the Server private key
+// for the provided list of dnsNames
+func GenerateTLSCerts(dnsNames []string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2222),
 		Subject: pkix.Name{
 			Organization: []string{"Mondoo Operator E2E CA"},
 		},
-		NotBefore: time.Now(),
-		NotAfter:  time.Now().AddDate(0, 0, 5),
-		IsCA:      true,
-		//ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 5),
+		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 
 	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	s.NoError(err, "Failed to generate private key for CA")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate private key for CA: %s", err)
+	}
 
 	caCert, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	s.NoError(err, "Failed to create self-sign certificate for CA")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create self-signed certificate for CA")
+	}
 
 	pemEncodedCA := new(bytes.Buffer)
-	s.NoError(pem.Encode(pemEncodedCA, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caCert,
-	}))
+	if err := pem.Encode(pemEncodedCA, &pem.Block{Type: "CERTIFICATE", Bytes: caCert}); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to encode CA certificate: %s", err)
+	}
 
 	serverCert := &x509.Certificate{
 		DNSNames:     dnsNames,
@@ -56,23 +58,25 @@ func GenerateWebhookCerts(s suite.Suite, dnsNames []string) (*bytes.Buffer, *byt
 	}
 
 	serverPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	s.NoError(err, "Failed to generate private key for webhook Service")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate private key for Service: %s", err)
+	}
 
 	serverCertBytes, err := x509.CreateCertificate(rand.Reader, serverCert, ca, &serverPrivKey.PublicKey, caPrivKey)
-	s.NoError(err, "Failed to sign webhook server certificate")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to sign server certificate for Service: %s", err)
+	}
 
 	pemEncodedServerCert := new(bytes.Buffer)
-	s.NoError(pem.Encode(pemEncodedServerCert, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: serverCertBytes,
-	}))
+	if err := pem.Encode(pemEncodedServerCert, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertBytes}); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to encode certificate for Service: %s", err)
+	}
 
 	pemEncodedServerPrivKey := new(bytes.Buffer)
-	s.NoError(pem.Encode(pemEncodedServerPrivKey, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey),
-	}))
+	if err := pem.Encode(pemEncodedServerPrivKey, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey)}); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to encode private key for Service: %s", err)
+	}
 
-	return pemEncodedCA, pemEncodedServerCert, pemEncodedServerPrivKey
+	return pemEncodedCA, pemEncodedServerCert, pemEncodedServerPrivKey, nil
 
 }

--- a/tests/integration/mondoo_installation_test.go
+++ b/tests/integration/mondoo_installation_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	webhooksv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mondoov1 "go.mondoo.com/mondoo-operator/api/v1alpha1"
@@ -123,7 +125,9 @@ func (s *MondooInstallationSuite) testMondooAuditConfig(auditConfig mondoov1.Mon
 	s.NoError(s.testCluster.K8sHelper.Clientset.Get(
 		s.ctx, client.ObjectKeyFromObject(&auditConfig), &auditConfig))
 
+	// Turn on node scanning; turn off workload scanning
 	auditConfig.Spec.Nodes.Enable = true
+	auditConfig.Spec.Workloads.Enable = false
 	s.NoErrorf(
 		s.testCluster.K8sHelper.Clientset.Update(s.ctx, &auditConfig),
 		"Failed to update Mondoo audit config.")
@@ -147,6 +151,123 @@ func (s *MondooInstallationSuite) testMondooAuditConfig(auditConfig mondoov1.Mon
 	s.Equalf(1, len(daemonSets.Items), "DaemonSets count in Mondoo namespace is incorrect.")
 	expectedDaemonSetName := fmt.Sprintf(mondoocontrollers.NodeDaemonSetNameTemplate, auditConfig.Name)
 	s.Equalf(expectedDaemonSetName, daemonSets.Items[0].Name, "DaemonSet name does not match expected name based from audit config name.")
+
+	zap.S().Info("Enable webhook.")
+
+	// Generate certificates manually
+	serviceDNSNames := []string{
+		// DNS names will take the form of ServiceName-ServiceNamespace.svc and .svc.cluster.local
+		fmt.Sprintf("%s-webhook-service.%s.svc", auditConfig.Name, auditConfig.Namespace),
+		fmt.Sprintf("%s-webhook-service.%s.svc.cluster.local", auditConfig.Name, auditConfig.Namespace),
+	}
+	caCert, serverCert, serverPrivKey := utils.GenerateWebhookCerts(s.Suite, serviceDNSNames)
+
+	// Save cert/key to the Secret name the Webhook Deployment will expect
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-server-cert",
+			Namespace: auditConfig.Namespace,
+		},
+		StringData: map[string]string{
+			"ca.crt":  caCert.String(),
+			"tls.crt": serverCert.String(),
+			"tls.key": serverPrivKey.String(),
+		},
+	}
+
+	s.NoError(s.testCluster.K8sHelper.Clientset.Create(s.ctx, secret))
+
+	// Disable imageResolution for the webhook image to be runnable.
+	// Otherwise, mondoo-operator will try to resolve the locally-built mondoo-operator container
+	// image, and fail because we haven't pushed this image publicly.
+	operatorConfig := &mondoov1.MondooOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mondoov1.MondooOperatorConfigName,
+		},
+	}
+	s.Require().NoError(
+		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(operatorConfig), operatorConfig),
+		"Failed to get existing MondooOperatorConfig")
+
+	operatorConfig.Spec.SkipContainerResolution = true
+	s.Require().NoError(s.testCluster.K8sHelper.Clientset.Update(s.ctx, operatorConfig),
+		"Failed to set SkipContainerResolution on MondooOperatorConfig for webhook test")
+
+	// Enable webhook
+	s.NoError(s.testCluster.K8sHelper.Clientset.Get(
+		s.ctx, client.ObjectKeyFromObject(&auditConfig), &auditConfig))
+
+	auditConfig.Spec.Nodes.Enable = false
+	auditConfig.Spec.Webhooks.Enable = true
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, &auditConfig),
+		"Failed to update MondooAuditConfig.")
+
+	// Wait for Ready Pod
+	webhookLabels := []string{mondoocontrollers.WebhookLabelKey + "=" + mondoocontrollers.WebhookLabelValue}
+	webhookLabelsString := strings.Join(webhookLabels, ",")
+	s.Truef(
+		s.testCluster.K8sHelper.IsPodReady(webhookLabelsString, auditConfig.Namespace),
+		"Mondoo webhook Pod is not in a Ready state.")
+
+	// Change the webhook from Ignore to Fail to prove that the webhook is active
+	vwc := &webhooksv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			// namespace-name-mondoo
+			Name: fmt.Sprintf("%s-%s-mondoo", auditConfig.Namespace, auditConfig.Name),
+		},
+	}
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(vwc), vwc),
+		"Failed to retrieve ValidatingWebhookConfiguration")
+
+	fail := webhooksv1.Fail
+	for i := range vwc.Webhooks {
+		vwc.Webhooks[i].FailurePolicy = &fail
+	}
+
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, vwc),
+		"Failed to change Webhook FailurePolicy to Fail")
+
+	// Try and fail to Update() a Deployment
+
+	listOpts, err = utils.LabelSelectorListOptions(webhookLabelsString)
+	s.NoError(err)
+	listOpts.Namespace = auditConfig.Namespace
+
+	deployments = &appsv1.DeploymentList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, deployments, listOpts))
+
+	s.Equalf(1, len(deployments.Items), "Deployments count for webhook should be precisely one")
+
+	deployments.Items[0].Labels["testLabel"] = "testValue"
+
+	s.Errorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, &deployments.Items[0]),
+		"Expected failed updated of Deployment because certificate setup is incomplete")
+
+	// Now put the CA data into the webhook
+	for i := range vwc.Webhooks {
+		vwc.Webhooks[i].ClientConfig.CABundle = caCert.Bytes()
+	}
+
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, vwc),
+		"Failed to add CA data to Webhook")
+
+	// Now the Deployment Update() should work
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, &deployments.Items[0]),
+		"Expected update of Deployment to succeed after CA data applied to webhook")
+
+	// Bring back the default image resolution behavior
+	operatorConfig.Spec.SkipContainerResolution = false
+
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Update(s.ctx, operatorConfig),
+		"Failed to restore container resolution in MondooOperatorConfig")
+
 }
 
 func TestMondooInstallationSuite(t *testing.T) {


### PR DESCRIPTION
Add some steps to test out the webhook functionality.

Manually create the certificates/Secret.
Enable the webhook.
Convert the webhook to a FailurePolicy of Fail (so that we can show the webhook is active and failing because we haven't completed the certificate configuration).
Attempt to modify a Deployment and expect it to fail (b/c Cert config not complete).
Add the CA data to the webhook.
Attempt to modify a Deployment and expect it to succeed.

closes #287 

Signed-off-by: Joel Diaz <joel@mondoo.com>