### PR TITLE
🧹 Revised resources requests for operator and webhook

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,9 +53,9 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 60Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 35Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -120,11 +120,11 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceMemory: resource.MustParse("30Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
I noticed on my cluster that we are actually under-provisioning the operator and webhook. 

![image](https://user-images.githubusercontent.com/16187050/179833348-96b86a61-68d1-4c57-b920-898bd48f532c.png)
 

Signed-off-by: Ivan Milchev <ivan@mondoo.com>