### PR TITLE
⭐ Container image scanning

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -64,6 +64,10 @@ type Scanner struct {
 
 type KubernetesResources struct {
 	Enable bool `json:"enable,omitempty"`
+
+	// ContainerImageScanning determines whether container images are being scanned. The current implementation
+	// runs a separate job once every 24h that scans the container images running in the cluster.
+	ContainerImageScanning bool `json:"containerImageScanning,omitempty"`
 }
 
 type Nodes struct {

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -150,6 +150,8 @@ const (
 	NodeScanningDegraded MondooAuditConfigConditionType = "NodeScanningDegraded"
 	// Indicates weather Kubernetes resources scanning is Degraded
 	K8sResourcesScanningDegraded MondooAuditConfigConditionType = "K8sResourcesScanningDegraded"
+	// Indicates weather Kubernetes container image scanning is Degraded
+	K8sContainerImageScanningDegraded MondooAuditConfigConditionType = "K8sContainerImageScanningDegraded"
 	// Indicates weather Admission controller is Degraded
 	AdmissionDegraded MondooAuditConfigConditionType = "AdmissionDegraded"
 	// Indicates weather Admission controller is Degraded because of the ScanAPI

--- a/cmd/mondoo-operator/k8s_scan/cmd.go
+++ b/cmd/mondoo-operator/k8s_scan/cmd.go
@@ -21,6 +21,7 @@ func init() {
 	scanApiUrl := Cmd.Flags().String("scan-api-url", "", "The URL of the service to send scan requests to.")
 	tokenFilePath := Cmd.Flags().String("token-file-path", "", "Path to a file containing token to use when making scan requests.")
 	integrationMrn := Cmd.Flags().String("integration-mrn", "", "The Mondoo integration MRN to label scanned items with if the MondooAuditConfig is configured with Mondoo integration.")
+	scanContainerImages := Cmd.Flags().Bool("scan-container-images", false, "A value indicating whether to scan container images.")
 
 	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		log.SetLogger(zap.New())
@@ -46,7 +47,7 @@ func init() {
 		})
 
 		logger.Info("triggering Kubernetes resources scan")
-		res, err := client.ScanKubernetesResources(context.Background(), *integrationMrn)
+		res, err := client.ScanKubernetesResources(context.Background(), *integrationMrn, *scanContainerImages)
 		if err != nil {
 			logger.Error(err, "failed to trigger a Kubernetes resources scan")
 		}

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -78,6 +78,12 @@ spec:
                 type: object
               kubernetesResources:
                 properties:
+                  containerImageScanning:
+                    description: ContainerImageScanning determines whether container
+                      images are being scanned. The current implementation runs a
+                      separate job once every 24h that scans the container images
+                      running in the cluster.
+                    type: boolean
                   enable:
                     type: boolean
                 type: object

--- a/controllers/k8s_scan/container_image/conditions.go
+++ b/controllers/k8s_scan/container_image/conditions.go
@@ -18,5 +18,5 @@ func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedS
 	}
 
 	config.Status.Conditions = mondoo.SetMondooAuditCondition(
-		config.Status.Conditions, v1alpha2.K8sResourcesScanningDegraded, status, reason, msg, updateCheck)
+		config.Status.Conditions, v1alpha2.K8sContainerImageScanningDegraded, status, reason, msg, updateCheck)
 }

--- a/controllers/k8s_scan/container_image/conditions.go
+++ b/controllers/k8s_scan/container_image/conditions.go
@@ -1,0 +1,22 @@
+package container_image
+
+import (
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedStatus bool) {
+	msg := "Kubernetes Container Image Scanning is Available"
+	reason := "KubernetesContainerImageScanningAvailable"
+	status := corev1.ConditionFalse
+	updateCheck := mondoo.UpdateConditionIfReasonOrMessageChange
+	if degradedStatus {
+		msg = "Kubernetes ContainerImage Scanning is Unavailable"
+		reason = "KubernetesContainerImageScanningUnavailable"
+		status = corev1.ConditionTrue
+	}
+
+	config.Status.Conditions = mondoo.SetMondooAuditCondition(
+		config.Status.Conditions, v1alpha2.K8sResourcesScanningDegraded, status, reason, msg, updateCheck)
+}

