### PR TITLE
Adds mondooCredsSecretRef to MondooAuditConfig docs

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -99,9 +99,13 @@ Once the secret is configured, we configure the operator to define the scan targ
       name: mondoo-client
       namespace: mondoo-operator
     spec:
+      mondooCredsSecretRef:
+        name: mondoo-client
       kubernetesResources:
         enable: true
       nodes:
+        enable: true
+      admission:
         enable: true
     ```
 


### PR DESCRIPTION
Fixes the `MondooAuditConfig` reference in the docs to add  required `mondooCredsSecretRef`. 

Signed-off-by: Scott Ford <scott@scottford.io>