### PR TITLE
🧹 resist the urge to panic

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -53,7 +53,9 @@ func (s *Scanner) request(ctx context.Context, url string, reqBodyBytes []byte) 
 	header := make(http.Header)
 	header.Set("Accept", "application/json")
 	header.Set("Content-Type", "application/json")
-	header.Set("Authorization", "Bearer "+s.Token)
+	if s.Token != "" {
+		header.Set("Authorization", "Bearer "+s.Token)
+	}
 
 	reader := bytes.NewReader(reqBodyBytes)
 	req, err := http.NewRequest(http.MethodPost, url, reader)

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -96,9 +96,11 @@ func TestScanner(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
 
 	// check if the scan passed
-	passed := result.WorstScore.Type == 2 && result.WorstScore.Value == 100
-	assert.True(t, passed)
+	if assert.NotNil(t, result.WorstScore, "nil WorstScore") {
+		passed := result.WorstScore.Type == 2 && result.WorstScore.Value == 100
+		assert.True(t, passed)
+	}
 }


### PR DESCRIPTION
The healthcheck is allowed to be unauthenticated, so set the Bearer header only if a token was provided.

A failed RunKubernetesManifests call can result in nil fields in the result.WorstScore. Protect access into that structure around a nil assertion.

Signed-off-by: Joel Diaz <joel@mondoo.com>