### PR TITLE
attempt an immediate CheckIn() after Register()

### DIFF
--- a/controllers/integration/integration_controller.go
+++ b/controllers/integration/integration_controller.go
@@ -132,28 +132,6 @@ func (r *IntegrationReconciler) processMondooAuditConfig(mondoo v1alpha2.MondooA
 		return err
 	}
 
-	// serviceAccount := &mondooclient.ServiceAccountCredentials{}
-	// if err := json.Unmarshal(mondooCreds.Data[constants.MondooCredsSecretServiceAccountKey], serviceAccount); err != nil {
-	// 	r.log.Error(err, "failed to unmarshal creds Secret")
-	// 	return err
-	// }
-	// token, err := r.generateTokenFromServiceAccount(serviceAccount)
-	// if err != nil {
-	// 	r.log.Error(err, "unable to generate token from service account")
-	// 	return err
-	// }
-	// mondooClient := r.mondooClientBuilder(mondooclient.ClientOptions{
-	// 	ApiEndpoint: serviceAccount.ApiEndpoint,
-	// 	Token:       token,
-	// })
-
-	// // Do the actual check-in
-	// if _, err := mondooClient.IntegrationCheckIn(r.ctx, &mondooclient.IntegrationCheckInInput{
-	// 	Mrn: string(integrationMrn),
-	// }); err != nil {
-	// 	r.log.Error(err, "failed to CheckIn() to Mondoo API")
-	// 	return err
-	// }
 	return nil
 }
 

--- a/controllers/integration/integration_controller_test.go
+++ b/controllers/integration/integration_controller_test.go
@@ -107,8 +107,8 @@ func (s *IntegrationCheckInSuite) TestCheckIn() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		log:                 testLogger,
-		mondooClientBuilder: testMondooClientBuilder,
+		Log:                 testLogger,
+		MondooClientBuilder: testMondooClientBuilder,
 	}
 
 	// Act
@@ -145,8 +145,8 @@ func (s *IntegrationCheckInSuite) TestMissingIntegrationMRN() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		log:                 testLogger,
-		mondooClientBuilder: testMondooClientBuilder,
+		Log:                 testLogger,
+		MondooClientBuilder: testMondooClientBuilder,
 	}
 
 	// Act
@@ -184,8 +184,8 @@ func (s *IntegrationCheckInSuite) TestBadServiceAccountData() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		log:                 testLogger,
-		mondooClientBuilder: testMondooClientBuilder,
+		Log:                 testLogger,
+		MondooClientBuilder: testMondooClientBuilder,
 	}
 
 	// Act
@@ -222,8 +222,8 @@ func (s *IntegrationCheckInSuite) TestFailedCheckIn() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		log:                 testLogger,
-		mondooClientBuilder: testMondooClientBuilder,
+		Log:                 testLogger,
+		MondooClientBuilder: testMondooClientBuilder,
 	}
 
 	// Act


### PR DESCRIPTION
When trading a token for a Mondoo service account, don't wait for the periodic integration controller to run and perform the first CheckIn(). Just make an attempt right after saving the Secret with the Mondoo service account.

Update test cases to expect the additional CheckIn() API call, and restructure the Integration controller to more easily allow perfoming a CheckIn() using only the Integration MRN and the Mondoo service account data.

Addresses #343 

Signed-off-by: Joel Diaz <joel@mondoo.com>