### PR TITLE
🧹 Include missing ServiceAccount in MondooAuditConfig conditions

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -144,6 +144,8 @@ const (
 	K8sResourcesScanningDegraded MondooAuditConfigConditionType = "K8sResourcesScanningDegraded"
 	// Indicates weather Admission controller is Degraded
 	AdmissionDegraded MondooAuditConfigConditionType = "AdmissionDegraded"
+	// Indicates weather Admission controller is Degraded because of the ScanAPI
+	ScanAPIDegraded MondooAuditConfigConditionType = "ScanAPIDegraded"
 	// MondooIntegrationDegraded will hold the status for any issues encountered while trying to CheckIn()
 	// on behalf of the Mondoo integration MRN
 	MondooIntegrationDegraded MondooAuditConfigConditionType = "IntegrationDegraded"

--- a/controllers/admission/deployment_handler_test.go
+++ b/controllers/admission/deployment_handler_test.go
@@ -268,51 +268,6 @@ func TestReconcile(t *testing.T) {
 				assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, string(mondoov1alpha2.Permissive), "expected Webhook mode to be updated to 'permissive'")
 			},
 		},
-		/*
-			// SHOULD BE REMOVED WHEN WE AGREE ON INTEGRATION TESTS
-			{
-				name:                  "admission enabled with missing service account condition",
-				mondooAuditConfigSpec: testMondooAuditConfigSpec(true, false),
-				existingObjects: func(m mondoov1alpha2.MondooAuditConfig) []client.Object {
-					conditionMessage := "pods \"webhook-123\" is forbidden: " +
-						"error looking up service account mondoo-operator/missing-serviceaccount: " +
-						"serviceaccount \"missing-serviceaccount\" not found"
-					dep := &appsv1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      webhookDeploymentName(testMondooAuditConfigName),
-							Namespace: testNamespace,
-						},
-						Status: appsv1.DeploymentStatus{
-							Replicas:      1,
-							ReadyReplicas: 0,
-							Conditions: []appsv1.DeploymentCondition{
-								{
-									Message: conditionMessage,
-									Reason:  "FailedCreate",
-									Status:  corev1.ConditionStatus(appsv1.DeploymentReplicaFailure),
-									Type:    appsv1.DeploymentReplicaFailure,
-								},
-							},
-						},
-					}
-					return []client.Object{dep}
-				},
-				validate: func(t *testing.T, kubeClient client.Client) {
-					foundMondooConfig := &mondoov1alpha2.MondooAuditConfig{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      testMondooAuditConfigName,
-							Namespace: testNamespace,
-						},
-					}
-					err := kubeClient.Get(context.TODO(), client.ObjectKeyFromObject(foundMondooConfig), foundMondooConfig)
-					assert.NoError(t, err, "error retrieving Mondoo Config that should exist: %s", client.ObjectKeyFromObject(foundMondooConfig))
-
-					conditions := foundMondooConfig.Status.Conditions
-					assert.NotEmpty(t, conditions)
-					assert.Contains(t, conditions[0].Message, "error looking up service account")
-				},
-			},
-		*/
 		{
 			name:                  "update webhook Deployment when changed externally",
 			mondooAuditConfigSpec: testMondooAuditConfigSpec(true, false),

--- a/controllers/admission/deployment_handler_test.go
+++ b/controllers/admission/deployment_handler_test.go
@@ -268,6 +268,51 @@ func TestReconcile(t *testing.T) {
 				assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, string(mondoov1alpha2.Permissive), "expected Webhook mode to be updated to 'permissive'")
 			},
 		},
