### PR TITLE
🐛 Allow node scanning on rancher-provisioned controlplane and etcd nodes

### DIFF
--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -210,7 +210,7 @@ func (n *Nodes) daemonsetForMondoo() *appsv1.DaemonSet {
 							Value:  "true",
 						},
 						{
-							// Rancher controlplaen node
+							// Rancher controlplane node
 							// https://rancher.com/docs/rke/latest/en/config-options/nodes/#controlplane
 							Key:    "node-role.kubernetes.io/controlplane",
 							Effect: corev1.TaintEffectNoSchedule,

--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -197,10 +197,22 @@ func (n *Nodes) daemonsetForMondoo() *appsv1.DaemonSet {
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations: []corev1.Toleration{{
-						Key:    "node-role.kubernetes.io/master",
-						Effect: corev1.TaintEffect("NoSchedule"),
-					}},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:    "node-role.kubernetes.io/master",
+							Effect: corev1.TaintEffect("NoSchedule"),
+						},
+						{
+							Key:    "node-role.kubernetes.io/etcd",
+							Effect: corev1.TaintEffect("NoSchedule"),
+							Value:  "true",
+						},
+						{
+							Key:    "node-role.kubernetes.io/controlplane",
+							Effect: corev1.TaintEffect("NoSchedule"),
+							Value:  "true",
+						},
+					},
 					// The node scanning does not use the Kubernetes API at all, therefore the service account token
 					// should not be mounted at all.
 					AutomountServiceAccountToken: pointer.Bool(false),

--- a/controllers/nodes.go
+++ b/controllers/nodes.go
@@ -200,16 +200,20 @@ func (n *Nodes) daemonsetForMondoo() *appsv1.DaemonSet {
 					Tolerations: []corev1.Toleration{
 						{
 							Key:    "node-role.kubernetes.io/master",
-							Effect: corev1.TaintEffect("NoSchedule"),
+							Effect: corev1.TaintEffectNoSchedule,
 						},
 						{
+							// Rancher etcd node
+							// https://rancher.com/docs/rke/latest/en/config-options/nodes/#etcd
 							Key:    "node-role.kubernetes.io/etcd",
-							Effect: corev1.TaintEffect("NoSchedule"),
+							Effect: corev1.TaintEffectNoExecute,
 							Value:  "true",
 						},
 						{
+							// Rancher controlplaen node
+							// https://rancher.com/docs/rke/latest/en/config-options/nodes/#controlplane
 							Key:    "node-role.kubernetes.io/controlplane",
-							Effect: corev1.TaintEffect("NoSchedule"),
+							Effect: corev1.TaintEffectNoSchedule,
 							Value:  "true",
 						},
 					},


### PR DESCRIPTION
Closes #288 

I tested it manually to verify these changes are sufficient to fix the issue. It seems to be working!

Signed-off-by: Ivan Milchev <ivan@mondoo.com>