### PR TITLE
⭐ Define a matrix for testing all currently supported k8s versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -271,6 +271,11 @@ jobs:
     needs:
       - build-bundle
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        k8s-version: [v1.22.10, v1.23.7, v1.24.1]
+
     steps:
       - uses: actions/checkout@v2
       - name: Import environment variables from file
@@ -282,7 +287,8 @@ jobs:
       - name: Start minikube
         uses: medyagh/setup-minikube@master
         with:
-          memory: 4000m      
+          memory: 4000m
+          kubernetes-version: ${{ matrix.k8s-version }}
 
       - name: Install operator-sdk
         id: operator-sdk
@@ -358,6 +364,11 @@ jobs:
     needs:
       - push-virtual-tag
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        k8s-version: [v1.22.10, v1.23.7, v1.24.1]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -378,6 +389,7 @@ jobs:
         uses: medyagh/setup-minikube@master
         with:
           memory: 4000m
+          kubernetes-version: ${{ matrix.k8s-version }}
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,16 +87,17 @@ jobs:
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: unit-test-results
+      - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-version }}.xml
       - uses: actions/upload-artifact@v3  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:                             # upload a combined archive with unit and integration test results
           name: test-results
           path: |
             unit-tests.xml
-            integration-tests.xml
+            integration-tests-${{ matrix.k8s-version }}.xml
       - name: Upload test logs artifact
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: test-logs
+          name: test-logs-${{ matrix.k8s-version }}
           path: /home/runner/work/mondoo-operator/mondoo-operator/tests/integration/_output/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,11 @@ jobs:
     needs: [unit-tests]
     if: needs.unit-tests.result == 'success' # run only if unit-tests are successful
     name: Integration tests
+
+    strategy:
+      matrix:
+        k8s-version: [v1.22.10, v1.23.7, v1.24.1]
+
     steps:
       - uses: actions/checkout@v2
       - name: Import environment variables from file
@@ -59,6 +64,7 @@ jobs:
         uses: medyagh/setup-minikube@master
         with:
           memory: 4000m
+          kubernetes-version: ${{ matrix.k8s-version }}
       - uses: actions/setup-go@v2
         with:
           go-version: "${{ env.golang-version }}"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following Kubernetes environments are tested:
 - AWS EKS 1.21
 - Azure AKS 1.21
 - GCP GKE 1.22 and 1.23
-- Minikube
+- Minikube with Kubernetes versions 1.22, 1.23 and 1.24
 - Rancher RKE1 1.22 and 1.23
 - K3S
 


### PR DESCRIPTION
Specified a matrix strategy for the integration tests such that they are being ran against all currently supported k8s versions.

I intentionally did not add v1.21 as it is going to be in maintenance mode for another month and will be then dropped. I know that the tests will fail as the `CronJob` API there is not supported by our operator. That should be fine as in a month it is EOL. See [here](https://endoflife.date/kubernetes).

Signed-off-by: Ivan Milchev <ivan@mondoo.com>