### PR TITLE
🐛 Revert to `go install` for kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,10 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
 
 ENVTEST = $(LOCALBIN)/setup-envtest
 .PHONY: envtest


### PR DESCRIPTION
The new `curl | bash` command for operator-sdk 1.21.0 does not work probably, when executed mutliple times.
`go install` takes care of this and is alligned with the other tools we install.

Signed-off-by: Christian Zunker <christian@mondoo.com>