### PR TITLE
🐛 Fix typo in `MondooOperatorConfig`

### DIFF
--- a/docs/deployment-configurations.md
+++ b/docs/deployment-configurations.md
@@ -19,7 +19,7 @@ To enable metrics reporting via Prometheus and to disable the translation of con
 
 ```yaml
 apiVersion: k8s.mondoo.com/v1alpha2
-Kind: MondooOperatorConfig
+kind: MondooOperatorConfig
 metadata:
   name: mondoo-operator-config
 spec:


### PR DESCRIPTION
This config couldn't be applied with `Kind`.

Fixes #389

Signed-off-by: Christian Zunker <christian@mondoo.com>