### PR TITLE
⭐️ Enable workload discovery by default

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,9 @@ spec:
         args:
         - operator
         - --leader-elect
+        env:
+        - name: FEATURE_DISCOVER_WORKLOADS
+          value: "1"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
As discussed we want to enabled workload discovery by default but we still want to leave a "way out of it" if necessary. To do that we just use the feature flag but make sure we set it by default.