### PR TITLE
⭐ Add timeout parameter for scan cronjobs

### DIFF
--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -62,7 +62,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          cronTab,
-			ConcurrencyPolicy: batchv1.AllowConcurrent,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/k8s_scan/container_image/resources.go
+++ b/controllers/k8s_scan/container_image/resources.go
@@ -45,6 +45,9 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		"--scan-api-url", scanApiUrl,
 		"--token-file-path", "/etc/scanapi/token",
 		"--scan-container-images",
+
+		// The job runs daily and we need to make sure that the previous one is killed before the new one is started so we don't stack them.
+		"--timeout", "1430",
 	}
 
 	if integrationMrn != "" {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -59,7 +59,7 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          cronTab,
-			ConcurrencyPolicy: batchv1.AllowConcurrent,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -42,6 +42,9 @@ func CronJob(image, integrationMrn string, m v1alpha2.MondooAuditConfig) *batchv
 		"k8s-scan",
 		"--scan-api-url", scanApiUrl,
 		"--token-file-path", "/etc/scanapi/token",
+
+		// The job runs hourly and we need to make sure that the previous one is killed before the new one is started so we don't stack them.
+		"--timeout", "55",
 	}
 
 	if integrationMrn != "" {


### PR DESCRIPTION
Adds a timeout parameter for the scan `CronJobs`. The goal is to make sure that we don't keep stacking running scan `CronJobs`. Over the weekend I ran into the issue that the Mondoo client seems to get stuck occasionally during a scan or it gets killed due to OOM. If this happens the pending scan `CronJobs` remain pending forever and new ones are being added on top. This eventually eats all the cluster resources and the follow-up jobs are just queued to be scheduled.

This PR does NOT fix the Mondoo client issue but it does make sure that the operator properly handles such edge cases and does not eat up the cluster resources.

Signed-off-by: Ivan Milchev <ivan@mondoo.com>