### PR TITLE
Extract token exchange

### DIFF
--- a/controllers/status/operator_status.go
+++ b/controllers/status/operator_status.go
@@ -30,6 +30,7 @@ const (
 	NodeScanningIdentifier         = "node-scanning"
 	AdmissionControllerIdentifier  = "admission-controller"
 	ScanApiIdentifier              = "scan-api"
+	noStatusMessage                = "No status yet reported'"
 )
 
 type OperatorCustomState struct {
@@ -57,12 +58,17 @@ func ReportStatusRequestFromAuditConfig(
 	messages[0].Identifier = K8sResourcesScanningIdentifier
 	if m.Spec.KubernetesResources.Enable {
 		k8sResourcesScanning := mondoo.FindMondooAuditConditions(m.Status.Conditions, v1alpha2.K8sResourcesScanningDegraded)
-		if k8sResourcesScanning != nil && k8sResourcesScanning.Status == v1.ConditionTrue {
-			messages[0].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+		if k8sResourcesScanning != nil {
+			if k8sResourcesScanning.Status == v1.ConditionTrue {
+				messages[0].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+			} else {
+				messages[0].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			}
+			messages[0].Message = k8sResourcesScanning.Message
 		} else {
-			messages[0].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			messages[0].Status = mondooclient.MessageStatus_MESSAGE_UNKNOWN
+			messages[0].Message = noStatusMessage
 		}
-		messages[0].Message = k8sResourcesScanning.Message
 	} else {
 		messages[0].Status = mondooclient.MessageStatus_MESSAGE_INFO
 		messages[0].Message = "Kubernetes resources scanning is disabled"
@@ -72,12 +78,17 @@ func ReportStatusRequestFromAuditConfig(
 	messages[1].Identifier = NodeScanningIdentifier
 	if m.Spec.Nodes.Enable {
 		nodeScanning := mondoo.FindMondooAuditConditions(m.Status.Conditions, v1alpha2.NodeScanningDegraded)
-		if nodeScanning != nil && nodeScanning.Status == v1.ConditionTrue {
-			messages[1].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+		if nodeScanning != nil {
+			if nodeScanning.Status == v1.ConditionTrue {
+				messages[1].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+			} else {
+				messages[1].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			}
+			messages[1].Message = nodeScanning.Message
 		} else {
-			messages[1].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			messages[1].Status = mondooclient.MessageStatus_MESSAGE_UNKNOWN
+			messages[1].Message = noStatusMessage
 		}
-		messages[1].Message = nodeScanning.Message
 	} else {
 		messages[1].Status = mondooclient.MessageStatus_MESSAGE_INFO
 		messages[1].Message = "Node scanning is disabled"
@@ -87,12 +98,17 @@ func ReportStatusRequestFromAuditConfig(
 	messages[2].Identifier = AdmissionControllerIdentifier
 	if m.Spec.Admission.Enable {
 		admissionControllerScanning := mondoo.FindMondooAuditConditions(m.Status.Conditions, v1alpha2.AdmissionDegraded)
-		if admissionControllerScanning != nil && admissionControllerScanning.Status == v1.ConditionTrue {
-			messages[2].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+		if admissionControllerScanning != nil {
+			if admissionControllerScanning.Status == v1.ConditionTrue {
+				messages[2].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+			} else {
+				messages[2].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			}
+			messages[2].Message = admissionControllerScanning.Message
 		} else {
-			messages[2].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			messages[2].Status = mondooclient.MessageStatus_MESSAGE_UNKNOWN
+			messages[2].Message = noStatusMessage
 		}
-		messages[2].Message = admissionControllerScanning.Message
 	} else {
 		messages[2].Status = mondooclient.MessageStatus_MESSAGE_INFO
 		messages[2].Message = "Admission controller is disabled"
@@ -101,12 +117,17 @@ func ReportStatusRequestFromAuditConfig(
 	messages[3].Identifier = ScanApiIdentifier
 	if m.Spec.Admission.Enable || m.Spec.KubernetesResources.Enable {
 		scanApi := mondoo.FindMondooAuditConditions(m.Status.Conditions, v1alpha2.ScanAPIDegraded)
-		if scanApi.Status == v1.ConditionTrue {
-			messages[3].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+		if scanApi != nil {
+			if scanApi.Status == v1.ConditionTrue {
+				messages[3].Status = mondooclient.MessageStatus_MESSAGE_ERROR
+			} else {
+				messages[3].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			}
+			messages[3].Message = scanApi.Message
 		} else {
-			messages[3].Status = mondooclient.MessageStatus_MESSAGE_INFO
+			messages[3].Status = mondooclient.MessageStatus_MESSAGE_UNKNOWN
+			messages[3].Message = noStatusMessage
 		}
-		messages[3].Message = scanApi.Message
 	} else {
 		messages[3].Status = mondooclient.MessageStatus_MESSAGE_INFO
 		messages[3].Message = "Scan API is disabled"

--- a/pkg/utils/mondoo/token_exchange.go
+++ b/pkg/utils/mondoo/token_exchange.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tokenexchange
+package mondoo
 
 import (
 	"context"
@@ -33,7 +33,6 @@ import (
 	"go.mondoo.com/mondoo-operator/pkg/constants"
 	"go.mondoo.com/mondoo-operator/pkg/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
-	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 )
 
 type MondooClientBuilder func(mondooclient.ClientOptions) mondooclient.Client
@@ -136,7 +135,7 @@ func CreateServiceAccountFromToken(ctx context.Context, kubeClient client.Client
 }
 
 func performInitialCheckIn(ctx context.Context, mondooClientBuilder MondooClientBuilder, integrationMrn string, sa mondooclient.ServiceAccountCredentials, logger logr.Logger) error {
-	if err := mondoo.IntegrationCheckIn(ctx, integrationMrn, sa, mondooClientBuilder, logger); err != nil {
+	if err := IntegrationCheckIn(ctx, integrationMrn, sa, mondooClientBuilder, logger); err != nil {
 		logger.Error(err, "initial CheckIn() failed, will CheckIn() periodically", "integrationMRN", integrationMrn)
 		return err
 	}

--- a/pkg/utils/tokenexchange/tokenexchange.go
+++ b/pkg/utils/tokenexchange/tokenexchange.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenexchange
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	jwt "github.com/golang-jwt/jwt/v4"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.mondoo.com/mondoo-operator/pkg/constants"
+	"go.mondoo.com/mondoo-operator/pkg/mondooclient"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+)
+
+type MondooClientBuilder func(mondooclient.ClientOptions) mondooclient.Client
+
+// CreateServiceAccountFromToken will take the provided Mondoo token and exchange it with the Mondoo API
+// for a long lived Mondoo ServiceAccount
+func CreateServiceAccountFromToken(ctx context.Context, kubeClient client.Client, mondooClientBuilder MondooClientBuilder, withConsoleIntegration bool, serviceAccountSecret types.NamespacedName, tokenSecretData string, log logr.Logger) error {
+	jwtString := strings.TrimSpace(tokenSecretData)
+
+	parser := &jwt.Parser{}
+	token, _, err := parser.ParseUnverified(jwtString, jwt.MapClaims{})
+	if err != nil {
+		log.Error(err, "failed to parse token")
+		return err
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		err := fmt.Errorf("failed to type asesrt claims from token")
+		log.Error(err, "failed to extract claim")
+		return err
+	}
+	apiEndpoint := claims["api_endpoint"]
+
+	opts := mondooclient.ClientOptions{
+		ApiEndpoint: fmt.Sprintf("%v", apiEndpoint),
+		Token:       jwtString,
+	}
+
+	mClient := mondooClientBuilder(opts)
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountSecret.Name,
+			Namespace: serviceAccountSecret.Namespace,
+		},
+	}
+	if withConsoleIntegration {
+		// owner is the MRN of the integration
+		tokenOwner, ok := claims["owner"]
+		if !ok {
+			err := fmt.Errorf("'owner' claim missing from token which is expected for Mondoo integration registration")
+			log.Error(err, "missing data in token Secret")
+			return err
+		}
+		// Do an integration-style registration to associate the generated
+		// service account with the Mondoo console Integration
+		resp, err := mClient.IntegrationRegister(ctx, &mondooclient.IntegrationRegisterInput{
+			Mrn:   fmt.Sprintf("%v", tokenOwner),
+			Token: jwtString,
+		})
+		if err != nil {
+			log.Error(err, "failed to exchange token for a service account")
+			return err
+		}
+
+		integrationMrn := resp.Mrn
+		credsBytes, err := json.Marshal(*resp.Creds)
+		if err != nil {
+			log.Error(err, "failed to marshal service account creds from IntegrationRegister()")
+			return err
+		}
+		tokenSecret.Data = map[string][]byte{
+			constants.MondooCredsSecretServiceAccountKey: credsBytes,
+			constants.MondooCredsSecretIntegrationMRNKey: []byte(integrationMrn),
+		}
+		_, err = k8s.CreateIfNotExist(ctx, kubeClient, tokenSecret, tokenSecret)
+		if err != nil {
+			log.Error(err, "error while trying to save Mondoo service account into secret")
+			return err
+		}
+
+		// No easy way to retry this one-off CheckIn(). An error on initial CheckIn()
+		// means we'll just retry on the regularly scheduled interval via the integration controller
+		_ = performInitialCheckIn(ctx, mondooClientBuilder, integrationMrn, *resp.Creds, log)
+	} else {
+		// Do a vanilla token-for-service-account exchange
+		resp, err := mClient.ExchangeRegistrationToken(ctx, &mondooclient.ExchangeRegistrationTokenInput{
+			Token: jwtString,
+		})
+		if err != nil {
+			log.Error(err, "failed to exchange token for a service account")
+			return err
+		}
+
+		// Save the service account
+		tokenSecret.StringData = map[string]string{
+			constants.MondooCredsSecretServiceAccountKey: resp.ServiceAccount,
+		}
+		_, err = k8s.CreateIfNotExist(ctx, kubeClient, tokenSecret, tokenSecret)
+		if err != nil {
+			log.Error(err, "error while trying to save Mondoo service account into secret")
+			return err
+		}
+	}
+
+	log.Info("saved Mondoo service account", "secret", fmt.Sprintf("%s/%s", serviceAccountSecret.Namespace, serviceAccountSecret.Name))
+
+	return nil
+}
+
+func performInitialCheckIn(ctx context.Context, mondooClientBuilder MondooClientBuilder, integrationMrn string, sa mondooclient.ServiceAccountCredentials, logger logr.Logger) error {
+	if err := mondoo.IntegrationCheckIn(ctx, integrationMrn, sa, mondooClientBuilder, logger); err != nil {
+		logger.Error(err, "initial CheckIn() failed, will CheckIn() periodically", "integrationMRN", integrationMrn)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Was starting work on the remote/managed MondooAuditConfig pieces, but will need to switch to a different task. Save the work up until now to extract the token exchange codepaths because the remote/managed MondooAuditConfig controller will need to make use of this functionality.

Also, bugfix around some potential nil conditions that are returned.