### PR TITLE
🐛  Make sure manifests are re-generated for webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/..." paths="./pkg/webhooks/..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen gomockgen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -19,6 +18,7 @@ webhooks:
   - apiGroups:
     - ""
     - apps
+    - batch
     apiVersions:
     - v1
     operations:
@@ -27,4 +27,8 @@ webhooks:
     resources:
     - pods
     - deployments
+    - daemonsets
+    - statefulsets
+    - jobs
+    - cronjobs
   sideEffects: None

--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Have kubebuilder generate a ValidatingWebhookConfiguration under the path /validate-k8s-mondoo-com that watches Pod/Deployment creation/updates
-//+kubebuilder:webhook:path=/validate-k8s-mondoo-com,mutating=false,failurePolicy=ignore,sideEffects=None,groups="";apps,resources=pods;deployments,verbs=create;update,versions=v1,name=policy.k8s.mondoo.com,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-k8s-mondoo-com,mutating=false,failurePolicy=ignore,sideEffects=None,groups="";apps;batch,resources=pods;deployments;daemonsets;statefulsets;jobs;cronjobs,verbs=create;update,versions=v1,name=policy.k8s.mondoo.com,admissionReviewVersions=v1
 
 var handlerlog = logf.Log.WithName("webhook-validator")
 


### PR DESCRIPTION
An issue that was introduced in #368. I only realized now what the impact of that thing was. I also noticed that the actual settings for the webhook are generated from the code, so this is fixed now as well

Signed-off-by: Ivan Milchev <ivan@mondoo.com>