### PR TITLE
🐛 detect when running on OpenShift

### DIFF
--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -81,11 +81,17 @@ func init() {
 			return err
 		}
 
+		isOpenShift, err := k8s.IsOpenShift(mgr.GetConfig())
+		if err != nil {
+			setupLog.Error(err, "error while checking if running on OpenShift")
+		}
+
 		if err = (&controllers.MondooAuditConfigReconciler{
 			Client:                 mgr.GetClient(),
 			MondooClientBuilder:    controllers.MondooClientBuilder,
-			ContainerImageResolver: mondoo.NewContainerImageResolver(),
+			ContainerImageResolver: mondoo.NewContainerImageResolver(isOpenShift),
 			StatusReporter:         status.NewStatusReporter(mgr.GetClient(), controllers.MondooClientBuilder, v),
+			RunningOnOpenShift:     isOpenShift,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MondooAuditConfig")
 			return err

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -60,6 +60,7 @@ type MondooAuditConfigReconciler struct {
 	ContainerImageResolver mondoo.ContainerImageResolver
 	MondooAuditConfig      *v1alpha2.MondooAuditConfig
 	StatusReporter         *status.StatusReporter
+	RunningOnOpenShift     bool
 }
 
 // so we can mock out the mondoo client for testing
@@ -229,6 +230,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		KubeClient:             r.Client,
 		MondooOperatorConfig:   config,
 		ContainerImageResolver: r.ContainerImageResolver,
+		DeployOnOpenShift:      r.RunningOnOpenShift,
 	}
 	result, reconcileError := scanapi.Reconcile(ctx)
 	if reconcileError != nil {

--- a/controllers/scanapi/deployment_handler_test.go
+++ b/controllers/scanapi/deployment_handler_test.go
@@ -70,7 +70,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_KubernetesResources() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	s.Equal(*deployment, ds.Items[0])
@@ -113,7 +113,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() 
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "my-pull-secrets")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "my-pull-secrets", false)
 	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	s.Equal(*deployment, ds.Items[0])
@@ -145,7 +145,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecretNot
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "mondoo-private-registries-secrets")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "mondoo-private-registries-secrets", false)
 	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	s.Equal(*deployment, ds.Items[0])
