### PR TITLE
🧹 Re-work PR workflows

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -8,26 +8,19 @@ on:
     secrets:
       MONDOO_CLIENT:
         required: true
-  workflow_run:
-    workflows: ["Unit Tests"]
-    types:
-      - completed
 
 env:
   MONDOO_CLIENT_IMAGE_TAG: ${{ github.event.inputs.mondooClientImageTag }}
 
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
-      contents: read
-      pull-requests: read
-      actions: read
-# Attention: These jobs still have access to all the secrets when triggered by a workflow_run event.
+  contents: read
+# Attention: These jobs still have access to all the secrets.
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: Integration tests
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_call'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security-tests.yaml
+++ b/.github/workflows/security-tests.yaml
@@ -4,23 +4,16 @@ on:
     secrets:
       MONDOO_CLIENT:
         required: true
-  workflow_run:
-    workflows: ["Unit Tests"]
-    types:
-      - completed
 
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
-      contents: read
-      pull-requests: read
-      actions: read
-# Attention: These jobs still have access to all the secrets when triggered by a workflow_run event.
+  contents: read
+# Attention: These jobs still have access to all the secrets.
 
 jobs:
   security-tests:
     runs-on: ubuntu-latest
     name: Security tests
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_call'
     env:
       # Use docker.io for Docker Hub if empty
       REGISTRY: ghcr.io

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: remove labels
-        uses: andymckay/labeler@v1
+        uses: andymckay/labeler@1.0.4
         with:
           remove-labels: "ok to test"
   unit-tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Check label
     runs-on: ubuntu-latest
     if: |
-      !github.event.pull_request.head.repo.fork
+      (!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
       || (github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok to test'))
       || (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,6 @@
 name: Run Test
 on:
+  pull_request:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
   push:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,7 @@
-name: Unit Tests
+name: Run Test
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
   push:
     paths-ignore:
       - 'docs/**'
@@ -9,32 +10,39 @@ on:
     tags: ["v*.*.*"]
 
 jobs:
-  unit-tests:
+  check-label:
+    name: Check label
     runs-on: ubuntu-latest
-    name: Unit tests
+    if: |
+      !github.event.repository.fork
+      || (github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok to test'))
+      || (github.event.repository.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - name: remove labels
+        uses: andymckay/labeler@v1
         with:
-          persist-credentials: false
-      - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "${{ env.golang-version }}"
-      
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - run: make test/ci
-      - uses: actions/upload-artifact@v3  # upload test results
-        if: success() || failure()        # run this step even if previous step failed
-        with:
-          name: test-results
-          path: unit-tests.xml
-   
+          remove-labels: "ok to test"
+  unit-tests:
+    needs: [check-label]
+    if: needs.check-label.result == 'success'
+    uses: ./.github/workflows/unit-tests.yaml
+    name: Unit tests
+  security-tests:
+    name: Security tests
+    needs: [unit-tests]
+    if: needs.unit-tests.result == 'success'
+    uses: ./.github/workflows/security-tests.yaml
+    with:
+      mondooClientImageTag: ""
+    secrets: inherit
+  integration-tests:
+    name: Integration tests
+    needs: [unit-tests]
+    if: needs.unit-tests.result == 'success'
+    uses: ./.github/workflows/integration-tests.yaml
+    with:
+      mondooClientImageTag: ""
+    secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,9 @@ jobs:
     name: Check label
     runs-on: ubuntu-latest
     if: |
-      !github.event.repository.fork
+      !github.event.pull_request.head.repo.fork
       || (github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok to test'))
-      || (github.event.repository.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
+      || (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,10 @@ on:
       - "main"
     tags: ["v*.*.*"]
 
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+permissions:
+  contents: read
+
 jobs:
   check-label:
     name: Check label

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,6 @@ jobs:
     needs: [unit-tests]
     if: needs.unit-tests.result == 'success'
     uses: ./.github/workflows/security-tests.yaml
-    with:
-      mondooClientImageTag: ""
     secrets: inherit
   integration-tests:
     name: Integration tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,40 @@
+name: Unit Tests
+on:
+  workflow_call:
+
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+permissions:
+  contents: read
+# Attention: These jobs still have access to all the secrets.
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.golang-version }}"
+      
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - run: make test/ci
+      - uses: actions/upload-artifact@v3  # upload test results
+        if: success() || failure()        # run this step even if previous step failed
+        with:
+          name: test-results
+          path: unit-tests.xml
+   


### PR DESCRIPTION
This will bring back the integration and security tests into the PR.

It will also allow us dependabot and fork PRs. But we need to apply a label, before the tests start.

The label is also directly removed after the workflow starts, to prevent later commits from just starting the tests again.

Signed-off-by: Christian Zunker <christian@mondoo.com>