--- a/controllers/k8s_scan/container_image/conditions.go
+++ b/controllers/k8s_scan/container_image/conditions.go
@@ -12,7 +12,7 @@ func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedS
 	status := corev1.ConditionFalse
 	updateCheck := mondoo.UpdateConditionIfReasonOrMessageChange
 	if degradedStatus {
-		msg = "Kubernetes ContainerImage Scanning is Unavailable"
+		msg = "Kubernetes Container Image Scanning is Unavailable"
 		reason = "KubernetesContainerImageScanningUnavailable"
 		status = corev1.ConditionTrue
 	}

--- a/controllers/k8s_scan/container_image/deployment_handler.go
+++ b/controllers/k8s_scan/container_image/deployment_handler.go
@@ -39,7 +39,7 @@ type DeploymentHandler struct {
 }
 
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
-	if !n.Mondoo.Spec.KubernetesResources.Enable {
+	if !n.Mondoo.Spec.KubernetesResources.ContainerImageScanning {
 		return ctrl.Result{}, n.down(ctx)
 	}
 

--- a/controllers/k8s_scan/container_image/deployment_handler.go
+++ b/controllers/k8s_scan/container_image/deployment_handler.go
@@ -39,7 +39,11 @@ type DeploymentHandler struct {
 }
 
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
-	if !n.Mondoo.Spec.KubernetesResources.ContainerImageScanning {
+	if !n.Mondoo.Spec.KubernetesResources.Enable && n.Mondoo.Spec.KubernetesResources.ContainerImageScanning {
+		logger.Info("Container image scanning cannot be enabled when k8s resources scanning is disabled.")
+	}
+
+	if !n.Mondoo.Spec.KubernetesResources.Enable || !n.Mondoo.Spec.KubernetesResources.ContainerImageScanning {
 		return ctrl.Result{}, n.down(ctx)
 	}
 

--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -54,7 +54,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      CronJobName(m.Name),
 			Namespace: m.Namespace,
-			Labels:    CronJobLabels(m),
+			Labels:    ls,
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          cronTab,

--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container_image
+
+import (
+	"fmt"
+	"time"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/controllers/scanapi"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+const CronJobNameSuffix = "-k8s-images-scan"
+
+func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv1.CronJob {
+	ls := CronJobLabels(m)
+
+	// We want to start the cron job one minute after it was enabled.
+	cronStart := time.Now().Add(1 * time.Minute)
+	cronTab := fmt.Sprintf("%d %d * * *", cronStart.Minute(), cronStart.Hour())
+	scanApiUrl := scanapi.ScanApiServiceUrl(m)
+
+	containerArgs := []string{
+		"k8s-scan",
+		"--scan-api-url", scanApiUrl,
+		"--token-file-path", "/etc/scanapi/token",
+		"--scan-container-images",
+	}
+
+	if integrationMrn != "" {
+		containerArgs = append(containerArgs, []string{"--integration-mrn", integrationMrn}...)
+	}
+
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CronJobName(m.Name),
+			Namespace: m.Namespace,
+			Labels:    CronJobLabels(m),
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          cronTab,
+			ConcurrencyPolicy: batchv1.AllowConcurrent,
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: ls},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: ls},
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+							// Triggering the Kubernetes resources scan does not require any API access, therefore no service account
+							// is needed.
+							AutomountServiceAccountToken: pointer.Bool(false),
+							Containers: []corev1.Container{
+								{
+									Image:           image,
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									Name:            "mondoo-k8s-scan",
+									Command:         []string{"/mondoo-operator"},
+									Args:            containerArgs,
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("200m"),
+											corev1.ResourceMemory: resource.MustParse("100Mi"),
+										},
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("20Mi"),
+										},
+									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: pointer.Bool(false),
+										ReadOnlyRootFilesystem:   pointer.Bool(true),
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "token",
+											MountPath: "/etc/scanapi",
+											ReadOnly:  true,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "token",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											DefaultMode: pointer.Int32(0o444),
+											SecretName:  scanapi.SecretName(m.Name),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			SuccessfulJobsHistoryLimit: pointer.Int32(1),
+			FailedJobsHistoryLimit:     pointer.Int32(1),
+		},
+	}
+}
+
+func CronJobLabels(m v1alpha2.MondooAuditConfig) map[string]string {
+	return map[string]string{
+		"app":       "mondoo-k8s-images-scan",
+		"scan":      "k8s",
+		"mondoo_cr": m.Name,
+	}
+}
+
+func CronJobName(prefix string) string {
+	return fmt.Sprintf("%s%s", prefix, CronJobNameSuffix)
+}

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -51,7 +51,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      CronJobName(m.Name),
 			Namespace: m.Namespace,
