### PR TITLE
⭐ Switch to mondoo client rootless images

### DIFF
--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -86,6 +86,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: pointer.Bool(false),
 										ReadOnlyRootFilesystem:   pointer.Bool(true),
+										RunAsNonRoot:             pointer.Bool(true),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -66,6 +66,7 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig) *batc
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: pointer.Bool(false),
 										ReadOnlyRootFilesystem:   pointer.Bool(true),
+										RunAsNonRoot:             pointer.Bool(true),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -66,7 +66,8 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig) *batc
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: pointer.Bool(false),
 										ReadOnlyRootFilesystem:   pointer.Bool(true),
-										RunAsNonRoot:             pointer.Bool(true),
+										RunAsNonRoot:             pointer.Bool(false),
+										RunAsUser:                pointer.Int64(0),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -102,6 +102,7 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: pointer.Bool(false),
 							ReadOnlyRootFilesystem:   pointer.Bool(true),
+							RunAsNonRoot:             pointer.Bool(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -103,6 +103,9 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig) *appsv1.D
 							AllowPrivilegeEscalation: pointer.Bool(false),
 							ReadOnlyRootFilesystem:   pointer.Bool(true),
 							RunAsNonRoot:             pointer.Bool(true),
+							// This is needed to prevent:
+							// Error: container has runAsNonRoot and image has non-numeric user (mondoo), cannot verify user is non-root ...
+							RunAsUser: pointer.Int64(101),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/pkg/utils/mondoo/container_image_resolver.go
+++ b/pkg/utils/mondoo/container_image_resolver.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	MondooClientImage   = "docker.io/mondoo/client"
-	MondooClientTag     = "6"
+	MondooClientTag     = "6-rootless"
 	MondooOperatorImage = "ghcr.io/mondoohq/mondoo-operator"
 )
 


### PR DESCRIPTION
Also set `runAsNonRoot` in the `securityContext` where missing.

relates-to #423

Signed-off-by: Christian Zunker <christian@mondoo.com>