### PR TITLE
🐛 Do not fail fast for matrix tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,6 +19,7 @@ jobs:
     name: Integration tests
     
     strategy:
+      fail-fast: false
       matrix:
         k8s-version: [v1.22.13, v1.23.10, v1.24.4]
         k8s-distro: [minikube, k3d]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -262,6 +262,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         k8s-version: [v1.22.13, v1.23.10, v1.24.4]
 
@@ -360,6 +361,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         k8s-version: [v1.22.13, v1.23.10, v1.24.4]
 


### PR DESCRIPTION
Instead of cancelling all test when 1 fails, let them run. 