### PR TITLE
⭐️ Enable workload discovery for admission controller

### DIFF
--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -21,6 +21,7 @@ import (
 
 	mondoov1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers/scanapi"
+	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 )
 
 const (
@@ -108,6 +109,7 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 								InitialDelaySeconds: int32(15),
 								PeriodSeconds:       int32(20),
 							},
+							Env:  feature_flags.AllFeatureFlagsAsEnv(),
 							Name: "webhook",
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -213,6 +213,10 @@ func (s *mondooClient) RunKubernetesManifest(ctx context.Context, in *Kubernetes
 type KubernetesManifestJob struct {
 	Files  []*File           `json:"files,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
+	// Additional options for the manifest job
+	Options map[string]string `json:"options,omitempty"`
+	// Additional discovery settings for the manifest job
+	Discovery *inventory.Discovery `json:"discovery,omitempty"`
 }
 
 type File struct {


### PR DESCRIPTION
Enabled workload discovery for the admission controller. This depends on a Mondoo back-end and CLI release before we can fully test it and merge it. Ideally, we merge this and create an operator release once the Mondoo client has been released.