### PR TITLE
turn on garbage collection by default

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,8 @@ spec:
         env:
         - name: FEATURE_DISCOVER_WORKLOADS
           value: "1"
+        - name: FEATURE_ENABLE_GARBAGE_COLLECTION
+          value: "1"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
If you want to disable it unset
FEATURE_ENABLE_GARBAGE_COLLECTION in the operator Deployment.

Signed-off-by: Joel Diaz <joel@mondoo.com>