### PR TITLE
🧹 Add operator version to status of `MondooAuditConfig`

### DIFF
--- a/.github/workflows/validate-actions.yaml
+++ b/.github/workflows/validate-actions.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           go-version: "${{ env.golang-version }}"
       - run: |
-          curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+          curl -O https://raw.githubusercontent.com/nektos/act/master/install.sh
+          sudo bash -c ./install.sh v0.2.26
           export PATH=$PATH:./bin
           make test/github-actions

--- a/.github/workflows/validate-actions.yaml
+++ b/.github/workflows/validate-actions.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: "${{ env.golang-version }}"
       - run: |
-          curl -O https://github.com/nektos/act/releases/download/v0.2.26/act_Linux_x86_64.tar.gz
+          curl -OLs https://github.com/nektos/act/releases/download/v0.2.26/act_Linux_x86_64.tar.gz
           tar xzf act_Linux_x86_64.tar.gz
           mkdir ./bin
           cp act ./bin

--- a/.github/workflows/validate-actions.yaml
+++ b/.github/workflows/validate-actions.yaml
@@ -18,7 +18,9 @@ jobs:
         with:
           go-version: "${{ env.golang-version }}"
       - run: |
-          curl -O https://raw.githubusercontent.com/nektos/act/master/install.sh
-          sudo bash -c ./install.sh v0.2.26
+          curl -O https://github.com/nektos/act/releases/download/v0.2.26/act_Linux_x86_64.tar.gz
+          tar xzf act_Linux_x86_64.tar.gz
+          mkdir ./bin
+          cp act ./bin
           export PATH=$PATH:./bin
           make test/github-actions

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test/integration: manifests generate generate-manifests load-minikube
 	go test -ldflags $(LDFLAGS) -v -timeout 900s -p 1 ./tests/integration/...
 
 test/integration/ci: manifests generate generate-manifests load-minikube gotestsum
