### PR TITLE
🐛 Set KUBERNETES_ADMISSION_CONTROLLER for scan API deployment

### DIFF
--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -118,6 +118,9 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 							{Name: "DEBUG", Value: "false"},
 							{Name: "MONDOO_PROCFS", Value: "on"},
 							{Name: "PORT", Value: fmt.Sprintf("%d", Port)},
+
+							// Required so the scan API knows it is running as a Kubernetes integration
+							{Name: "KUBERNETES_ADMISSION_CONTROLLER", Value: "true"},
 						},
 					}},
 					ServiceAccountName: m.Spec.Scanner.ServiceAccountName,


### PR DESCRIPTION
Required to make sure the scan API knows that it is running as a Kubernetes integration. The whole thing will start working only after a release of the Mondoo client with some changes from @vjeffrey 

Signed-off-by: Ivan Milchev <ivan@mondoo.com>