### PR TITLE
create separate default Node resource requirements

### DIFF
--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -75,11 +75,11 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 									Args:            containerArgs,
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("200m"),
+											corev1.ResourceCPU:    resource.MustParse("100m"),
 											corev1.ResourceMemory: resource.MustParse("100Mi"),
 										},
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceCPU:    resource.MustParse("50m"),
 											corev1.ResourceMemory: resource.MustParse("20Mi"),
 										},
 									},

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -62,7 +62,7 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig) *batc
 										"--inventory-file", "/etc/opt/mondoo/inventory.yml",
 										"--score-threshold", "0",
 									},
-									Resources: k8s.ResourcesRequirementsWithDefaults(m.Spec.Nodes.Resources),
+									Resources: k8s.NodeScanningResourcesRequirementsWithDefaults(m.Spec.Nodes.Resources),
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: pointer.Bool(false),
 										ReadOnlyRootFilesystem:   pointer.Bool(true),

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -103,7 +103,7 @@ func TestResources(t *testing.T) {
 			mondooauditconfig: func() *v1alpha2.MondooAuditConfig {
 				return testMondooAuditConfig()
 			},
-			expectedResources: k8s.DefaultMondooClientResources,
+			expectedResources: k8s.DefaultNodeScanningResources,
 		},
 		{
 			name: "resources should match spec",

--- a/pkg/utils/k8s/resources_requirements.go
+++ b/pkg/utils/k8s/resources_requirements.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// defaultMondooClientResources for Mondoo Client container
+// DefaultMondooClientResources for Mondoo Client container
 var DefaultMondooClientResources corev1.ResourceRequirements = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{
 		corev1.ResourceMemory: resource.MustParse("400M"),
@@ -43,4 +43,28 @@ func ResourcesRequirementsWithDefaults(m corev1.ResourceRequirements) corev1.Res
 
 	// Default values for Mondoo resources requirements.
 	return DefaultMondooClientResources
+}
+
+// DefaultNodeScanningResources for Mondoo Client container when scanning nodes
+var DefaultNodeScanningResources corev1.ResourceRequirements = corev1.ResourceRequirements{
+	Limits: corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("400M"),
+		corev1.ResourceCPU:    resource.MustParse("200m"),
+	},
+
+	Requests: corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("180M"),
+		corev1.ResourceCPU:    resource.MustParse("50m"),
+	},
+}
+
+// NodeScanningResourcesRequirementsWithDefaults will return the resource requirements from the parameter if such
+// are specified. If not requirements are specified, default values will be returned.
+func NodeScanningResourcesRequirementsWithDefaults(m corev1.ResourceRequirements) corev1.ResourceRequirements {
+	if m.Size() != 0 {
+		return m
+	}
+
+	// Default values for Mondoo resources requirements.
+	return DefaultNodeScanningResources
 }

--- a/pkg/utils/k8s/resources_requirements.go
+++ b/pkg/utils/k8s/resources_requirements.go
@@ -48,12 +48,12 @@ func ResourcesRequirementsWithDefaults(m corev1.ResourceRequirements) corev1.Res
 // DefaultNodeScanningResources for Mondoo Client container when scanning nodes
 var DefaultNodeScanningResources corev1.ResourceRequirements = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("400M"),
+		corev1.ResourceMemory: resource.MustParse("100M"),
 		corev1.ResourceCPU:    resource.MustParse("200m"),
 	},
 
 	Requests: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("180M"),
+		corev1.ResourceMemory: resource.MustParse("60M"),
 		corev1.ResourceCPU:    resource.MustParse("50m"),
 	},
 }


### PR DESCRIPTION
Having a 400m CPU request for the Node scanning Jobs is excessive for an hourly node scan where the completion time is not time sensitive.

Rather than have the Node resource defaults be shared with the singleton ScanAPI Deployment, allow for the Node default resource requirements to be different. Lower the CPU requests for the Node Jobs down to 50m so that scheduling a node scan doesn't request such a high amount of CPU on each node.

Signed-off-by: Joel Diaz <joel@mondoo.com>