### PR TITLE
⭐️ Implement scanning AdmissionReview resources

### DIFF
--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -10,10 +10,11 @@ import (
 const FeatureFlagPrefix = "FEATURE_"
 
 var (
-	enablePodDiscovery      bool
-	enableWorkloadDiscovery bool
-	enableGarbageCollection bool
-	allFeatureFlags         = make(map[string]string)
+	enablePodDiscovery             bool
+	enableWorkloadDiscovery        bool
+	enableGarbageCollection        bool
+	enableAdmissionReviewDiscovery bool
+	allFeatureFlags                = make(map[string]string)
 )
 
 func init() {
@@ -52,6 +53,10 @@ func GetEnableGarbageCollection() bool {
 	return enableGarbageCollection
 }
 
+func GetAdmissionReviewDiscovery() bool {
+	return enableAdmissionReviewDiscovery
+}
+
 func setGlobalFlags(k, v string) {
 	switch k {
 	case "FEATURE_DISCOVER_PODS":
@@ -60,5 +65,7 @@ func setGlobalFlags(k, v string) {
 		enableWorkloadDiscovery = true
 	case "FEATURE_ENABLE_GARBAGE_COLLECTION":
 		enableGarbageCollection = true
+	case "FEATURE_ENABLE_ADMISSION_REVIEW_DISCOVERY":
+		enableAdmissionReviewDiscovery = true
 	}
 }

--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -39,7 +39,6 @@ type Client interface {
 	ExchangeRegistrationToken(context.Context, *ExchangeRegistrationTokenInput) (*ExchangeRegistrationTokenOutput, error)
 
 	HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error)
-	RunKubernetesManifest(context.Context, *KubernetesManifestJob) (*ScanResult, error)
 	RunAdmissionReview(context.Context, *AdmissionReviewJob) (*ScanResult, error)
 	ScanKubernetesResources(ctx context.Context, integrationMrn string, scanContainerImages bool, managedBy string) (*ScanResult, error)
 	ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey string) (*Empty, error)
@@ -189,42 +188,10 @@ type HealthCheckResponse struct {
 }
 
 const (
-	RunKubernetesManifestEndpoint = "/Scan/RunKubernetesManifest"
+	RunAdmissionReviewEndpoint = "/Scan/RunAdmissionReview"
 	// A valid result would come back as a '2'
 	ValidScanResult = uint32(2)
 )
-
-func (s *mondooClient) RunKubernetesManifest(ctx context.Context, in *KubernetesManifestJob) (*ScanResult, error) {
-	url := s.ApiEndpoint + RunKubernetesManifestEndpoint
-
-	reqBodyBytes, err := json.Marshal(in)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %v", err)
-	}
-
-	respBodyBytes, err := s.request(ctx, url, reqBodyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse response: %v", err)
-	}
-
-	out := &ScanResult{}
-	if err = json.Unmarshal(respBodyBytes, out); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal proto response: %v", err)
-	}
-
-	return out, nil
-}
-
-type KubernetesManifestJob struct {
-	Files  []*File           `json:"files,omitempty"`
-	Labels map[string]string `json:"labels,omitempty"`
-	// Additional options for the manifest job
-	Options map[string]string `json:"options,omitempty"`
-	// Additional discovery settings for the manifest job
-	Discovery *inventory.Discovery `json:"discovery,omitempty"`
-}
-
-const RunAdmissionReviewEndpoint = "/Scan/RunAdmissionReview"
 
 func (s *mondooClient) RunAdmissionReview(ctx context.Context, in *AdmissionReviewJob) (*ScanResult, error) {
 	url := s.ApiEndpoint + RunAdmissionReviewEndpoint

--- a/pkg/mondooclient/client_test.go
+++ b/pkg/mondooclient/client_test.go
@@ -41,16 +41,7 @@ func TestScanner(t *testing.T) {
 	err = yaml.Unmarshal(webhookPayload, &request)
 	require.NoError(t, err)
 
-	k8sObjectData, err := yaml.Marshal(request.Object)
-	require.NoError(t, err)
-
-	result, err := mClient.RunKubernetesManifest(context.Background(), &mondooclient.KubernetesManifestJob{
-		Files: []*mondooclient.File{
-			{
-				Data: k8sObjectData,
-			},
-			{},
-		},
+	result, err := mClient.RunAdmissionReview(context.Background(), &mondooclient.AdmissionReviewJob{
 		Labels: map[string]string{
 			"k8s.mondoo.com/author":     request.UserInfo.Username,
 			"k8s.mondoo.com/operation":  string(request.Operation),

--- a/pkg/mondooclient/fakeserver/fakeserver.go
+++ b/pkg/mondooclient/fakeserver/fakeserver.go
@@ -25,7 +25,7 @@ func FakeServer() *httptest.Server {
 		}
 	})
 
-	mux.HandleFunc(mondooclient.RunKubernetesManifestEndpoint, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(mondooclient.RunAdmissionReviewEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		result := &mondooclient.ScanResult{
 			Ok: true,
 			WorstScore: &mondooclient.Score{

--- a/pkg/mondooclient/mock/client_generated.go
+++ b/pkg/mondooclient/mock/client_generated.go
@@ -124,6 +124,21 @@ func (mr *MockClientMockRecorder) IntegrationReportStatus(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntegrationReportStatus", reflect.TypeOf((*MockClient)(nil).IntegrationReportStatus), arg0, arg1)
 }
 
+// RunAdmissionReview mocks base method.
+func (m *MockClient) RunAdmissionReview(arg0 context.Context, arg1 *mondooclient.AdmissionReviewJob) (*mondooclient.ScanResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunAdmissionReview", arg0, arg1)
+	ret0, _ := ret[0].(*mondooclient.ScanResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunAdmissionReview indicates an expected call of RunAdmissionReview.
+func (mr *MockClientMockRecorder) RunAdmissionReview(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAdmissionReview", reflect.TypeOf((*MockClient)(nil).RunAdmissionReview), arg0, arg1)
+}
+
 // RunKubernetesManifest mocks base method.
 func (m *MockClient) RunKubernetesManifest(arg0 context.Context, arg1 *mondooclient.KubernetesManifestJob) (*mondooclient.ScanResult, error) {
 	m.ctrl.T.Helper()

--- a/pkg/mondooclient/mock/client_generated.go
+++ b/pkg/mondooclient/mock/client_generated.go
@@ -139,21 +139,6 @@ func (mr *MockClientMockRecorder) RunAdmissionReview(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAdmissionReview", reflect.TypeOf((*MockClient)(nil).RunAdmissionReview), arg0, arg1)
 }
 
-// RunKubernetesManifest mocks base method.
-func (m *MockClient) RunKubernetesManifest(arg0 context.Context, arg1 *mondooclient.KubernetesManifestJob) (*mondooclient.ScanResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunKubernetesManifest", arg0, arg1)
-	ret0, _ := ret[0].(*mondooclient.ScanResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunKubernetesManifest indicates an expected call of RunKubernetesManifest.
-func (mr *MockClientMockRecorder) RunKubernetesManifest(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunKubernetesManifest", reflect.TypeOf((*MockClient)(nil).RunKubernetesManifest), arg0, arg1)
-}
-
 // ScanKubernetesResources mocks base method.
 func (m *MockClient) ScanKubernetesResources(ctx context.Context, integrationMrn string, scanContainerImages bool, managedBy string) (*mondooclient.ScanResult, error) {
 	m.ctrl.T.Helper()

--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -140,11 +140,15 @@ func (a *webhookValidator) Handle(ctx context.Context, req admission.Request) (r
 		Data:   data,
 		Labels: k8sLabels,
 	}
+
+	scanJob.Discovery = &inventory.Discovery{}
 	if feature_flags.GetEnableWorkloadDiscovery() {
 		scanJob.Options = map[string]string{"all-namespaces": "true"}
-		scanJob.Discovery = &inventory.Discovery{
-			Targets: []string{"pods", "deployments", "daemonsets", "statefulsets", "replicasets", "jobs", "cronjobs"},
-		}
+		scanJob.Discovery.Targets = []string{"pods", "deployments", "daemonsets", "statefulsets", "replicasets", "jobs", "cronjobs"}
+	}
+
+	if feature_flags.GetAdmissionReviewDiscovery() {
+		scanJob.Discovery.Targets = append(scanJob.Discovery.Targets, "admissionreviews")
 	}
 
 	result, err := a.scanner.RunAdmissionReview(ctx, scanJob)


### PR DESCRIPTION
- [ ] Implement RunAdmissionReview scan API endpoint
- [ ] Delete RunKubernetesManifest scan API endpoint
- [ ] Add feature flag for discovering admission review assets (currently, doesn't work because of a bug I introduced in cnquery which is fixed by https://github.com/mondoohq/cnquery/pull/77)