### PR TITLE
🧹 Optimize kubernetes resources scan CronJobs

### DIFF
--- a/config/samples/k8s_v1alpha2_mondooauditconfig_minimal.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig_minimal.yaml
@@ -7,11 +7,12 @@ spec:
   mondooCredsSecretRef:
     name: mondoo-client
   kubernetesResources:
-    enable: false
+    enable: true
+    containerImageScanning: true
   nodes:
-    enable: true
+    enable: false
   admission:
-    enable: true
+    enable: false
     certificateProvisioning:
       # Could be "cert-manager", "openshift" or "manual"
       mode: cert-manager

--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -78,11 +78,11 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 									Args:            containerArgs,
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("200m"),
-											corev1.ResourceMemory: resource.MustParse("100Mi"),
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("30Mi"),
 										},
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceCPU:    resource.MustParse("50m"),
 											corev1.ResourceMemory: resource.MustParse("20Mi"),
 										},
 									},

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -76,7 +76,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("100m"),
-											corev1.ResourceMemory: resource.MustParse("100Mi"),
+											corev1.ResourceMemory: resource.MustParse("30Mi"),
 										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -247,6 +247,7 @@ const ScanKubernetesResourcesEndpoint = "/Scan/Run"
 func (s *mondooClient) ScanKubernetesResources(ctx context.Context, integrationMrn string, scanContainerImages bool) (*ScanResult, error) {
 	url := s.ApiEndpoint + ScanKubernetesResourcesEndpoint
 	scanJob := ScanJob{
+		ReportType: ReportType_ERROR,
 		Inventory: inventory.MondooInventory{
 			Spec: inventory.MondooInventorySpec{
 				Assets: []inventory.Asset{
@@ -293,8 +294,17 @@ func (s *mondooClient) ScanKubernetesResources(ctx context.Context, integrationM
 	return out, nil
 }
 
+type ReportType int
+
+const (
+	ReportType_NONE  ReportType = 0
+	ReportType_ERROR ReportType = 1
+	ReportType_FULL  ReportType = 2
+)
+
 type ScanJob struct {
-	Inventory inventory.MondooInventory `json:"inventory"`
+	Inventory  inventory.MondooInventory `json:"inventory"`
+	ReportType ReportType                `protobuf:"varint,22,opt,name=report_type,json=reportType,proto3,enum=mondoo.policy.scan.ReportType" json:"report_type,omitempty"`
 }
 
 func NewClient(opts ClientOptions) Client {


### PR DESCRIPTION
Request only the errors instead of the entire report collection (which we anyways discard). This allows us to lower the limits for the scan `CronJobs`

Signed-off-by: Ivan Milchev <ivan@mondoo.com>