### PR TITLE
🧹 Use deployments instead of pods for integration tests

### DIFF
--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -101,7 +101,6 @@ func (a *webhookValidator) Handle(ctx context.Context, req admission.Request) (r
 	}
 
 	obj, err := a.objFromRaw(req.Object)
-	handlerlog.Info("admission obj", "obj", obj)
 	if err == nil {
 		if !shouldScanObject(obj) {
 			handlerlog.Info("skipping because the resource has a parent", "resource", resource)
@@ -162,7 +161,7 @@ func (a *webhookValidator) Handle(ctx context.Context, req admission.Request) (r
 		passed = true
 	}
 
-	handlerlog.Info("Scan result", "shouldAdmit", passed, "kind", req.Kind.Kind, "resource", resource)
+	handlerlog.Info("Scan result", "shouldAdmit", passed, "kind", req.Kind.Kind, "resource", resource, "worstscore", result.WorstScore)
 
 	// Depending on the mode, we either just allow the resource through no matter the scan result
 	// or allow/deny based on the scan result

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -579,13 +579,13 @@ func (s *AuditConfigBaseSuite) getFailingDeployment() *appsv1.Deployment {
 	labels := map[string]string{
 		"admission-result": "fail",
 	}
-	pod := s.getPassingDeployment().DeepCopy()
-	pod.ObjectMeta.Name = "failing-deployment"
-	pod.ObjectMeta.Labels = labels
-	pod.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+	deployment := s.getPassingDeployment().DeepCopy()
+	deployment.ObjectMeta.Name = "failing-deployment"
+	deployment.ObjectMeta.Labels = labels
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 		Privileged: pointer.Bool(true),
 	}
-	return pod
+	return deployment
 }
 
 func (s *AuditConfigBaseSuite) checkDeployments(auditConfig *mondoov2.MondooAuditConfig) {

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -264,7 +264,7 @@ func (s *AuditConfigBaseSuite) verifyAdmissionWorking(auditConfig mondoov2.Mondo
 	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
 
 	time.Sleep(10 * time.Second)
-	s.checkPods(&auditConfig)
+	s.checkDeployments(&auditConfig)
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmissionScaleDownScanApi(auditConfig mondoov2.MondooAuditConfig) {
@@ -506,97 +506,110 @@ func (s *AuditConfigBaseSuite) disableContainerImageResolution() func() {
 	}
 }
 
-func (s *AuditConfigBaseSuite) getPassingPod() *corev1.Pod {
+func (s *AuditConfigBaseSuite) getPassingDeployment() *appsv1.Deployment {
 	labels := map[string]string{
 		"admission-result": "pass",
 	}
-	return &corev1.Pod{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "passing-pod",
+			Name:      "passing-deployment",
 			Namespace: "mondoo-operator",
 			Labels:    labels,
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "ubuntu",
-					Image:           "ubuntu:20.04",
-					Command:         []string{"/bin/sh", "-c"},
-					Args:            []string{"exit 0"},
-					ImagePullPolicy: corev1.PullAlways,
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
-						},
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("100Mi"),
-						},
-					},
-					SecurityContext: &corev1.SecurityContext{
-						RunAsNonRoot:             pointer.Bool(true),
-						RunAsUser:                pointer.Int64(1000),
-						ReadOnlyRootFilesystem:   pointer.Bool(true),
-						AllowPrivilegeEscalation: pointer.Bool(false),
-						Privileged:               pointer.Bool(false),
-					},
-					ReadinessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"/bin/sh", "-c", "exit 0"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: pointer.Bool(false),
+					Containers: []corev1.Container{
+						{
+							Name:            "ubuntu",
+							Image:           "ubuntu:20.04",
+							Command:         []string{"/bin/sh", "-c"},
+							Args:            []string{"exit 0"},
+							ImagePullPolicy: corev1.PullAlways,
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
 							},
-						},
-					},
-					LivenessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"/bin/sh", "-c", "exit 0"},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"NET_RAW"},
+								},
+								RunAsNonRoot:             pointer.Bool(true),
+								RunAsUser:                pointer.Int64(1000),
+								ReadOnlyRootFilesystem:   pointer.Bool(true),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"/bin/sh", "-c", "exit 0"},
+									},
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"/bin/sh", "-c", "exit 0"},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
-			AutomountServiceAccountToken: pointer.Bool(false),
 		},
 	}
 }
 