-	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -v -timeout 900s -p 1
+	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -ldflags $(LDFLAGS) -v -timeout 900s -p 1
 
 ##@ Build
 

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -113,6 +113,9 @@ type MondooAuditConfigStatus struct {
 
 	// Conditions includes detailed status for the MondooAuditConfig
 	Conditions []MondooAuditConfigCondition `json:"conditions,omitempty"`
+
+	// ReconciledByOperatorVersion contains the version of the operator which reconciled this MondooAuditConfig
+	ReconciledByOperatorVersion string `json:"reconciledByOperatorVersion,omitempty"`
 }
 
 type MondooAuditConfigCondition struct {

--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -22,6 +22,7 @@ import (
 	k8sv1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers"
 	"go.mondoo.com/mondoo-operator/controllers/integration"
+	"go.mondoo.com/mondoo-operator/pkg/health"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	"go.mondoo.com/mondoo-operator/pkg/version"
 	//+kubebuilder:scaffold:imports
@@ -100,9 +101,11 @@ func init() {
 			return err
 		}
 
-		// TODO: add a ready check that verifies whether all CRD statuses state they are upgraded to
-		// the current version of the operator
-		if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		reconcileCheck := &health.HealthChecks{
+			Client: mgr.GetClient(),
+			Log:    setupLog,
+		}
+		if err := mgr.AddReadyzCheck("readyz", reconcileCheck.CheckMondooAuditConfigsForOperatorVersion); err != nil {
 			setupLog.Error(err, "unable to set up ready check")
 			return err
 		}

--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -105,7 +105,7 @@ func init() {
 			Client: mgr.GetClient(),
 			Log:    setupLog,
 		}
-		if err := mgr.AddReadyzCheck("readyz", reconcileCheck.CheckMondooAuditConfigsForOperatorVersion); err != nil {
+		if err := mgr.AddReadyzCheck("readyz", reconcileCheck.AreAllMondooAuditConfigsReconciled); err != nil {
 			setupLog.Error(err, "unable to set up ready check")
 			return err
 		}

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -193,6 +193,10 @@ spec:
                 items:
                   type: string
                 type: array
+              reconciledByOperatorVersion:
+                description: ReconciledByOperatorVersion contains the version of the
+                  operator which reconciled this MondooAuditConfig
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -271,11 +271,6 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Update status.ReconciledByOperatorVersion to the running operator version
 	if mondooAuditConfig.Status.ReconciledByOperatorVersion != version.Version {
 		mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
-		err := r.Status().Update(ctx, mondooAuditConfig)
-		if err != nil {
-			log.Error(err, "Failed to update mondoo status")
-			return ctrl.Result{}, err
-		}
 	}
 
 	if err := mondoo.UpdateMondooAuditStatus(ctx, r.Client, mondooAuditConfigCopy, mondooAuditConfig, log); err != nil {

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -54,6 +54,7 @@ import (
 	"go.mondoo.com/mondoo-operator/pkg/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+	"go.mondoo.com/mondoo-operator/pkg/version"
 )
 
 const finalizerString = "k8s.mondoo.com/delete"
@@ -64,6 +65,7 @@ type MondooAuditConfigReconciler struct {
 	Scheme                 *runtime.Scheme
 	MondooClientBuilder    func(mondooclient.ClientOptions) mondooclient.Client
 	ContainerImageResolver mondoo.ContainerImageResolver
+	MondooAuditConfig      *v1alpha2.MondooAuditConfig
 }
 
 // Embed the Default Inventory for CronJob and Deployment Configurations
@@ -108,6 +110,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	mondooAuditConfig := &v1alpha2.MondooAuditConfig{}
 
 	err := r.Get(ctx, req.NamespacedName, mondooAuditConfig)
+	r.MondooAuditConfig = mondooAuditConfig
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -258,6 +261,16 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if !statusPodNames.Equal(podListNames) {
 		mondooAuditConfig.Status.Pods = podListNames.List()
+		err := r.Status().Update(ctx, mondooAuditConfig)
+		if err != nil {
+			log.Error(err, "Failed to update mondoo status")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Update status.ReconciledByOperatorVersion to the running operator version
+	if mondooAuditConfig.Status.ReconciledByOperatorVersion != version.Version {
+		mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
 		err := r.Status().Update(ctx, mondooAuditConfig)
 		if err != nil {
 			log.Error(err, "Failed to update mondoo status")

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,40 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HealthChecks struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+func (h *HealthChecks) CheckMondooAuditConfigsForOperatorVersion(req *http.Request) error {
+	ctx := context.TODO()
+	mondooAuditConfigs := &v1alpha2.MondooAuditConfigList{}
+	if err := h.Client.List(ctx, mondooAuditConfigs); err != nil {
+		h.Log.Error(err, "error listing MondooAuditConfigs")
+		return err
+	}
+
+	for _, mac := range mondooAuditConfigs.Items {
+		if mac.Status.ReconciledByOperatorVersion != version.Version {
+			errorMsg := fmt.Sprintf("MondooAuditConfig not yet completly reconciled: namespace=%s MondooAuditConfig=%s", mac.Namespace, mac.Name)
+			h.Log.Info(errorMsg)
+			return errors.New(errorMsg)
+		} else {
+			infoMsg := fmt.Sprintf("MondooAuditconfig reconciled: namespace=%s MondooAuditConfig=%s", mac.Namespace, mac.Name)
+			h.Log.Info(infoMsg)
+		}
+	}
+
+	return nil
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,140 @@
+package health
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/version"
+)
+
+const (
+	mondooNamespace = "mondoo-operator"
+	otherNamespace  = "some-namespace"
+)
+
+var (
+	testLogger logr.Logger
+)
+
+type IntegrationCheckInSuite struct {
+	suite.Suite
+}
+
+func TestMondooIntegrationCheckInSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationCheckInSuite))
+}
+
+func (s *IntegrationCheckInSuite) SetupSuite() {
+	utilruntime.Must(v1alpha2.AddToScheme(clientgoscheme.Scheme))
+
+	// Setup logging
+	var err error
+	cfg := zap.NewDevelopmentConfig()
+
+	cfg.InitialFields = map[string]interface{}{
+		"controller": "integration-test",
+	}
+
+	zapLog, err := cfg.Build()
+	s.Require().NoError(err, "failed to set up logging for test cases")
+
+	testLogger = zapr.NewLogger(zapLog)
+
+}
+
+func (s *IntegrationCheckInSuite) TestReconciledMondooAuditConfig() {
+	// Arrange
+	mondooAuditConfig := createReconciledMondooAuditConfig(mondooNamespace)
+
+	existingObjects := []runtime.Object{
+		mondooAuditConfig,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).Build()
+
+	hc := &HealthChecks{
+		Client: fakeClient,
+		Log:    testLogger,
+	}
+
+	// Act
+	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+
+	// Assert
+	s.NoError(err, "should not error while processing reconciled MondooAuditConfig")
+}
+
+func (s *IntegrationCheckInSuite) TestReconciledMondooAuditConfigs() {
+	// Arrange
+	mondooAuditConfig := createReconciledMondooAuditConfig(mondooNamespace)
+	mondooAuditConfigOtherNamespace := createReconciledMondooAuditConfig(otherNamespace)
+
+	existingObjects := []runtime.Object{
+		mondooAuditConfig,
+		mondooAuditConfigOtherNamespace,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).Build()
+
+	hc := &HealthChecks{
+		Client: fakeClient,
+		Log:    testLogger,
+	}
+
+	// Act
+	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+
+	// Assert
+	s.NoError(err, "should not error while processing reconciled MondooAuditConfigs across namespaces")
+}
+
+func (s *IntegrationCheckInSuite) TestUnfinishedMondooAuditConfig() {
+	// Arrange
+	mondooAuditConfig := createReconciledMondooAuditConfig(mondooNamespace)
+	unreconciledMACOtherNamespace := createMondooAuditConfig(otherNamespace)
+
+	existingObjects := []runtime.Object{
+		mondooAuditConfig,
+		unreconciledMACOtherNamespace,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).Build()
+
+	hc := &HealthChecks{
+		Client: fakeClient,
+		Log:    testLogger,
+	}
+
+	// Act
+	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+
+	// Assert
+	s.Error(err, "should error while processing not yet reconciled MondooAuditConfig")
+}
+
+func createMondooAuditConfig(namespace string) *v1alpha2.MondooAuditConfig {
+	return &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mondoo-config",
+			Namespace: namespace,
+		},
+	}
+}
+
+func createReconciledMondooAuditConfig(namespace string) *v1alpha2.MondooAuditConfig {
+	mondooAuditConfig := createMondooAuditConfig(namespace)
+	mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
+	return mondooAuditConfig
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -70,7 +70,7 @@ func (s *IntegrationCheckInSuite) TestReconciledMondooAuditConfig() {
 	}
 
 	// Act
-	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+	err := hc.AreAllMondooAuditConfigsReconciled(&http.Request{})
 
 	// Assert
 	s.NoError(err, "should not error while processing reconciled MondooAuditConfig")
@@ -94,7 +94,7 @@ func (s *IntegrationCheckInSuite) TestReconciledMondooAuditConfigs() {
 	}
 
 	// Act
-	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+	err := hc.AreAllMondooAuditConfigsReconciled(&http.Request{})
 
 	// Assert
 	s.NoError(err, "should not error while processing reconciled MondooAuditConfigs across namespaces")
@@ -118,7 +118,7 @@ func (s *IntegrationCheckInSuite) TestUnfinishedMondooAuditConfig() {
 	}
 
 	// Act
-	err := hc.CheckMondooAuditConfigsForOperatorVersion(&http.Request{})
+	err := hc.AreAllMondooAuditConfigsReconciled(&http.Request{})
 
 	// Assert
 	s.Error(err, "should error while processing not yet reconciled MondooAuditConfig")

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -439,7 +439,7 @@ func (k8sh *K8sHelper) GetMondooAuditConfigConditionByType(auditConfig *api.Mond
 		}
 	}
 
-	return api.MondooAuditConfigCondition{}, fmt.Errorf("couldn't find condition of type %v", conditionType)
+	return searchedForCondition, fmt.Errorf("couldn't find condition of type %v", conditionType)
 }
 
 // CheckForDegradedCondition Check whether specified Condition is in degraded state in a MondooAuditConfig with retries.

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -301,6 +301,32 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConf
 	s.Assert().NoErrorf(err, "Couldn't find condition message about missing service account")
 }
 
+func (s *AuditConfigBaseSuite) testMondooAuditConfigEmpty(auditConfig mondoov2.MondooAuditConfig) {
+	s.auditConfig = auditConfig
+	// Disable imageResolution for the webhook image to be runnable.
+	// Otherwise, mondoo-operator will try to resolve the locally-built mondoo-operator container
+	// image, and fail because we haven't pushed this image publicly.
+	operatorConfig := &mondoov2.MondooOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mondoov2.MondooOperatorConfigName,
+		},
+		Spec: mondoov2.MondooOperatorConfigSpec{
+			SkipContainerResolution: true,
+		},
+	}
+	s.Require().NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, operatorConfig), "Failed to create MondooOperatorConfig")
+
+	// Enable nothing
+	zap.S().Info("Create an audit config that enables nothing.")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	err := s.checkForReconciledOperatorVersion()
+	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+}
+
 func (s *AuditConfigBaseSuite) validateScanApiDeployment(auditConfig mondoov2.MondooAuditConfig) {
 	scanApiLabelsString := utils.LabelsToLabelSelector(mondooscanapi.DeploymentLabels(auditConfig))
 	s.Truef(
@@ -410,32 +436,6 @@ func (s *AuditConfigBaseSuite) checkForPodInStatus(podName string) error {
 	return err
 }
 
-func (s *AuditConfigBaseSuite) testMondooAuditConfigEmpty(auditConfig mondoov2.MondooAuditConfig) {
-	s.auditConfig = auditConfig
-	// Disable imageResolution for the webhook image to be runnable.
-	// Otherwise, mondoo-operator will try to resolve the locally-built mondoo-operator container
-	// image, and fail because we haven't pushed this image publicly.
-	operatorConfig := &mondoov2.MondooOperatorConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: mondoov2.MondooOperatorConfigName,
-		},
-		Spec: mondoov2.MondooOperatorConfigSpec{
-			SkipContainerResolution: true,
-		},
-	}
-	s.Require().NoErrorf(
-		s.testCluster.K8sHelper.Clientset.Create(s.ctx, operatorConfig), "Failed to create MondooOperatorConfig")
-
-	// Enable nothing
-	zap.S().Info("Create an audit config that enables nothing.")
-	s.NoErrorf(
-		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
-		"Failed to create Mondoo audit config.")
-
-	err := s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
-}
-
 // checkForReconciledOperatorVersion Check whether the MondooAuditConfig Status contains the current operator Version after Reconcile.
 func (s *AuditConfigBaseSuite) checkForReconciledOperatorVersion() error {
 	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
@@ -449,19 +449,4 @@ func (s *AuditConfigBaseSuite) checkForReconciledOperatorVersion() error {
 	})
 
 	return err