+		/*
+			// SHOULD BE REMOVED WHEN WE AGREE ON INTEGRATION TESTS
+			{
+				name:                  "admission enabled with missing service account condition",
+				mondooAuditConfigSpec: testMondooAuditConfigSpec(true, false),
+				existingObjects: func(m mondoov1alpha2.MondooAuditConfig) []client.Object {
+					conditionMessage := "pods \"webhook-123\" is forbidden: " +
+						"error looking up service account mondoo-operator/missing-serviceaccount: " +
+						"serviceaccount \"missing-serviceaccount\" not found"
+					dep := &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      webhookDeploymentName(testMondooAuditConfigName),
+							Namespace: testNamespace,
+						},
+						Status: appsv1.DeploymentStatus{
+							Replicas:      1,
+							ReadyReplicas: 0,
+							Conditions: []appsv1.DeploymentCondition{
+								{
+									Message: conditionMessage,
+									Reason:  "FailedCreate",
+									Status:  corev1.ConditionStatus(appsv1.DeploymentReplicaFailure),
+									Type:    appsv1.DeploymentReplicaFailure,
+								},
+							},
+						},
+					}
+					return []client.Object{dep}
+				},
+				validate: func(t *testing.T, kubeClient client.Client) {
+					foundMondooConfig := &mondoov1alpha2.MondooAuditConfig{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      testMondooAuditConfigName,
+							Namespace: testNamespace,
+						},
+					}
+					err := kubeClient.Get(context.TODO(), client.ObjectKeyFromObject(foundMondooConfig), foundMondooConfig)
+					assert.NoError(t, err, "error retrieving Mondoo Config that should exist: %s", client.ObjectKeyFromObject(foundMondooConfig))
+
+					conditions := foundMondooConfig.Status.Conditions
+					assert.NotEmpty(t, conditions)
+					assert.Contains(t, conditions[0].Message, "error looking up service account")
+				},
+			},
+		*/
 		{
 			name:                  "update webhook Deployment when changed externally",
 			mondooAuditConfigSpec: testMondooAuditConfigSpec(true, false),

--- a/controllers/scanapi/conditions.go
+++ b/controllers/scanapi/conditions.go
@@ -1,7 +1,6 @@
 package scanapi
 
 import (
-	"fmt"
 	"regexp"
 
 	mondoov1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
@@ -16,7 +15,6 @@ func updateScanAPIConditions(config *mondoov1alpha2.MondooAuditConfig, degradedS
 	status := corev1.ConditionFalse
 	updateCheck := mondoo.UpdateConditionIfReasonOrMessageChange
 	if degradedStatus {
-		fmt.Println("degraded state")
 		msg = "ScanAPI controller is unavailable"
 
 		// perhaps more general ReplicaFailure?

--- a/controllers/scanapi/conditions.go
+++ b/controllers/scanapi/conditions.go
@@ -1,0 +1,36 @@
+package scanapi
+
+import (
+	"fmt"
+	"regexp"
+
+	mondoov1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func updateScanAPIConditions(config *mondoov1alpha2.MondooAuditConfig, degradedStatus bool, conditions []appsv1.DeploymentCondition) {
+	msg := "ScanAPI controller is available"
+	reason := "ScanAPIAvailable"
+	status := corev1.ConditionFalse
+	updateCheck := mondoo.UpdateConditionIfReasonOrMessageChange
+	if degradedStatus {
+		fmt.Println("degraded state")
+		msg = "ScanAPI controller is unavailable"
+
+		// perhaps more general ReplicaFailure?
+		serviceAccountNotFound := regexp.MustCompile(`^.+serviceaccount ".+" not found$`)
+		for _, condition := range conditions {
+			if serviceAccountNotFound.MatchString(condition.Message) {
+				msg = condition.Message
+				break
+			}
+		}
+
+		reason = "ScanAPIUnvailable"
+		status = corev1.ConditionTrue
+	}
+
+	config.Status.Conditions = mondoo.SetMondooAuditCondition(config.Status.Conditions, mondoov1alpha2.ScanAPIDegraded, status, reason, msg, updateCheck)
+}

--- a/controllers/scanapi/deployment_handler_test.go
+++ b/controllers/scanapi/deployment_handler_test.go
@@ -2,6 +2,7 @@ package scanapi
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -126,8 +127,6 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_Admission() {
 	s.Equal(*service, ss.Items[0])
 }
 
-/*
-// SHOULD BE REMOVED WHEN WE AGREE ON INTEGRATION TESTS
 func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 	ns := "test-ns"
 	s.auditConfig = utils.DefaultAuditConfig(ns, false, false, true)
@@ -138,6 +137,7 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 	s.NoError(err)
 
 	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig)
+	deployment.Status.UnavailableReplicas = 1
 	deployment.Status.Conditions = []appsv1.DeploymentCondition{
 		{
 			Type:    appsv1.DeploymentConditionType(mondoov1alpha2.ScanAPIDegraded),
@@ -157,14 +157,7 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 	s.NoError(d.KubeClient.List(s.ctx, ds))
 	s.Equal(1, len(ds.Items))
 
-	foundMondooAuditConfig := &mondoov1alpha2.MondooAuditConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.auditConfig.Name,
-			Namespace: s.auditConfig.Namespace,
-		},
-	}
-	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(foundMondooAuditConfig), foundMondooAuditConfig), "Error getting MondooAuditConfig")
-	conditions := foundMondooAuditConfig.Status.Conditions
+	conditions := s.auditConfig.Status.Conditions
 	foundMissingServiceAccountCondition := false
 	s.Assertions.NotEmpty(conditions)
 	for _, condition := range conditions {
@@ -175,7 +168,6 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 	}
 	s.Assertions.Truef(foundMissingServiceAccountCondition, "No Condition for missing service account found")
 }
-*/
 
 func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	image, err := s.containerImageResolver.MondooClientImage(

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -273,3 +273,80 @@ func (s *AuditConfigBaseSuite) disableContainerImageResolution() func() {
 			"Failed to restore container resolution in MondooOperatorConfig")
 	}
 }
+
+func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConfig mondoov2.MondooAuditConfig) {
+	s.auditConfig = auditConfig
+	// Generate certificates manually
+	serviceDNSNames := []string{
+		// DNS names will take the form of ServiceName.ServiceNamespace.svc and .svc.cluster.local
+		fmt.Sprintf("%s-webhook-service.%s.svc", auditConfig.Name, auditConfig.Namespace),
+		fmt.Sprintf("%s-webhook-service.%s.svc.cluster.local", auditConfig.Name, auditConfig.Namespace),
+	}
+	secretName := mondooadmission.GetTLSCertificatesSecretName(auditConfig.Name)
+	_, err := s.testCluster.MondooInstaller.GenerateServiceCerts(&auditConfig, secretName, serviceDNSNames)
+
+	// Don't bother with further webhook tests if we couldnt' save the certificates
+	s.Require().NoErrorf(err, "Error while generating/saving certificates for webhook service")
+	// Disable imageResolution for the webhook image to be runnable.
+	// Otherwise, mondoo-operator will try to resolve the locally-built mondoo-operator container
+	// image, and fail because we haven't pushed this image publicly.
+	operatorConfig := &mondoov2.MondooOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mondoov2.MondooOperatorConfigName,
+		},
+		Spec: mondoov2.MondooOperatorConfigSpec{
+			SkipContainerResolution: true,
+		},
+	}
+	s.Require().NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, operatorConfig), "Failed to create MondooOperatorConfig")
+
+	// Enable webhook
+	zap.S().Info("Create an audit config that enables only admission control.")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	// Wait for Ready Pod
+	webhookLabels := []string{mondooadmission.WebhookLabelKey + "=" + mondooadmission.WebhookLabelValue}
+	webhookLabelsString := strings.Join(webhookLabels, ",")
+	s.Truef(
+		s.testCluster.K8sHelper.IsPodReady(webhookLabelsString, auditConfig.Namespace),
+		"Mondoo webhook Pod is not in a Ready state.")
+
+	// Pod should not start, because of missing service account
+	var scanApiLabels []string
+	for k, v := range mondooscanapi.DeploymentLabels(auditConfig) {
+		scanApiLabels = append(scanApiLabels, fmt.Sprintf("%s=%s", k, v))
+	}
+	scanApiLabelsString := strings.Join(scanApiLabels, ",")
+	s.Falsef(
+		s.testCluster.K8sHelper.IsPodReady(scanApiLabelsString, auditConfig.Namespace),
+		"Mondoo scan API Pod should not be in Ready state.")
+
+	// Try and fail to Update() a Deployment
+	listOpts, err := utils.LabelSelectorListOptions(scanApiLabelsString)
+	s.NoError(err)
+	listOpts.Namespace = auditConfig.Namespace
+
+	deployments := &appsv1.DeploymentList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, deployments, listOpts))
+
+	s.Equalf(1, len(deployments.Items), "Deployments count for ScanAPI should be precisely one")
+
+	// Condition of MondooAuditConfig should be updated
+	foundMondooAuditConfig := &mondoov2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      auditConfig.Name,
+			Namespace: auditConfig.Namespace,
+		},
+	}
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(foundMondooAuditConfig), foundMondooAuditConfig),
+		"Failed to retrieve MondooAuditConfig")
+
+	zap.S().Debug("MondooAuditConfig: ", foundMondooAuditConfig)
+
+	s.Assert().NotEmpty(foundMondooAuditConfig.Status.Conditions)
+	s.Assert().Contains(foundMondooAuditConfig.Status.Conditions[0].Message, "error looking up service account")
+}

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -324,7 +324,7 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConf
 		s.testCluster.K8sHelper.IsPodReady(scanApiLabelsString, auditConfig.Namespace),
 		"Mondoo scan API Pod should not be in Ready state.")
 