@@ -177,7 +177,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecretWro
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	s.Equal(*deployment, ds.Items[0])
@@ -210,7 +210,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_Admission() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	s.Equal(*deployment, ds.Items[0])
@@ -234,7 +234,7 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	deployment.Status.UnavailableReplicas = 1
 	deployment.Status.Conditions = []appsv1.DeploymentCondition{
 		{
@@ -272,7 +272,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	deployment.Spec.Replicas = pointer.Int32(3)
 
 	service := ScanApiService(s.auditConfig.Namespace, s.auditConfig)
@@ -289,7 +289,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	s.NoError(d.KubeClient.List(s.ctx, ds))
 	s.Equal(1, len(ds.Items))
 
-	deployment = ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment = ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
 	deployment.ResourceVersion = "1000" // Needed because the fake client sets it.
 
@@ -314,7 +314,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Cleanup_NoScanning() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	service := ScanApiService(s.auditConfig.Namespace, s.auditConfig)
 	s.fakeClientBuilder = s.fakeClientBuilder.WithObjects(deployment, service)
 
@@ -345,7 +345,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Cleanup_AuditConfigDeletion() {
 		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
 	s.NoError(err)
 
-	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "")
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
 	service := ScanApiService(s.auditConfig.Namespace, s.auditConfig)
 	s.fakeClientBuilder = s.fakeClientBuilder.WithObjects(deployment, service)
 

--- a/pkg/utils/k8s/equality.go
+++ b/pkg/utils/k8s/equality.go
@@ -39,7 +39,27 @@ func AreDeploymentsEqual(a, b appsv1.Deployment) bool {
 		AreResouceRequirementsEqual(a.Spec.Template.Spec.Containers[0].Resources, b.Spec.Template.Spec.Containers[0].Resources) &&
 		reflect.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) &&
 		reflect.DeepEqual(a.Spec.Template.Spec.Affinity, b.Spec.Template.Spec.Affinity) &&
+		AreSecurityContextsEqual(a.Spec.Template.Spec.Containers[0].SecurityContext, b.Spec.Template.Spec.Containers[0].SecurityContext) &&
 		reflect.DeepEqual(a.GetOwnerReferences(), b.GetOwnerReferences())
+}
+
+// AreSecurityContextsEqual checks whether the provided Pod SecurityContexts are equal
+// for the fields we are interested in.
+func AreSecurityContextsEqual(a, b *corev1.SecurityContext) bool {
+	// If both left undefined, then they're equal to us
+	if a == nil && b == nil {
+		return true
+	}
+	// If not both are undefined, but one is, then unequal
+	if a == nil || b == nil {
+		return false
+	}
+
+	// Finally do the field comparisons for the filds we care about
+	return reflect.DeepEqual(a.AllowPrivilegeEscalation, b.AllowPrivilegeEscalation) &&
+		reflect.DeepEqual(a.ReadOnlyRootFilesystem, b.ReadOnlyRootFilesystem) &&
+		reflect.DeepEqual(a.RunAsNonRoot, b.RunAsNonRoot) &&
+		reflect.DeepEqual(a.RunAsUser, b.RunAsUser)
 }
 
 // AreServicesEqual return a value indicating whether 2 services are equal. Note that it

--- a/pkg/utils/k8s/openshift.go
+++ b/pkg/utils/k8s/openshift.go
@@ -1,0 +1,36 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// IsOpenShift will check whether we are running on
+// an OpenShift-style cluster
+func IsOpenShift(cfg *rest.Config) (bool, error) {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+
+	crdClient := dynClient.Resource(schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	})
+
+	// The clusterversions CRD shouldn't exist outside of OpenShift
+	_, err = crdClient.Get(context.Background(), "clusterversions.config.openshift.io", metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	} else if errors.IsNotFound(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}

--- a/pkg/utils/mondoo/container_image_resolver_test.go
+++ b/pkg/utils/mondoo/container_image_resolver_test.go
@@ -47,7 +47,7 @@ func (s *ContainerImageResolverSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *ContainerImageResolverSuite) TestNewContainerImageResolver() {
-	resolver := NewContainerImageResolver()
+	resolver := NewContainerImageResolver(false)
 
 	ref, err := name.ParseReference(fmt.Sprintf("%s:%s", MondooClientImage, MondooClientTag))
 	s.NoError(err)

--- a/pkg/utils/mondoo/container_image_resolver_test.go
+++ b/pkg/utils/mondoo/container_image_resolver_test.go
@@ -95,6 +95,16 @@ func (s *ContainerImageResolverSuite) TestMondooClientImage_SkipImageResolution(
 	s.Equalf(0, s.remoteCallsCount, "remote call has been performed")
 }
 
+func (s *ContainerImageResolverSuite) TestMondooClientImage_OpenShift() {
+	s.resolver.resolveForOpenShift = true
+
+	res, err := s.resolver.MondooClientImage("", "", true)
+	s.NoError(err)
+
+	s.Equal(fmt.Sprintf("%s:%s", MondooClientImage, OpenShiftMondooClientTag), res)
+	s.Equalf(0, s.remoteCallsCount, "remote call has been performed")
+}
+
 func (s *ContainerImageResolverSuite) TestMondooOperatorImage() {
 	image := "ghcr.io/mondoo/testimage"
 	res, err := s.resolver.MondooOperatorImage(image, "testtag", false)


### PR DESCRIPTION
OpenShift will assign a range of allowed UIDs for Pods in each Namespace
to use. The static use of UID 101 for the ScanAPI Pod interferes with
that.

- [x] detect when running on OpenShift at startup of the operator
- [x] Clear out the 101 UID when on OpenShift

Additionally, use the UBI container image when running on OpenShift

- [x] add test cases for building the Pod images and resolving image tags when on OpenShift

Signed-off-by: Joel Diaz <joel@mondoo.com>