### PR TITLE
🐛 Pin opm image to prevent `permission denied` errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ generate-manifests: manifests kustomize ## Generates manifests and pipes into a 
 .PHONY: deploy-olm
 deploy-olm: manifests kustomize ## Deploy using operator-sdk OLM 
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | operator-sdk run bundle ${BUNDLE_IMG}
+	$(KUSTOMIZE) build config/default | operator-sdk run bundle --index-image=quay.io/operator-framework/opm:v1.23.0 ${BUNDLE_IMG}
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
Workaround for https://github.com/operator-framework/operator-registry/issues/984

Fixes #429

Signed-off-by: Christian Zunker <christian@mondoo.com>