-	// Try and fail to Update() a Deployment
+	// Check for the ScanAPI Deployment to be present.
 	listOpts, err := utils.LabelSelectorListOptions(scanApiLabelsString)
 	s.NoError(err)
 	listOpts.Namespace = auditConfig.Namespace
@@ -344,8 +344,6 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConf
 	s.NoErrorf(
 		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(foundMondooAuditConfig), foundMondooAuditConfig),
 		"Failed to retrieve MondooAuditConfig")
-
-	zap.S().Debug("MondooAuditConfig: ", foundMondooAuditConfig)
 
 	s.Assert().NotEmpty(foundMondooAuditConfig.Status.Conditions)
 	s.Assert().Contains(foundMondooAuditConfig.Status.Conditions[0].Message, "error looking up service account")

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -86,7 +86,7 @@ func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Admission() {
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
-func (s *AuditConfigCustomNamespaceSuite) TestReconcile_00_AdmissionMissingSA() {
+func (s *AuditConfigCustomNamespaceSuite) TestReconcile_AdmissionMissingSA() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true)
 	auditConfig.Spec.Scanner.ServiceAccountName = "missing-serviceaccount"
 	s.testMondooAuditConfigAdmissionMissingSA(auditConfig)

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -86,6 +86,12 @@ func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Admission() {
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
+func (s *AuditConfigCustomNamespaceSuite) TestReconcile_00_AdmissionMissingSA() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true)
+	auditConfig.Spec.Scanner.ServiceAccountName = "missing-serviceaccount"
+	s.testMondooAuditConfigAdmissionMissingSA(auditConfig)
+}
+
 func TestAuditConfigCustomNamespaceSuite(t *testing.T) {
 	s := new(AuditConfigCustomNamespaceSuite)
 	defer func(s *AuditConfigCustomNamespaceSuite) {


### PR DESCRIPTION
In case the Service Account needed by the ScanAPI is missing, a condition will be added to the MondooAuditConfig.
This might be the case, when a MondooAuditConfig is created in a custom namespace.
We only create ServiceAccounts in the mondoo-operator namespace.

Fixes https://github.com/mondoohq/mondoo-operator/issues/382