-			Labels:    CronJobLabels(m),
+			Labels:    ls,
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          cronTab,

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -59,7 +59,7 @@ type TransportConfig struct {
 	Record  bool              `protobuf:"varint,22,opt,name=record,proto3" json:"record,omitempty"`
 	Options map[string]string `protobuf:"bytes,23,rep,name=options,proto3" json:"options,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// flags for additional asset discovery
-	// Discover *Discovery `protobuf:"bytes,27,opt,name=discover,proto3" json:"discover,omitempty"`
+	Discover Discovery `protobuf:"bytes,27,opt,name=discover,proto3" json:"discover,omitempty"`
 	// additional platform information, passed-through
 	// Kind    Kind   `protobuf:"varint,24,opt,name=kind,proto3,enum=mondoo.motor.transports.v1.Kind" json:"kind,omitempty"`
 	Runtime string `protobuf:"bytes,25,opt,name=runtime,proto3" json:"runtime,omitempty"`
@@ -98,3 +98,8 @@ const (
 	TransportBackend_CONNECTION_TERRAFORM               TransportBackend = 26
 	TransportBackend_CONNECTION_HOST                    TransportBackend = 27
 )
+
+type Discovery struct {
+	Targets []string          `protobuf:"bytes,1,rep,name=targets,proto3" json:"targets,omitempty"`
+	Filter  map[string]string `protobuf:"bytes,2,rep,name=filter,proto3" json:"filter,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}

--- a/pkg/mondooclient/client_test.go
+++ b/pkg/mondooclient/client_test.go
@@ -87,7 +87,7 @@ func TestScanner_ScanKubernetesResources(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, healthResp.Status == "SERVING")
 
-	result, err := mClient.ScanKubernetesResources(context.Background(), "")
+	result, err := mClient.ScanKubernetesResources(context.Background(), "", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/pkg/mondooclient/mock/client_generated.go
+++ b/pkg/mondooclient/mock/client_generated.go
@@ -111,16 +111,16 @@ func (mr *MockClientMockRecorder) RunKubernetesManifest(arg0, arg1 interface{}) 
 }
 
 // ScanKubernetesResources mocks base method.
-func (m *MockClient) ScanKubernetesResources(ctx context.Context, integrationMrn string) (*mondooclient.ScanResult, error) {
+func (m *MockClient) ScanKubernetesResources(ctx context.Context, integrationMrn string, scanContainerImages bool) (*mondooclient.ScanResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScanKubernetesResources", ctx, integrationMrn)
+	ret := m.ctrl.Call(m, "ScanKubernetesResources", ctx, integrationMrn, scanContainerImages)
 	ret0, _ := ret[0].(*mondooclient.ScanResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ScanKubernetesResources indicates an expected call of ScanKubernetesResources.
-func (mr *MockClientMockRecorder) ScanKubernetesResources(ctx, integrationMrn interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ScanKubernetesResources(ctx, integrationMrn, scanContainerImages interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanKubernetesResources", reflect.TypeOf((*MockClient)(nil).ScanKubernetesResources), ctx, integrationMrn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanKubernetesResources", reflect.TypeOf((*MockClient)(nil).ScanKubernetesResources), ctx, integrationMrn, scanContainerImages)
 }

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -70,6 +70,7 @@ func (s *AuditConfigCustomNamespaceSuite) TearDownSuite() {
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_KubernetesResources() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, true, false, false)
+	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
 	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -20,6 +20,7 @@ func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
 
 func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false)
+	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }
 


### PR DESCRIPTION
Allow scanning container images that are used by the workloads in the cluster. Currently, this is implemented as a new `CronJob` that runs once per day because for large clusters container scanning can take a while.

- [x] implement change
- [x] extend tests
- [x] ~~document use-case~~ -> will be done in the docs repo and not here

Signed-off-by: Ivan Milchev <ivan@mondoo.com>