### PR TITLE
🧹 Skip initial scan of cluster resources

### DIFF
--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -126,7 +126,7 @@ func init() {
 			return err
 		}
 
-		if err = resource_monitor.RegisterResourceMonitors(ctx, mgr, scanApiStore); err != nil {
+		if err = resource_monitor.RegisterResourceMonitors(mgr, scanApiStore); err != nil {
 			setupLog.Error(err, "unable to register resource monitors", "controller", "resource_monitor")
 			return err
 		}

--- a/controllers/resource_monitor/debouncer/debouncer_test.go
+++ b/controllers/resource_monitor/debouncer/debouncer_test.go
@@ -35,7 +35,7 @@ func (s *DebouncerSuite) BeforeTest(suiteName, testName string) {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.mockMondooClient = mock.NewMockClient(s.mockCtrl)
 	s.scanApiStore = scanapistoremock.NewMockScanApiStore(s.mockCtrl)
-	s.debouncer = NewDebouncer(s.ctx, s.scanApiStore).(*debouncer)
+	s.debouncer = NewDebouncer(s.scanApiStore).(*debouncer)
 	s.debouncer.flushTimeout = 1 * time.Second
 }
 
@@ -45,7 +45,7 @@ func (s *DebouncerSuite) AfterTest(suiteName, testName string) {
 }
 
 func (s *DebouncerSuite) TestStart_IgnoreInitialResources() {
-	go s.debouncer.Start()
+	go s.debouncer.Start(s.ctx)
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -61,7 +61,7 @@ func (s *DebouncerSuite) TestStart_IgnoreInitialResources() {
 
 func (s *DebouncerSuite) TestStart_Debounce() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start()
+	go s.debouncer.Start(s.ctx)
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -90,7 +90,7 @@ func (s *DebouncerSuite) TestStart_Debounce() {
 
 func (s *DebouncerSuite) TestStart_NoScanApiClients() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start()
+	go s.debouncer.Start(s.ctx)
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -109,7 +109,7 @@ func (s *DebouncerSuite) TestStart_NoScanApiClients() {
 
 func (s *DebouncerSuite) TestStart_MultipleScanApiClients() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start()
+	go s.debouncer.Start(s.ctx)
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {

--- a/controllers/resource_monitor/debouncer/debouncer_test.go
+++ b/controllers/resource_monitor/debouncer/debouncer_test.go
@@ -44,7 +44,23 @@ func (s *DebouncerSuite) AfterTest(suiteName, testName string) {
 	s.mockCtrl.Finish()
 }
 
+func (s *DebouncerSuite) TestStart_IgnoreInitialResources() {
+	go s.debouncer.Start()
+
+	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
+	for _, k := range keys {
+		for i := 0; i < 100; i++ {
+			s.debouncer.Add(k)
+		}
+	}
+
+	time.Sleep(s.debouncer.flushTimeout + 100*time.Millisecond)
+
+	s.Empty(s.debouncer.resources)
+}
+
 func (s *DebouncerSuite) TestStart_Debounce() {
+	s.debouncer.isFirstFlush = false
 	go s.debouncer.Start()
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
@@ -73,6 +89,7 @@ func (s *DebouncerSuite) TestStart_Debounce() {
 }
 
 func (s *DebouncerSuite) TestStart_NoScanApiClients() {
+	s.debouncer.isFirstFlush = false
 	go s.debouncer.Start()
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
@@ -91,6 +108,7 @@ func (s *DebouncerSuite) TestStart_NoScanApiClients() {
 }
 
 func (s *DebouncerSuite) TestStart_MultipleScanApiClients() {
+	s.debouncer.isFirstFlush = false
 	go s.debouncer.Start()
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}

--- a/controllers/resource_monitor/debouncer/mock/debouncer_generated.go
+++ b/controllers/resource_monitor/debouncer/mock/debouncer_generated.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -46,13 +47,13 @@ func (mr *MockDebouncerMockRecorder) Add(res interface{}) *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockDebouncer) Start() {
+func (m *MockDebouncer) Start(ctx context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
+	m.ctrl.Call(m, "Start", ctx)
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockDebouncerMockRecorder) Start() *gomock.Call {
+func (mr *MockDebouncerMockRecorder) Start(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDebouncer)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDebouncer)(nil).Start), ctx)
 }

--- a/controllers/resource_monitor/register.go
+++ b/controllers/resource_monitor/register.go
@@ -9,8 +9,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 package resource_monitor
 
 import (
-	"context"
-
 	"go.mondoo.com/mondoo-operator/controllers/resource_monitor/scan_api_store"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -29,9 +27,9 @@ var resourceTypes = []func() client.Object{
 	func() client.Object { return &batchv1.CronJob{} },
 }
 
-func RegisterResourceMonitors(ctx context.Context, mgr manager.Manager, scanApiStore scan_api_store.ScanApiStore) error {
+func RegisterResourceMonitors(mgr manager.Manager, scanApiStore scan_api_store.ScanApiStore) error {
 	for _, r := range resourceTypes {
-		if err := NewResourceMonitorController(ctx, mgr.GetClient(), r, scanApiStore).SetupWithManager(mgr); err != nil {
+		if err := NewResourceMonitorController(mgr.GetClient(), r, scanApiStore).SetupWithManager(mgr); err != nil {
 			return err
 		}
 	}

--- a/controllers/resource_monitor/resource_monitor_controller_test.go
+++ b/controllers/resource_monitor/resource_monitor_controller_test.go
@@ -44,7 +44,6 @@ func (s *ResourceMonitorControllerSuite) AfterTest(suiteName, testName string) {
 func (s *ResourceMonitorControllerSuite) TestReconcile_Pod() {
 	ctx := context.Background()
 	r := NewResourceMonitorController(
-		ctx,
 		s.fakeClientBuilder.Build(),
 		func() client.Object { return &corev1.Pod{} },
 		nil)


### PR DESCRIPTION
For large clusters it is inconvenient to scan all cluster resources on each operator startup. This PR makes sure the initially observed resources are dumped instead of scanned