### PR TITLE
set the docker build-arg during publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,10 @@ jobs:
       id-token: write
 
     steps:
+      - name: extract tag/version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo ${GITHUB_REF##refs/tags/})
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -79,6 +83,8 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          build_args: |
+            VERSION=${{ steps.get_version.outputs.VERSION }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Similar to how the Makefile sets the 'build-arg', set it during the docker buildx github workflow.

Signed-off-by: Joel Diaz <joel@mondoo.com>