### PR TITLE
⭐ Allow enabling pod discovery with an env var

### DIFF
--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -22,6 +22,7 @@ import (
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers/scanapi"
+	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -97,6 +98,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 											ReadOnly:  true,
 										},
 									},
+									Env: feature_flags.AllFeatureFlagsAsEnv(),
 								},
 							},
 							Volumes: []corev1.Volume{

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -22,6 +22,7 @@ import (
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers/scanapi"
+	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -95,6 +96,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 											ReadOnly:  true,
 										},
 									},
+									Env: feature_flags.AllFeatureFlagsAsEnv(),
 								},
 							},
 							Volumes: []corev1.Volume{

--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -31,7 +31,7 @@ func AllFeatureFlags() map[string]string {
 }
 
 func AllFeatureFlagsAsEnv() []corev1.EnvVar {
-	env := []corev1.EnvVar{}
+	var env []corev1.EnvVar
 	for k, v := range allFeatureFlags {
 		env = append(env, corev1.EnvVar{Name: k, Value: v})
 	}

--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -1,0 +1,50 @@
+package feature_flags
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const FeatureFlagPrefix = "FEATURE_"
+
+var (
+	enablePodDiscovery bool
+	allFeatureFlags    = make(map[string]string)
+)
+
+func init() {
+	envs := os.Environ()
+	for _, e := range envs {
+		// If it has the feature flag prefix, then parse the env var.
+		if strings.HasPrefix(e, FeatureFlagPrefix) {
+			val := strings.Split(e, "=")
+			allFeatureFlags[val[0]] = val[1]
+			setGlobalFlags(val[0], val[1])
+		}
+	}
+}
+
+func AllFeatureFlags() map[string]string {
+	return allFeatureFlags
+}
+
+func AllFeatureFlagsAsEnv() []corev1.EnvVar {
+	env := []corev1.EnvVar{}
+	for k, v := range allFeatureFlags {
+		env = append(env, corev1.EnvVar{Name: k, Value: v})
+	}
+	return env
+}
+
+func GetEnablePodDiscovery() bool {
+	return enablePodDiscovery
+}
+
+func setGlobalFlags(k, v string) {
+	switch k {
+	case "FEATURE_DISCOVER_PODS":
+		enablePodDiscovery = true
+	}
+}

--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -24,10 +24,10 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"go.mondoo.com/mondoo-operator/pkg/constants"
+	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 	"go.mondoo.com/mondoo-operator/pkg/inventory"
 )
 
@@ -38,13 +38,6 @@ const (
 	defaultTLSHandshakeTimeout = 10 * time.Second
 	maxIdleConnections         = 100
 )
-
-var enablePodDiscovery bool
-
-func init() {
-	_, ok := os.LookupEnv("SCAN_DISCOVER_PODS")
-	enablePodDiscovery = ok
-}
 
 //go:generate ./../../bin/mockgen -source=./client.go -destination=./mock/client_generated.go -package=mock
 
@@ -277,7 +270,7 @@ func (s *mondooClient) ScanKubernetesResources(ctx context.Context, integrationM
 		scanJob.Inventory.Spec.Assets[0].Labels[constants.MondooAssetsIntegrationLabel] = integrationMrn
 	}
 
-	if scanContainerImages || enablePodDiscovery {
+	if scanContainerImages || feature_flags.GetEnablePodDiscovery() {
 		scanJob.Inventory.Spec.Assets[0].Connections[0].Options = make(map[string]string)
 		scanJob.Inventory.Spec.Assets[0].Connections[0].Options["all-namespaces"] = "true"
 
@@ -287,7 +280,7 @@ func (s *mondooClient) ScanKubernetesResources(ctx context.Context, integrationM
 		scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets = append(scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets, "container-images")
 	}
 
-	if enablePodDiscovery {
+	if feature_flags.GetEnablePodDiscovery() {
 		scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets = append(scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets, "pods")
 	}
 


### PR DESCRIPTION
Allow enabling pod discovery by setting `FEATURE_DISCOVER_PODS` env var. If you'd like to test this you need to do the following:

1. Make sure minikube is running `minikube start`
2. In the `mondoo-operator` root directory run the following:
 ```bash
make generate-manifests
make load-minikube
kubectl apply -f mondoo-operator-manifests.yaml
``` 
3. Edit the mondoo-operator deployment to add the env var
```bash
kubectl edit -n mondoo-operator deployment mondoo-operator-controller-manager
```

It should look like this:
```yaml
....
containers:
  - args:
    - operator
    - --health-probe-bind-address=:8081
    - --metrics-bind-address=:8080
    - --leader-elect
    command:
    - /mondoo-operator
    env: # <-- this is the important bit
    - name: FEATURE_DISCOVER_PODS
      value: "1"
....
```

4. Apply the following `MondooOperatorConfig` config:
```yaml
apiVersion: k8s.mondoo.com/v1alpha2
kind: MondooOperatorConfig
metadata:
  name: mondoo-operator-config
spec:
  skipContainerResolution: true
```
5. Create a Mondoo space and upload policies that are targeting `k8s.pod` assets
6. Create a k8s integration in the Mondoo space and copy ONLY the command that creates the token
7. Apply the following `MondooAuditConfig`:
```yaml
apiVersion: k8s.mondoo.com/v1alpha2
kind: MondooAuditConfig
metadata:
  name: mondoo-client
  namespace: mondoo-operator
spec:
  mondooCredsSecretRef:
    name: mondoo-client
  mondooTokenSecretRef:
    name: mondoo-token
  scanner:
    image:
      name: docker.io/mondoo/client
      tag: edge-6.9.0-7
  kubernetesResources:
    enable: true
```

Within a minute the pods should show up in your Mondoo space