### PR TITLE
🐛 Do not report error status during an active scan

### DIFF
--- a/pkg/utils/k8s/cron_job.go
+++ b/pkg/utils/k8s/cron_job.go
@@ -14,7 +14,9 @@ import batchv1 "k8s.io/api/batch/v1"
 // successful.
 func AreCronJobsSuccessful(cs []batchv1.CronJob) bool {
 	for _, c := range cs {
-		if c.Status.LastSuccessfulTime.Before(c.Status.LastScheduleTime) {
+		// If there are no active jobs at the moment and the last successful run is not before the last
+		// scheduled job everything is working correctly.
+		if len(c.Status.Active) == 0 && c.Status.LastSuccessfulTime.Before(c.Status.LastScheduleTime) {
 			return false
 		}
 	}


### PR DESCRIPTION
I noticed that we are reporting an error status for each of the scans whenever the scan is actually active. This PR fixes the bug and adds a test for that case.