### PR TITLE
🐛 Change `PodAntiAffinity` to prevent scheduling errors

### DIFF
--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -174,14 +174,17 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 					},
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											WebhookLabelKey: WebhookLabelValue,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												WebhookLabelKey: WebhookLabelValue,
+											},
 										},
+										TopologyKey: "kubernetes.io/hostname",
 									},
-									TopologyKey: "kubernetes.io/hostname",
+									Weight: int32(100),
 								},
 							},
 						},

--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -184,12 +184,15 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 					},
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: labels,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: labels,
+										},
+										TopologyKey: "kubernetes.io/hostname",
 									},
-									TopologyKey: "kubernetes.io/hostname",
+									Weight: int32(100),
 								},
 							},
 						},


### PR DESCRIPTION
`RequiredDuringSchedulingIgnoredDuringExecution` leads to problems on small clusters.

Fixes #442

Signed-off-by: Christian Zunker <christian@mondoo.com>