### PR TITLE
🧹 Automatically generate release notes

### DIFF
--- a/.github/workflows/release-manifests.yaml
+++ b/.github/workflows/release-manifests.yaml
@@ -28,3 +28,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: mondoo-operator-manifests.yaml
+          generate_release_notes: true


### PR DESCRIPTION
This will automatically generate the release notes, looking quite
the same as we currently doing it manually.

Support added here:
https://github.com/softprops/action-gh-release/releases/tag/v0.1.14

Signed-off-by: Christian Zunker <christian@mondoo.com>