### PR TITLE
🐛 Use separate entrypoints to workflows

### DIFF
--- a/.github/workflows/tests-forks.yaml
+++ b/.github/workflows/tests-forks.yaml
@@ -1,6 +1,7 @@
-name: Run Test
+name: Run Test (forks & dependabot)
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
   push:
     paths-ignore:
       - 'docs/**'
@@ -17,7 +18,8 @@ jobs:
     name: Check label
     runs-on: ubuntu-latest
     if: |
-      !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'      
+      (github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok to test'))
+      || (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,22 +13,9 @@ permissions:
   contents: read
 
 jobs:
-  check-label:
-    name: Check label
-    runs-on: ubuntu-latest
-    if: |
-      !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'      
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - name: remove labels
-        uses: andymckay/labeler@1.0.4
-        with:
-          remove-labels: "ok to test"
   unit-tests:
-    needs: [check-label]
-    if: needs.check-label.result == 'success'
+    if: |
+      !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/unit-tests.yaml
     name: Unit tests
   security-tests:


### PR DESCRIPTION
This prevents duplicate workflow runs for non-forks/dependabot PRs

Signed-off-by: Christian Zunker <christian@mondoo.com>