### PR TITLE
🧹 recent Mondoo API requires the cluster-id label

### DIFF
--- a/pkg/mondooclient/scanner_test.go
+++ b/pkg/mondooclient/scanner_test.go
@@ -52,8 +52,9 @@ func TestScanner(t *testing.T) {
 			{},
 		},
 		Labels: map[string]string{
-			"k8s.mondoo.com/author":    request.UserInfo.Username,
-			"k8s.mondoo.com/operation": string(request.Operation),
+			"k8s.mondoo.com/author":     request.UserInfo.Username,
+			"k8s.mondoo.com/operation":  string(request.Operation),
+			"k8s.mondoo.com/cluster-id": "SOME-ID-HERE",
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
It is required for associating CI/CD assets. Update our test so that it can be used against a live Mondoo API.

Signed-off-by: Joel Diaz <joel@mondoo.com>