### PR TITLE
🐛 Make sure Deployments and CronJobs are updated when resource requests/limits change

### DIFF
--- a/pkg/utils/k8s/equality.go
+++ b/pkg/utils/k8s/equality.go
@@ -36,6 +36,7 @@ func AreDeploymentsEqual(a, b appsv1.Deployment) bool {
 		reflect.DeepEqual(a.Spec.Template.Spec.Containers[0].Args, b.Spec.Template.Spec.Containers[0].Args) &&
 		reflect.DeepEqual(a.Spec.Template.Spec.Containers[0].VolumeMounts, b.Spec.Template.Spec.Containers[0].VolumeMounts) &&
 		reflect.DeepEqual(a.Spec.Template.Spec.Containers[0].Env, b.Spec.Template.Spec.Containers[0].Env) &&
+		AreResouceRequirementsEqual(a.Spec.Template.Spec.Containers[0].Resources, b.Spec.Template.Spec.Containers[0].Resources) &&
 		reflect.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) &&
 		reflect.DeepEqual(a.GetOwnerReferences(), b.GetOwnerReferences())
 }
@@ -64,6 +65,7 @@ func AreCronJobsEqual(a, b batchv1.CronJob) bool {
 		reflect.DeepEqual(aPodSpec.Containers[0].Args, bPodSpec.Containers[0].Args) &&
 		reflect.DeepEqual(aPodSpec.Containers[0].VolumeMounts, bPodSpec.Containers[0].VolumeMounts) &&
 		reflect.DeepEqual(aPodSpec.Containers[0].Env, bPodSpec.Containers[0].Env) &&
+		AreResouceRequirementsEqual(aPodSpec.Containers[0].Resources, bPodSpec.Containers[0].Resources) &&
 		reflect.DeepEqual(aPodSpec.Volumes, bPodSpec.Volumes) &&
 		reflect.DeepEqual(a.Spec.SuccessfulJobsHistoryLimit, b.Spec.SuccessfulJobsHistoryLimit) &&
 		reflect.DeepEqual(a.Spec.FailedJobsHistoryLimit, b.Spec.FailedJobsHistoryLimit) &&

--- a/pkg/utils/k8s/equality_test.go
+++ b/pkg/utils/k8s/equality_test.go
@@ -209,6 +209,15 @@ func TestAreDeploymentsEqual(t *testing.T) {
 			shouldBeEqual: false,
 		},
 		{
+			name: "should not be equal when container resource requirements differ",
+			createB: func(a appsv1.Deployment) appsv1.Deployment {
+				b := *a.DeepCopy()
+				b.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("233m")
+				return b
+			},
+			shouldBeEqual: false,
+		},
+		{
 			name: "should not be equal when owner references differ",
 			createB: func(a appsv1.Deployment) appsv1.Deployment {
 				b := *a.DeepCopy()
@@ -501,6 +510,15 @@ func TestAreCronJobsEqual(t *testing.T) {
 			createB: func(a batchv1.CronJob) batchv1.CronJob {
 				b := *a.DeepCopy()
 				b.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env = make([]corev1.EnvVar, 0)
+				return b
+			},
+			shouldBeEqual: false,
+		},
+		{
+			name: "should not be equal when container resource requirements differ",
+			createB: func(a batchv1.CronJob) batchv1.CronJob {
+				b := *a.DeepCopy()
+				b.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("233m")
 				return b
 			},
 			shouldBeEqual: false,


### PR DESCRIPTION
I noticed that the operator doesn't compare the resource requests/limits for Deployments and CronJobs, so they never get updated. This PR fixes the issue

Signed-off-by: Ivan Milchev <ivan@mondoo.com>