### PR TITLE
⭐ Add k3s to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,8 +20,10 @@ jobs:
     
     strategy:
       matrix:
-        k8s-version: [v1.22.12, v1.23.9, v1.24.3]
-        k8s-distro: [minikube,k3s]
+        # k8s-version: [v1.22.12, v1.23.9, v1.24.3]
+        # k8s-distro: [minikube,k3s]
+        k8s-version: [v1.24.3]
+        k8s-distro: [k3s]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,14 +32,14 @@ jobs:
 
       - name: Start minikube
         uses: medyagh/setup-minikube@master
-        if: ${{ matrix.k8s-distro }} == 'minikube'
+        if: matrix.k8s-distro == 'minikube'
         with:
           memory: 4000m
           kubernetes-version: ${{ matrix.k8s-version }}
 
       - name: Start k3s
         uses: nolar/setup-k3d-k3s@v1
-        if: ${{ matrix.k8s-distro }} == 'k3s'
+        if: matrix.k8s-distro == 'k3s'
         with:
           version: ${{ matrix.k8s-version }}
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           limit-access-to-users: imilchev
 
       - name: Run integration tests
-        run: make test/integration/ci
+        run: K8S_DISTRO=${{ matrix.k8s-distro }} make test/integration/ci
 
       - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-version }}.xml
         if: success() || failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         # k8s-version: [v1.22.12, v1.23.9, v1.24.3]
-        # k8s-distro: [minikube,k3s]
+        # k8s-distro: [minikube,k3d]
         k8s-version: [v1.24.3]
-        k8s-distro: [k3s]
+        k8s-distro: [k3d]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,9 +39,9 @@ jobs:
           memory: 4000m
           kubernetes-version: ${{ matrix.k8s-version }}
 
-      - name: Start k3s
+      - name: Start k3d
         uses: nolar/setup-k3d-k3s@v1
-        if: matrix.k8s-distro == 'k3s'
+        if: matrix.k8s-distro == 'k3d'
         with:
           version: ${{ matrix.k8s-version }}
           k3d-args: --k3s-arg=--disable=traefik@server:*

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -61,6 +61,14 @@ jobs:
       - name: Wait a bit for the runner to become more stable
         run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=90s
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+          limit-access-to-actor: true
+          ## limits ssh access and adds the ssh public keys of the listed GitHub users
+          limit-access-to-users: imilchev
+
       - name: Run integration tests
         run: make test/integration/ci
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -44,6 +44,7 @@ jobs:
         if: matrix.k8s-distro == 'k3s'
         with:
           version: ${{ matrix.k8s-version }}
+          k3d-args: --k3s-arg=--disable=traefik@server:*
 
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,10 +20,8 @@ jobs:
     
     strategy:
       matrix:
-        # k8s-version: [v1.22.12, v1.23.9, v1.24.3]
-        # k8s-distro: [minikube,k3d]
-        k8s-version: [v1.24.3]
-        k8s-distro: [k3d]
+        k8s-version: [v1.22.12, v1.23.9, v1.24.3]
+        k8s-distro: [minikube, k3d]
 
     steps:
       - uses: actions/checkout@v2
@@ -64,14 +62,6 @@ jobs:
       - name: Wait a bit for the runner to become more stable
         run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=90s
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-          limit-access-to-actor: true
-          ## limits ssh access and adds the ssh public keys of the listed GitHub users
-          limit-access-to-users: imilchev
-
       - name: Run integration tests
         run: K8S_DISTRO=${{ matrix.k8s-distro }} make test/integration/ci
 
@@ -82,11 +72,11 @@ jobs:
         if: success() || failure()        # run this step even if previous step failed
         with:                             # upload a combined archive with unit and integration test results
           name: test-results
-          path: integration-tests-${{ matrix.k8s-version }}.xml
+          path: ${{ matrix.k8s-distro }}-integration-tests-${{ matrix.k8s-version }}.xml
 
       - name: Upload test logs artifact
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: test-logs-${{ matrix.k8s-version }}
+          name: ${{ matrix.k8s-distro }}test-logs-${{ matrix.k8s-version }}
           path: /home/runner/work/mondoo-operator/mondoo-operator/tests/integration/_output/

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -65,18 +65,18 @@ jobs:
       - name: Run integration tests
         run: K8S_DISTRO=${{ matrix.k8s-distro }} make test/integration/ci
 
-      - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-version }}.xml
+      - run: mv integration-tests.xml integration-tests-${{ matrix.k8s-distro }}-${{ matrix.k8s-version }}.xml
         if: success() || failure()
 
       - uses: actions/upload-artifact@v3  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:                             # upload a combined archive with unit and integration test results
           name: test-results
