### PR TITLE
🧹 webhook shouldn't use default serviceaccount

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -97,6 +97,10 @@ type Admission struct {
 	// +kubebuilder:default=1
 	Replicas                *int32                  `json:"replicas,omitempty"`
 	CertificateProvisioning CertificateProvisioning `json:"certificateProvisioning,omitempty"`
+	// ServiceAccountName specifies the Kubernetes ServiceAccount the webhook should use
+	// during its operation.
+	// +kubebuilder:default=mondoo-operator-webhook
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type Image struct {

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -78,6 +78,11 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
+                  serviceAccountName:
+                    default: mondoo-operator-webhook
+                    description: ServiceAccountName specifies the Kubernetes ServiceAccount
+                      the webhook should use during its operation.
+                    type: string
                 type: object
               consoleIntegration:
                 properties:

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -20,5 +20,4 @@ resources:
 - k8s_resources_scanning_service_account.yaml
 - k8s_resources_scanning_clusterrole.yaml
 - k8s_resources_scanning_clusterrolebinding.yaml
-
-
+- webhook_service_account.yaml

--- a/config/rbac/webhook_service_account.yaml
+++ b/config/rbac/webhook_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook
+  namespace: system

--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -160,6 +160,7 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: pointer.Bool(true),
 					},
+					ServiceAccountName:            m.Spec.Admission.ServiceAccountName,
 					TerminationGracePeriodSeconds: pointer.Int64(10),
 					Volumes: []corev1.Volume{
 						{

--- a/controllers/admission/resources.go
+++ b/controllers/admission/resources.go
@@ -160,6 +160,8 @@ func WebhookDeployment(ns, image string, m mondoov1alpha2.MondooAuditConfig, int
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: pointer.Bool(true),
 					},
+					// service account used during the initial bringup of the webhook
+					// by the supporting controller-runtime packages
 					ServiceAccountName:            m.Spec.Admission.ServiceAccountName,
 					TerminationGracePeriodSeconds: pointer.Int64(10),
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
it is considered bad form to use the 'default' ServiceAccount in any Namespace. give the webhook its own ServiceAccount (with no special permissions associated with it), and use that webhook.

Extend the MondooAuditConfig for the case where a MondooAuditConfig is installed somewhere besides 'mondoo-operator' so that a user can provide/specify their own SerivceAccount in whatever Namespace the MondooAuditConfig was installed onto.

Signed-off-by: Joel Diaz <joel@mondoo.com>