### PR TITLE
e2e-olm: gather logs from all pods generically

### DIFF
--- a/.github/workflows/e2e-olm.yaml
+++ b/.github/workflows/e2e-olm.yaml
@@ -46,7 +46,7 @@ jobs:
           chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
       - name: Install olm
         run: |
-          trap 'echo "Saving OLM logs" ; kubectl get pods --namespace mondoo-operator -o yaml >> olm-logs.txt ; kubectl logs --namespace mondoo-operator deployment/mondoo-operator-controller-manager >> olm-logs.txt' EXIT
+          trap 'echo "Saving OLM logs" ; kubectl get pods --namespace mondoo-operator -o yaml >> olm-logs.txt ; kubectl get pods -o name -n mondoo-operator | xargs -I{} kubectl logs --namespace mondoo-operator --prefix {} >> olm-logs.txt' EXIT
           operator-sdk olm install
           kubectl create ns mondoo-operator
           operator-sdk run bundle '${{ inputs.bundle-img }}' --namespace mondoo-operator --timeout 5m0s


### PR DESCRIPTION
Since the mondoo-operator Deployment pod isn't coming up, we aren't getting useful pod logs.

Try gathering logs from all Pods in the mondoo-operator namespace if something failed.

Signed-off-by: Joel Diaz <joel@mondoo.com>