### PR TITLE
🐛 stop generating empty _.yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/... ./pkg/webhooks/..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen gomockgen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/pkg/utils/genericobjectdecoder/customobject.go
+++ b/pkg/utils/genericobjectdecoder/customobject.go
@@ -1,0 +1,12 @@
+package customobject
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CustomObjectMeta allows us to decode the raw k8s Object to unmarshal
+// the Type and Object fields we use to generate labels from.
+type CustomObjectMeta struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}

--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -14,6 +14,7 @@ import (
 
 	mondoov1alpha1 "go.mondoo.com/mondoo-operator/api/v1alpha1"
 	"go.mondoo.com/mondoo-operator/pkg/mondooclient"
+	customobject "go.mondoo.com/mondoo-operator/pkg/utils/genericobjectdecoder"
 	"go.mondoo.com/mondoo-operator/pkg/webhooks/utils"
 )
 
@@ -145,13 +146,6 @@ func (a *webhookValidator) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
-// customObjectMeta allows us to decode the raw k8s Object to unmarshal
-// the Type and Object fields we use to generate labels from.
-type customObjectMeta struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-}
-
 func generateLabelsFromAdmissionRequest(req admission.Request) (map[string]string, error) {
 
 	k8sObjectData, err := yaml.Marshal(req.Object)
@@ -161,7 +155,7 @@ func generateLabelsFromAdmissionRequest(req admission.Request) (map[string]strin
 	}
 
 	r := bytes.NewReader(k8sObjectData)
-	objMeta := &customObjectMeta{}
+	objMeta := &customobject.CustomObjectMeta{}
 
 	yamlDecoder := yamlutil.NewYAMLOrJSONDecoder(r, 4096)
 


### PR DESCRIPTION
The controller-gen tool was seeing our 'customObjectMeta` struct and processing it into this empty config/crd/bases/_.yaml file

Update the 'make manifests' target to only process ./api and ./pkg/webhooks. Move the 'customObjectMeta' struct out of that path.

Closes #311 

Signed-off-by: Joel Diaz <joel@mondoo.com>