-}
-
-// getMondooAuditConfigFromCluster Fetches current MondooAuditConfig from Cluster
-func (s *AuditConfigBaseSuite) getMondooAuditConfigFromCluster() *mondoov2.MondooAuditConfig {
-	foundMondooAuditConfig := &mondoov2.MondooAuditConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.auditConfig.Name,
-			Namespace: s.auditConfig.Namespace,
-		},
-	}
-	s.NoErrorf(
-		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(foundMondooAuditConfig), foundMondooAuditConfig),
-		"Failed to retrieve MondooAuditConfig")
-
-	return foundMondooAuditConfig
 }

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -23,7 +23,6 @@ import (
 	"go.mondoo.com/mondoo-operator/controllers/nodes"
 	mondooscanapi "go.mondoo.com/mondoo-operator/controllers/scanapi"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
-	"go.mondoo.com/mondoo-operator/pkg/version"
 	"go.mondoo.com/mondoo-operator/tests/framework/installer"
 	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,11 +92,11 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigKubernetesResources(auditCon
 		s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(utils.LabelsToLabelSelector(cronJobLabels), auditConfig.Namespace),
 		"Kubernetes resources scan CronJob did not run successfully.")
 
-	err = s.checkForPodInStatus("client-k8s-scan")
-	s.Assert().NoErrorf(err, "Couldn't find KubernetesResourceScan in Podlist of the MondooAuditConfig Status")
+	err = s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-k8s-scan")
+	s.NoErrorf(err, "Couldn't find KubernetesResourceScan in Podlist of the MondooAuditConfig Status")
 
-	err = s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.MondooAuditConfig) {
@@ -147,12 +146,12 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.M
 	s.True(s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(selector, auditConfig.Namespace), "Not all CronJobs have run successfully.")
 
 	for _, node := range nodes.Items {
-		err := s.checkForPodInStatus("client-node-" + node.Name)
-		s.Assert().NoErrorf(err, "Couldn't find NodeScan Pod for node "+node.Name+" in Podlist of the MondooAuditConfig Status")
+		err := s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-node-"+node.Name)
+		s.NoErrorf(err, "Couldn't find NodeScan Pod for node "+node.Name+" in Podlist of the MondooAuditConfig Status")
 	}
 
-	err = s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmission(auditConfig mondoov2.MondooAuditConfig) {
@@ -248,11 +247,11 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmission(auditConfig mondoo
 		s.testCluster.K8sHelper.Clientset.Update(s.ctx, &deployments.Items[0]),
 		"Expected update of Deployment to succeed after CA data applied to webhook")
 
-	err = s.checkForDegradedCondition(mondoov2.AdmissionDegraded)
-	s.Assert().NoErrorf(err, "Admission shouldn't be in degraded state")
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.AdmissionDegraded)
+	s.NoErrorf(err, "Admission shouldn't be in degraded state")
 
-	err = s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConfig mondoov2.MondooAuditConfig) {
@@ -299,19 +298,25 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionMissingSA(auditConf
 
 	err = s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
 		// Condition of MondooAuditConfig should be updated
-		foundMondooAuditConfig := s.getMondooAuditConfigFromCluster()
-		condition := s.getMondooAuditConfigConditionByType(foundMondooAuditConfig, mondoov2.ScanAPIDegraded)
+		foundMondooAuditConfig, err := s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+		if err != nil {
+			return false, err
+		}
+		condition, err := s.testCluster.K8sHelper.GetMondooAuditConfigConditionByType(foundMondooAuditConfig, mondoov2.ScanAPIDegraded)
+		if err != nil {
+			return false, err
+		}
 		if strings.Contains(condition.Message, "error looking up service account") {
 			return true, nil
 		}
 		return false, nil
 	})
 