-func (s *AuditConfigBaseSuite) getFailingPod() *corev1.Pod {
+func (s *AuditConfigBaseSuite) getFailingDeployment() *appsv1.Deployment {
 	labels := map[string]string{
 		"admission-result": "fail",
 	}
-	pod := s.getPassingPod().DeepCopy()
-	pod.ObjectMeta.Name = "failing-pod"
+	pod := s.getPassingDeployment().DeepCopy()
+	pod.ObjectMeta.Name = "failing-deployment"
 	pod.ObjectMeta.Labels = labels
-	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+	pod.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 		Privileged: pointer.Bool(true),
 	}
 	return pod
 }
 
-func (s *AuditConfigBaseSuite) checkPods(auditConfig *mondoov2.MondooAuditConfig) {
-	passingPod := s.getPassingPod()
-	failingPod := s.getFailingPod()
+func (s *AuditConfigBaseSuite) checkDeployments(auditConfig *mondoov2.MondooAuditConfig) {
+	passingDeployment := s.getPassingDeployment()
+	failingDeployment := s.getFailingDeployment()
 
-	zap.S().Info("Create a Pod which should pass.")
+	zap.S().Info("Create a Deployment which should pass.")
 	s.NoErrorf(
-		s.testCluster.K8sHelper.Clientset.Create(s.ctx, passingPod),
-		"Failed to create Pod which should pass.")
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, passingDeployment),
+		"Failed to create Deployment which should pass.")
 
-	zap.S().Info("Create a Pod which should be denied in enforcing mode.")
-	err := s.testCluster.K8sHelper.Clientset.Create(s.ctx, failingPod)
+	zap.S().Info("Create a Deployment which should be denied in enforcing mode.")
+	err := s.testCluster.K8sHelper.Clientset.Create(s.ctx, failingDeployment)
 
 	if auditConfig.Spec.Admission.Mode == mondoov2.Enforcing {
-		s.Errorf(err, "Created Pod which should have been denied.")
+		s.Errorf(err, "Created Deployment which should have been denied.")
 	} else {
-		s.NoErrorf(err, "Failed creating a Pod in permissive mode.")
+		s.NoErrorf(err, "Failed creating a Deployment in permissive mode.")
 	}
 
-	s.NoErrorf(s.testCluster.K8sHelper.DeleteResourceIfExists(passingPod), "Failed to delete passingPod")
-	s.NoErrorf(s.testCluster.K8sHelper.DeleteResourceIfExists(failingPod), "Failed to delete failingPod")
-	s.NoErrorf(s.testCluster.K8sHelper.WaitForResourceDeletion(passingPod), "Error waiting for deleteion of passingPod")
-	s.NoErrorf(s.testCluster.K8sHelper.WaitForResourceDeletion(failingPod), "Error waiting for deleteion of failingPod")
+	s.NoErrorf(s.testCluster.K8sHelper.DeleteResourceIfExists(passingDeployment), "Failed to delete passingDeployment")
+	s.NoErrorf(s.testCluster.K8sHelper.DeleteResourceIfExists(failingDeployment), "Failed to delete failingDeployment")
+	s.NoErrorf(s.testCluster.K8sHelper.WaitForResourceDeletion(passingDeployment), "Error waiting for deleteion of passingDeployment")
+	s.NoErrorf(s.testCluster.K8sHelper.WaitForResourceDeletion(failingDeployment), "Error waiting for deleteion of failingDeployment")
 }
 
 func (s *AuditConfigBaseSuite) getWebhookLabelsString() string {


### PR DESCRIPTION
We added controls to flag individual pods that are not part of another deployment so our integration tests are now failing. We also need to fix:
- Pods should not run with NET_RAW capability
- Pods should not run with SYS_ADMIN capability

They shouldn't flag pods that don't explicitly disable these.