### PR TITLE
🐛 Fixed broken CI badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mondoo Operator for Kubernetes
 
-![CI](https://github.com/mondoohq/mondoo-operator/actions/workflows/e2e.yaml/badge.svg)
+![CI](https://github.com/mondoohq/mondoo-operator/actions/workflows/tests.yaml/badge.svg)
 ![License](https://img.shields.io/github/license/mondoohq/mondoo-operator)
 
 > **Project Status**: This project is currently in Early-Access. The API and CRD may change.


### PR DESCRIPTION
The CI badge in the readme is broken on `main`. That happened when migrating the tests to the new framework. I just noticed it so therefor this PR.

Signed-off-by: Ivan Milchev <ivan@mondoo.com>