### PR TITLE
🧹 Unified logging style for operator, cronjobs and admission controller

### DIFF
--- a/cmd/mondoo-operator/k8s_scan/cmd.go
+++ b/cmd/mondoo-operator/k8s_scan/cmd.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.mondoo.com/mondoo-operator/pkg/mondooclient"
+	"go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var Cmd = &cobra.Command{
@@ -24,7 +24,7 @@ func init() {
 	scanContainerImages := Cmd.Flags().Bool("scan-container-images", false, "A value indicating whether to scan container images.")
 
 	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		log.SetLogger(zap.New())
+		log.SetLogger(logger.NewLogger())
 		logger := log.Log.WithName("k8s-scan")
 
 		if *scanApiUrl == "" {

--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -14,7 +14,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -24,6 +23,7 @@ import (
 	"go.mondoo.com/mondoo-operator/controllers/integration"
 	"go.mondoo.com/mondoo-operator/controllers/status"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	"go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	"go.mondoo.com/mondoo-operator/pkg/version"
 	//+kubebuilder:scaffold:imports
@@ -43,10 +43,7 @@ func init() {
 	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// TODO: opts.BindFlags(flag.CommandLine) is not supported with cobra. If we want to support that we should manually
 		// implement reading the flags.
-		opts := zap.Options{
-			Development: true,
-		}
-		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+		ctrl.SetLogger(logger.NewLogger())
 		setupLog := ctrl.Log.WithName("setup")
 
 		scheme := runtime.NewScheme()

--- a/cmd/mondoo-operator/webhook/cmd.go
+++ b/cmd/mondoo-operator/webhook/cmd.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/version"
 	webhookhandler "go.mondoo.com/mondoo-operator/pkg/webhooks/handler"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -31,7 +31,7 @@ func init() {
 	clusterID := Cmd.Flags().String("cluster-id", "", "A cluster-unique ID for associating the webhook payloads with the underlying cluster.")
 
 	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		log.SetLogger(zap.New())
+		log.SetLogger(logger.NewLogger())
 		webhookLog := log.Log.WithName("webhook")
 
 		if *scanApiUrl == "" {

--- a/controllers/integration/integration_controller_test.go
+++ b/controllers/integration/integration_controller_test.go
@@ -112,7 +112,6 @@ func (s *IntegrationCheckInSuite) TestCheckIn() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		Log:                 testLogger,
 		MondooClientBuilder: testMondooClientBuilder,
 	}
 
@@ -158,7 +157,6 @@ func (s *IntegrationCheckInSuite) TestClearPreviousCondition() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		Log:                 testLogger,
 		MondooClientBuilder: testMondooClientBuilder,
 	}
 
@@ -197,7 +195,6 @@ func (s *IntegrationCheckInSuite) TestMissingIntegrationMRN() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		Log:                 testLogger,
 		MondooClientBuilder: testMondooClientBuilder,
 	}
 
@@ -236,7 +233,6 @@ func (s *IntegrationCheckInSuite) TestBadServiceAccountData() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		Log:                 testLogger,
 		MondooClientBuilder: testMondooClientBuilder,
 	}
 
@@ -275,7 +271,6 @@ func (s *IntegrationCheckInSuite) TestFailedCheckIn() {
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
-		Log:                 testLogger,
 		MondooClientBuilder: testMondooClientBuilder,
 	}
 

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -1,0 +1,15 @@
+package logger
+
+import (
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func NewLogger() logr.Logger {
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+	}
+	return zap.New(zap.UseFlagOptions(&opts))
+}


### PR DESCRIPTION
Unify logging format for the operator, cronjobs and admission controller. It looks like this now:
```
2022-08-01T10:08:09Z    INFO    webhook setting up manager
2022-08-01T10:08:09Z    INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
2022-08-01T10:08:09Z    INFO    webhook setting up webhook server       {"version": "sha256-1cfc847f62242675f857d25a6c8e5c38488dfe07.sig"}
2022-08-01T10:08:09Z    INFO    webhook registering webhooks to the webhook server
2022-08-01T10:08:09Z    INFO    controller-runtime.webhook      Registering webhook     {"path": "/validate-k8s-mondoo-com"}
2022-08-01T10:08:09Z    INFO    webhook starting manager
2022-08-01T10:08:09Z    INFO    controller-runtime.webhook.webhooks     Starting webhook server
2022-08-01T10:08:09Z    INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2022-08-01T10:08:09Z    INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
2022-08-01T10:08:09Z    INFO    controller-runtime.certwatcher  Updated current TLS certificate
2022-08-01T10:08:09Z    INFO    controller-runtime.webhook      Serving webhook server  {"host": "", "port": 9443}
2022-08-01T10:08:09Z    INFO    controller-runtime.certwatcher  Starting certificate watcher
```

Closes #478 

Signed-off-by: Ivan Milchev <ivan@mondoo.com>