### PR TITLE
Fix Helm release for v0.4.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -280,6 +280,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
+      - name: extract tag/version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo ${GITHUB_REF##refs/tags/})
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -329,7 +332,7 @@ jobs:
         run: echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
 
       - name: Run integration tests
-        run: EXTERNAL_INSTALLATION=1 make test/integration/ci
+        run: EXTERNAL_INSTALLATION=1 VERSION=${{ steps.get_version.outputs.VERSION }} make test/integration/ci
 
       - name: Clean up
         run: |
@@ -375,6 +378,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: extract tag/version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo ${GITHUB_REF##refs/tags/})
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -405,7 +412,7 @@ jobs:
         run: sleep 60
 
       - name: Run integration tests
-        run: EXTERNAL_INSTALLATION=1 make test/integration/ci
+        run: EXTERNAL_INSTALLATION=1 VERSION=${{ steps.get_version.outputs.VERSION }} make test/integration/ci
 
       - name: Upload test logs artifact
         uses: actions/upload-artifact@v3

--- a/charts/mondoo-operator/templates/mondooauditconfig-crd.yaml
+++ b/charts/mondoo-operator/templates/mondooauditconfig-crd.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mondooauditconfigs.k8s.mondoo.com
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "mondoo-operator.fullname" . }}-
-    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
   {{- include "mondoo-operator.labels" . | nindent 4 }}
 spec:
@@ -204,6 +203,10 @@ spec:
                 items:
                   type: string
                 type: array
+              reconciledByOperatorVersion:
+                description: ReconciledByOperatorVersion contains the version of the
+                  operator which reconciled this MondooAuditConfig
+                type: string
             type: object
         type: object
     served: true

--- a/charts/mondoo-operator/templates/mondoooperatorconfig-crd.yaml
+++ b/charts/mondoo-operator/templates/mondoooperatorconfig-crd.yaml
@@ -4,8 +4,8 @@ metadata:
   name: mondoooperatorconfigs.k8s.mondoo.com
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "mondoo-operator.fullname" . }}-
-    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
+
   {{- include "mondoo-operator.labels" . | nindent 4 }}
 spec:
   group: k8s.mondoo.com


### PR DESCRIPTION
The new Status field `ReconciledByOperatorVersion` broke the Helm and OLM integration tests.
the filed was also missing in the CRD.

Signed-off-by: Christian Zunker <christian@mondoo.com>