-	s.Assert().NoErrorf(err, "Couldn't find condition message about missing service account")
+	s.NoErrorf(err, "Couldn't find condition message about missing service account")
 
 	// The SA is missing, but the actual reconcile loop gets finished. The SA is outside of the operators scope.
-	err = s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAllDisabled(auditConfig mondoov2.MondooAuditConfig) {
@@ -336,8 +341,8 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigAllDisabled(auditConfig mond
 		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &s.auditConfig),
 		"Failed to create Mondoo audit config.")
 
-	err := s.checkForReconciledOperatorVersion()
-	s.Assert().NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+	err := s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&s.auditConfig)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 }
 
 func (s *AuditConfigBaseSuite) validateScanApiDeployment(auditConfig mondoov2.MondooAuditConfig) {
@@ -355,11 +360,11 @@ func (s *AuditConfigBaseSuite) validateScanApiDeployment(auditConfig mondoov2.Mo
 	s.NoError(ctrl.SetControllerReference(&auditConfig, expectedService, s.testCluster.K8sHelper.Clientset.Scheme()))
 	s.Truef(k8s.AreServicesEqual(*expectedService, *scanApiService), "Scan API service is not as expected.")
 
-	err := s.checkForDegradedCondition(mondoov2.ScanAPIDegraded)
-	s.Assert().NoErrorf(err, "ScanAPI shouldn't be in degraded state")
+	err := s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.ScanAPIDegraded)
+	s.NoErrorf(err, "ScanAPI shouldn't be in degraded state")
 
-	err = s.checkForPodInStatus("client-scan-api")
-	s.Assert().NoErrorf(err, "Couldn't find ScanAPI in Podlist of the MondooAuditConfig Status")
+	err = s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-scan-api")
+	s.NoErrorf(err, "Couldn't find ScanAPI in Podlist of the MondooAuditConfig Status")
 }
 
 // disableContainerImageResolution Creates a MondooOperatorConfig that disables container image resolution. This is needed
