### PR TITLE
🐛 Pin opm image in GitHub actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -318,7 +318,7 @@ jobs:
           operator-sdk olm install
           sleep 30
           kubectl create ns mondoo-operator
-          operator-sdk run bundle ghcr.io/${{ github.repository }}-bundle:${{ github.ref_name }} --namespace mondoo-operator --timeout 3m0s
+          operator-sdk run bundle --index-image=quay.io/operator-framework/opm:v1.23.0 ghcr.io/${{ github.repository }}-bundle:${{ github.ref_name }} --namespace mondoo-operator --timeout 3m0s
 
       - name: Gather running pods
         if: failure()


### PR DESCRIPTION
This prevents `permission denied` errors.

Workaround for operator-framework/operator-registry#984

Fixes #429

Signed-off-by: Christian Zunker <christian@mondoo.com>