### PR TITLE
🐛 Update operator SDK version for CI

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
 golang-version=1.19
-operator-sdk-version=v1.21.0
+operator-sdk-version=v1.23.0


### PR DESCRIPTION
The release failed because the operator SDK version was never updated for the github env.