### PR TITLE
🧹 check for required APIs at startup

### DIFF
--- a/pkg/utils/k8s/api.go
+++ b/pkg/utils/k8s/api.go
@@ -60,3 +60,31 @@ func VerifyAPI(group, version string, log logr.Logger) (bool, error) {
 	log.Info(fmt.Sprintf("%s/%s API verified", group, version))
 	return true, nil
 }
+
+func VerifyResourceExists(group, version, resource string, log logr.Logger) (bool, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "unable to get k8s config")
+		return false, err
+	}
+
+	k8s, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Error(err, "unable to create k8s client")
+		return false, err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
+
+	exists, err := discovery.IsResourceEnabled(k8s, gvr)
+	if err != nil {
+		log.Error(err, "error while check whether resource exists", "gvr", gvr)
+		return false, err
+	}
+
+	return exists, nil
+}


### PR DESCRIPTION
Rather than fail later while the operator is up and running, just check
whether some of the resources we depend on to operator properly exist
in the cluster.

For the first pass, just check that Jobs exist (to prove that our
checks actually work) and whether CronJobs exist (to catch the case of
an EKS cluster running k8s 1.20 which lacks CronJobs v1 (but happens to
have CronJobs v1beta1)).

Signed-off-by: Joel Diaz <joel@mondoo.com>