-          path: ${{ matrix.k8s-distro }}-integration-tests-${{ matrix.k8s-version }}.xml
+          path: integration-tests-${{ matrix.k8s-distro }}-${{ matrix.k8s-version }}.xml
 
       - name: Upload test logs artifact
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: ${{ matrix.k8s-distro }}test-logs-${{ matrix.k8s-version }}
+          name: test-logs-${{ matrix.k8s-distro }}-${{ matrix.k8s-version }}
           path: /home/runner/work/mondoo-operator/mondoo-operator/tests/integration/_output/

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -9,16 +9,19 @@ on:
       MONDOO_CLIENT:
         required: true
 
+env:
+  MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.mondooClientImageTag }}
+
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: Integration tests
-    env:
-      MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.mondooClientImageTag }}
-
+    
     strategy:
       matrix:
         k8s-version: [v1.22.12, v1.23.9, v1.24.3]
+        k8s-distro: [minikube,k3s]
 
     steps:
       - uses: actions/checkout@v2
@@ -26,11 +29,20 @@ jobs:
           fetch-depth: 0 # fetch is nneded for "git tag --list" in the Makefile
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Start minikube
         uses: medyagh/setup-minikube@master
+        if: ${{ matrix.k8s-distro }} == 'minikube'
         with:
           memory: 4000m
           kubernetes-version: ${{ matrix.k8s-version }}
+
+      - name: Start k3s
+        uses: nolar/setup-k3d-k3s@v1
+        if: ${{ matrix.k8s-distro }} == 'k3s'
+        with:
+          version: ${{ matrix.k8s-version }}
+
       - uses: actions/setup-go@v2
         with:
           go-version: "${{ env.golang-version }}"

--- a/Makefile
+++ b/Makefile
@@ -109,15 +109,15 @@ test/ci: manifests generate fmt vet envtest gotestsum
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" $(GOTESTSUM) --junitfile unit-tests.xml -- $(UNIT_TEST_PACKAGES) -coverprofile cover.out
 
 # Integration tests are run synchronously to avoid race conditions
-ifeq ($(K8S_DISTRO),k3s)
-test/integration: manifests generate generate-manifests load-k3s
+ifeq ($(K8S_DISTRO),k3d)
+test/integration: manifests generate generate-manifests load-k3d
 else
 test/integration: manifests generate generate-manifests load-minikube
 endif
 	go test -ldflags $(LDFLAGS) -v -timeout 900s -p 1 ./tests/integration/...
 
-ifeq ($(K8S_DISTRO),k3s)
-test/integration/ci: manifests generate generate-manifests gotestsum load-k3s
+ifeq ($(K8S_DISTRO),k3d)
+test/integration/ci: manifests generate generate-manifests gotestsum load-k3d
 else
 test/integration/ci: manifests generate generate-manifests gotestsum load-minikube
 endif
@@ -138,10 +138,10 @@ docker-build: build ## Build docker image with the manager.
 load-minikube: docker-build ## Build docker image with the manager and load it into minikube.
 	minikube image load ${IMG}
 
-load-k3s: docker-build
+load-k3d: docker-build
 	docker save -o operator.tar ${IMG}
 	docker cp operator.tar k3d-k3s-default-server-0:/tmp/operator.tar
-	docker exec k3d-k3s-default-server-0 ctr -a /run/k3s/containerd/containerd.sock images import -n k8s.io operator.tar
+	docker exec k3d-k3s-default-server-0 ctr -a /run/k3s/containerd/containerd.sock -n k8s.io images import /tmp/operator.tar
 	rm operator.tar
 
 buildah-build: build ## Build container image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Mondoo Operator for Kubernetes
 
 ![CI](https://github.com/mondoohq/mondoo-operator/actions/workflows/tests.yaml/badge.svg)
+![Edge CI](https://github.com/mondoohq/mondoo-operator/actions/workflows/edge-integration-tests.yaml/badge.svg)
 ![License](https://img.shields.io/github/license/mondoohq/mondoo-operator)
 
 > **Project Status**: This project is currently in Early-Access. The API and CRD may change.
@@ -37,7 +38,7 @@ The following Kubernetes environments are tested:
 - GCP GKE 1.22 and 1.23
 - Minikube with Kubernetes versions 1.22, 1.23 and 1.24
 - Rancher RKE1 1.22 and 1.23
-- K3S
+- K3S 1.22, 1.23 and 1.24
 
 ## Documentation
 

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -261,6 +261,7 @@ func (s *AuditConfigBaseSuite) verifyAdmissionWorking(auditConfig mondoov2.Mondo
 	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig, version.Version)
 	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 
+	time.Sleep(10 * time.Second)
 	s.checkPods(&auditConfig)
 }
 


### PR DESCRIPTION
I added k3d to the pipeline. k3d is the minikube equivalent for spinning up a k3s cluster (btw it is blazingly fast compared to minikube).

I also fixed a flaky integration test for the admission controller that was causing issues

Signed-off-by: Ivan Milchev <ivan@mondoo.com>