### PR TITLE
🧹 dependabot ignore k8s.io/api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
       - dependency-name: sigs.k8s.io/controller-runtime
       - dependency-name: k8s.io/apimachinery
       - dependency-name: k8s.io/client-go
+      - dependency-name: k8s.io/api


### PR DESCRIPTION
this dependency is updated as part of updating OperatorSDK versions.

Signed-off-by: Joel Diaz <joel@mondoo.com>