### PR TITLE
🐛 Use the node name as platformid for node scanning

### DIFF
--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -178,11 +178,9 @@ func Inventory(node corev1.Node, integrationMRN string, m v1alpha2.MondooAuditCo
 		Spec: inventory.MondooInventorySpec{
 			Assets: []inventory.Asset{
 				{
-					Id:   "host",
-					Name: node.Name,
-					IdDetector: []string{
-						"machine-id",
-					},
+					Id:          "host",
+					Name:        node.Name,
+					PlatformIds: []string{node.Name},
 					Connections: []inventory.TransportConfig{
 						{
 							Host:    "/mnt/host",


### PR DESCRIPTION
Since the `machine-id` is not a reliable identifier and the hostname cannot always be determined (e.g. in GKE #348), we move to the Kubernetes node name.

Closes #463 

Signed-off-by: Ivan Milchev <ivan@mondoo.com>