### PR TITLE
⭐ Create edge integration tests workflow

### DIFF
--- a/.github/workflows/edge-integration-tests.yaml
+++ b/.github/workflows/edge-integration-tests.yaml
@@ -19,4 +19,5 @@ jobs:
 
       - uses: ./.github/workflows/integration-tests.yaml
         with:
-          mondooClientImageTag: ${{ github.event.inputs.mondooClientImageTag }} 
+          mondooClientImageTag: ${{ github.event.inputs.mondooClientImageTag }}
+          secrets: inherit

--- a/.github/workflows/edge-integration-tests.yaml
+++ b/.github/workflows/edge-integration-tests.yaml
@@ -1,0 +1,22 @@
+name: Edge integration tests
+on:
+  workflow_dispatch:
+    inputs:
+      mondooClientImageTag:
+        description: "The Mondoo client image tag to be used for the integration tests"
+        required: true
+        type: string
+
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    name: Start edge integration tests
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/workflows/integration-tests.yaml
+        with:
+          mondooClientImageTag: ${{ github.event.inputs.mondooClientImageTag }} 

--- a/.github/workflows/edge-integration-tests.yaml
+++ b/.github/workflows/edge-integration-tests.yaml
@@ -9,15 +9,7 @@ on:
 
 jobs:
   integration_tests:
-    runs-on: ubuntu-latest
-    name: Start edge integration tests
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/workflows/integration-tests.yaml
-        with:
-          mondooClientImageTag: ${{ github.event.inputs.mondooClientImageTag }}
-          secrets: inherit
+    uses: ./.github/workflows/integration-tests.yaml
+    with:
+      mondooClientImageTag: ${{ github.event.inputs.mondooClientImageTag }}
+      secrets: inherit

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,7 +2,7 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
-      client_version:
+      mondooClientImageTag:
         required: true
         type: string
 
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration tests
     env:
-      MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.client_version }}
+      MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.mondooClientImageTag }}
 
     strategy:
       matrix:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,6 +5,9 @@ on:
       mondooClientImageTag:
         required: true
         type: string
+    secrets:
+      MONDOO_CLIENT:
+        required: true
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,6 +10,8 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: Integration tests
+    env:
+      MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.client_version }}
 
     strategy:
       matrix:
@@ -33,9 +35,6 @@ jobs:
       - name: Store creds
         run: |
           echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
-
-      - name: Pre-pull container images
-        run: minikube image load docker.io/mondoo/client:latest
 
       # Now that dependencies are cached the tests start almost immediately after minikube has started
       # this makes tests fail occasionally. This sleep gives the runner some time to become more stable

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,67 @@
+name: Integration tests
+on:
+  workflow_call:
+    inputs:
+      client_version:
+        required: true
+        type: string
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    name: Integration tests
+
+    strategy:
+      matrix:
+        k8s-version: [v1.22.12, v1.23.9, v1.24.3]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch is nneded for "git tag --list" in the Makefile
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          memory: 4000m
+          kubernetes-version: ${{ matrix.k8s-version }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.golang-version }}"
+
+      - name: Store creds
+        run: |
+          echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
+
+      - name: Pre-pull container images
+        run: minikube image load docker.io/mondoo/client:latest
+
+      # Now that dependencies are cached the tests start almost immediately after minikube has started
+      # this makes tests fail occasionally. This sleep gives the runner some time to become more stable
+      # before the test execution starts.
+      - name: Wait a bit for the runner to become more stable
+        run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=90s
+
+      - name: Run integration tests
+        run: make test/integration/ci
+
+      - uses: actions/download-artifact@v3 # download the unit test results
+        if: success() || failure()        # run this step even if previous step failed
+        with:
+          name: unit-test-results
+      - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-version }}.xml
+        if: success() || failure()
+      - uses: actions/upload-artifact@v3  # upload test results
+        if: success() || failure()        # run this step even if previous step failed
+        with:                             # upload a combined archive with unit and integration test results
+          name: test-results
+          path: |
+            unit-tests.xml
+            integration-tests-${{ matrix.k8s-version }}.xml
+      - name: Upload test logs artifact
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test-logs-${{ matrix.k8s-version }}
+          path: /home/runner/work/mondoo-operator/mondoo-operator/tests/integration/_output/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,5 +53,6 @@ jobs:
     name: Integration tests
     with:
       mondooClientImageTag: ""
+    secrets: inherit
 
    

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,62 +47,11 @@ jobs:
           name: unit-test-results
           path: unit-tests.xml
   integration-tests:
-    runs-on: ubuntu-latest
     needs: [unit-tests]
