### PR TITLE
⭐ Run all containers with `readOnlyRootFilesystem` set to `true`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -129,6 +129,7 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: pointer.Bool(false),
+								ReadOnlyRootFilesystem:   pointer.Bool(true),
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -83,6 +83,10 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 											corev1.ResourceMemory: resource.MustParse("20Mi"),
 										},
 									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: pointer.Bool(false),
+										ReadOnlyRootFilesystem:   pointer.Bool(true),
+									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "token",

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -67,6 +67,10 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig) *batc
 										"--score-threshold", "0",
 									},
 									Resources: k8s.ResourcesRequirementsWithDefaults(m.Spec.Scanner.Resources),
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: pointer.Bool(false),
+										ReadOnlyRootFilesystem:   pointer.Bool(true),
+									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "root",

--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -99,6 +99,10 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 							PeriodSeconds:       5,
 							FailureThreshold:    5,
 						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
+							ReadOnlyRootFilesystem:   pointer.Bool(true),
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "config",
@@ -109,6 +113,10 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 								Name:      "token",
 								ReadOnly:  true,
 								MountPath: "/etc/opt/mondoo/token",
+							},
+							{
+								Name:      "temp",
+								MountPath: "/tmp",
 							},
 						},
 						Ports: []corev1.ContainerPort{
@@ -165,6 +173,12 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 									},
 									DefaultMode: pointer.Int32(0444),
 								},
+							},
+						},
+						{
+							Name: "temp",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},


### PR DESCRIPTION
Only the scan-api Pod requiers a scratch dir for `/tmp`.

Now all our containers pass the related policy rule.

Fixes #422

Signed-off-by: Christian Zunker <christian@mondoo.com>