@@ -384,82 +389,4 @@ func (s *AuditConfigBaseSuite) disableContainerImageResolution() func() {
 			s.testCluster.K8sHelper.Clientset.Delete(s.ctx, operatorConfig),
 			"Failed to restore container resolution in MondooOperatorConfig")
 	}
-}
-
-// getMondooAuditConfigFromCluster Fetches current MondooAuditConfig from Cluster
-func (s *AuditConfigBaseSuite) getMondooAuditConfigFromCluster() *mondoov2.MondooAuditConfig {
-	foundMondooAuditConfig := &mondoov2.MondooAuditConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.auditConfig.Name,
-			Namespace: s.auditConfig.Namespace,
-		},
-	}
-	s.NoErrorf(
-		s.testCluster.K8sHelper.Clientset.Get(s.ctx, client.ObjectKeyFromObject(foundMondooAuditConfig), foundMondooAuditConfig),
-		"Failed to retrieve MondooAuditConfig")
-
-	return foundMondooAuditConfig
-}
-
-// getMondooAuditConfigConditionByType Fetches Condition from MondooAuditConfig Status for the specified Type.
-func (s *AuditConfigBaseSuite) getMondooAuditConfigConditionByType(auditConfig *mondoov2.MondooAuditConfig, conditionType mondoov2.MondooAuditConfigConditionType) mondoov2.MondooAuditConfigCondition {
-	conditions := auditConfig.Status.Conditions
-	s.Assert().NotEmpty(conditions)
-	searchedForCondition := mondoov2.MondooAuditConfigCondition{}
-	for _, condition := range conditions {
-		if condition.Type == conditionType {
-			searchedForCondition = condition
-			break
-		}
-	}
-	errorMsg := fmt.Sprintf("Couldn't find condition of type %v", conditionType)
-	s.Assert().NotEmptyf(searchedForCondition, errorMsg)
-
-	return searchedForCondition
-}
-
-// checkForDegradedCondition Check whether specified Condition is in degraded state in a MondooAuditConfig with retries.
-func (s *AuditConfigBaseSuite) checkForDegradedCondition(conditionType mondoov2.MondooAuditConfigConditionType) error {
-	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
-		// Condition of MondooAuditConfig should be updated
-		foundMondooAuditConfig := s.getMondooAuditConfigFromCluster()
-		condition := s.getMondooAuditConfigConditionByType(foundMondooAuditConfig, conditionType)
-		if condition.Status == corev1.ConditionFalse {
-			return true, nil
-		}
-		return false, nil
-	})
-
-	return err
-}
-
-//checkForPodInStatus Check whether a give PodName is an element of the PodList saved in the Status part of MondooAuditConfig
-func (s *AuditConfigBaseSuite) checkForPodInStatus(podName string) error {
-	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
-		// Condition of MondooAuditConfig should be updated
-		foundMondooAuditConfig := s.getMondooAuditConfigFromCluster()
-		for _, currentPodName := range foundMondooAuditConfig.Status.Pods {
-			if strings.Contains(currentPodName, podName) {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-
-	return err
-}
-
-// checkForReconciledOperatorVersion Check whether the MondooAuditConfig Status contains the current operator Version after Reconcile.
-func (s *AuditConfigBaseSuite) checkForReconciledOperatorVersion() error {
-	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
-		// Condition of MondooAuditConfig should be updated
-		foundMondooAuditConfig := s.getMondooAuditConfigFromCluster()
-		reconciledVersion := foundMondooAuditConfig.Status.ReconciledByOperatorVersion
-		if reconciledVersion == version.Version {
-			return true, nil
-		}
-		return false, nil
-	})
-
-	return err
 }

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -13,6 +13,11 @@ type AuditConfigSuite struct {
 	AuditConfigBaseSuite
 }
 
+func (s *AuditConfigSuite) TestReconcile_Empty() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false)
+	s.testMondooAuditConfigEmpty(auditConfig)
+}
+
 func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false)
 	s.testMondooAuditConfigKubernetesResources(auditConfig)

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -13,9 +13,9 @@ type AuditConfigSuite struct {
 	AuditConfigBaseSuite
 }
 
-func (s *AuditConfigSuite) TestReconcile_Empty() {
+func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false)
-	s.testMondooAuditConfigEmpty(auditConfig)
+	s.testMondooAuditConfigAllDisabled(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {


### PR DESCRIPTION
This adds the version of the operator which reconciled the `MondooAuditConfig`
to the `Status` section of the CR.

The new readiness check waits for all `MondooAuditConfigs` to include this version before the operator is considered ready.

Fixes #380

Signed-off-by: Christian Zunker <christian@mondoo.com>