+    uses: ./.github/workflows/integration-tests.yaml
     if: needs.unit-tests.result == 'success' # run only if unit-tests are successful
     name: Integration tests
+    with:
+      client_version: latest
 
-    strategy:
-      matrix:
-        k8s-version: [v1.22.12, v1.23.9, v1.24.3]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # fetch is nneded for "git tag --list" in the Makefile
-      - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
-      - name: Start minikube
-        uses: medyagh/setup-minikube@master
-        with:
-          memory: 4000m
-          kubernetes-version: ${{ matrix.k8s-version }}
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "${{ env.golang-version }}"
-
-      - name: Store creds
-        run: |
-          echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
-
-      - name: Pre-pull container images
-        run: minikube image load docker.io/mondoo/client:latest
-
-      # Now that dependencies are cached the tests start almost immediately after minikube has started
-      # this makes tests fail occasionally. This sleep gives the runner some time to become more stable
-      # before the test execution starts.
-      - name: Wait a bit for the runner to become more stable
-        run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=60s
-
-      - name: Run integration tests
-        run: make test/integration/ci
-
-      - uses: actions/download-artifact@v3 # download the unit test results
-        if: success() || failure()        # run this step even if previous step failed
-        with:
-          name: unit-test-results
-      - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-version }}.xml
-        if: success() || failure()
-      - uses: actions/upload-artifact@v3  # upload test results
-        if: success() || failure()        # run this step even if previous step failed
-        with:                             # upload a combined archive with unit and integration test results
-          name: test-results
-          path: |
-            unit-tests.xml
-            integration-tests-${{ matrix.k8s-version }}.xml
-      - name: Upload test logs artifact
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: test-logs-${{ matrix.k8s-version }}
-          path: /home/runner/work/mondoo-operator/mondoo-operator/tests/integration/_output/
+   

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,6 @@ jobs:
     if: needs.unit-tests.result == 'success' # run only if unit-tests are successful
     name: Integration tests
     with:
-      client_version: ""
+      mondooClientImageTag: ""
 
    

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,6 @@ jobs:
     if: needs.unit-tests.result == 'success' # run only if unit-tests are successful
     name: Integration tests
     with:
-      client_version: latest
+      client_version: ""
 
    

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -1,20 +1,36 @@
 package utils
 
 import (
+	"os"
+
 	mondoov2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
-const MondooClientSecret = "mondoo-client"
+const (
+	MondooClientSecret         = "mondoo-client"
+	MondooClientImageTagEnvVar = "MONDOO_CLIENT_IMAGE_TAG"
+)
+
+var mondooClientImageTag = ""
+
+func init() {
+	imageTag, ok := os.LookupEnv(MondooClientImageTagEnvVar)
+	if ok {
+		mondooClientImageTag = imageTag
+	}
+}
 
 // DefaultAuditConfigMinimal returns a new Mondoo audit config with minimal default settings to
 // make sure a test passes (e.g. setting the correct secret name). Values which have defaults are not set.
 // This means that using this function in unit tests might result in strange behavior. For unit tests use
 // DefaultAuditConfig instead.
 func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission bool) mondoov2.MondooAuditConfig {
-	return mondoov2.MondooAuditConfig{
+	auditConfig := mondoov2.MondooAuditConfig{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "mondoo-client",
 			Namespace: ns,
@@ -26,6 +42,14 @@ func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission bool) mond
 			Admission:            mondoov2.Admission{Enable: admission},
 		},
 	}
+
+	if mondooClientImageTag != "" {
+		auditConfig.Spec.Scanner.Image.Name = mondoo.MondooClientImage
+		auditConfig.Spec.Scanner.Image.Tag = mondooClientImageTag
+		zap.S().Infof("Using image %s:%s for mondoo-client", mondoo.MondooClientImage, mondooClientImageTag)
+	}
+
+	return auditConfig
 }
 
 // DefaultAuditConfig returns a new Mondoo audit config with some default settings to

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -44,7 +44,6 @@ func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission bool) mond
 	}
 
 	if mondooClientImageTag != "" {
-		auditConfig.Spec.Scanner.Image.Name = mondoo.MondooClientImage
 		auditConfig.Spec.Scanner.Image.Tag = mondooClientImageTag
 		zap.S().Infof("Using image %s:%s for mondoo-client", mondoo.MondooClientImage, mondooClientImageTag)
 	}


### PR DESCRIPTION
- [x] split out integration tests into a re-usable workflow
- [x] fix current tests so they use the new workflow
- [x] add the possibility to override the Mondoo client tag via env var
- [x] create a new workflow that can be triggered manually by specifying a specific version of the Mondoo client

Signed-off-by: Ivan Milchev <ivan@mondoo.com>