### PR TITLE
🐛 Set managedBy when scanning resources via the resource monitor

### DIFF
--- a/controllers/resource_monitor/debouncer/debouncer_test.go
+++ b/controllers/resource_monitor/debouncer/debouncer_test.go
@@ -35,7 +35,7 @@ func (s *DebouncerSuite) BeforeTest(suiteName, testName string) {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.mockMondooClient = mock.NewMockClient(s.mockCtrl)
 	s.scanApiStore = scanapistoremock.NewMockScanApiStore(s.mockCtrl)
-	s.debouncer = NewDebouncer(s.scanApiStore, "").(*debouncer)
+	s.debouncer = NewDebouncer(s.scanApiStore).(*debouncer)
 	s.debouncer.flushTimeout = 1 * time.Second
 }
 
@@ -45,7 +45,7 @@ func (s *DebouncerSuite) AfterTest(suiteName, testName string) {
 }
 
 func (s *DebouncerSuite) TestStart_IgnoreInitialResources() {
-	go s.debouncer.Start(s.ctx)
+	go s.debouncer.Start(s.ctx, "")
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -61,7 +61,7 @@ func (s *DebouncerSuite) TestStart_IgnoreInitialResources() {
 
 func (s *DebouncerSuite) TestStart_Debounce() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start(s.ctx)
+	go s.debouncer.Start(s.ctx, "")
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -90,8 +90,7 @@ func (s *DebouncerSuite) TestStart_Debounce() {
 
 func (s *DebouncerSuite) TestStart_DebounceManagedBy() {
 	s.debouncer.isFirstFlush = false
-	s.debouncer.managedBy = "test"
-	go s.debouncer.Start(s.ctx)
+	go s.debouncer.Start(s.ctx, "test")
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -120,7 +119,7 @@ func (s *DebouncerSuite) TestStart_DebounceManagedBy() {
 
 func (s *DebouncerSuite) TestStart_NoScanApiClients() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start(s.ctx)
+	go s.debouncer.Start(s.ctx, "")
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {
@@ -139,7 +138,7 @@ func (s *DebouncerSuite) TestStart_NoScanApiClients() {
 
 func (s *DebouncerSuite) TestStart_MultipleScanApiClients() {
 	s.debouncer.isFirstFlush = false
-	go s.debouncer.Start(s.ctx)
+	go s.debouncer.Start(s.ctx, "")
 
 	keys := []string{"pod:default:test", "deployment:test-ns:dep"}
 	for _, k := range keys {

--- a/controllers/resource_monitor/debouncer/mock/debouncer_generated.go
+++ b/controllers/resource_monitor/debouncer/mock/debouncer_generated.go
@@ -47,13 +47,13 @@ func (mr *MockDebouncerMockRecorder) Add(res interface{}) *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockDebouncer) Start(ctx context.Context) {
+func (m *MockDebouncer) Start(ctx context.Context, managedBy string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start", ctx)
+	m.ctrl.Call(m, "Start", ctx, managedBy)
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockDebouncerMockRecorder) Start(ctx interface{}) *gomock.Call {
+func (mr *MockDebouncerMockRecorder) Start(ctx, managedBy interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDebouncer)(nil).Start), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDebouncer)(nil).Start), ctx, managedBy)
 }

--- a/controllers/resource_monitor/register.go
+++ b/controllers/resource_monitor/register.go
@@ -29,7 +29,11 @@ var resourceTypes = []func() client.Object{
 
 func RegisterResourceMonitors(mgr manager.Manager, scanApiStore scan_api_store.ScanApiStore) error {
 	for _, r := range resourceTypes {
-		if err := NewResourceMonitorController(mgr.GetClient(), r, scanApiStore).SetupWithManager(mgr); err != nil {
+		resMon, err := NewResourceMonitorController(mgr.GetClient(), r, scanApiStore)
+		if err != nil {
+			return err
+		}
+		if err := resMon.SetupWithManager(mgr); err != nil {
 			return err
 		}
 	}

--- a/controllers/resource_monitor/resource_monitor_controller_test.go
+++ b/controllers/resource_monitor/resource_monitor_controller_test.go
@@ -43,10 +43,11 @@ func (s *ResourceMonitorControllerSuite) AfterTest(suiteName, testName string) {
 
 func (s *ResourceMonitorControllerSuite) TestReconcile_Pod() {
 	ctx := context.Background()
-	r := NewResourceMonitorController(
+	r, err := NewResourceMonitorController(
 		s.fakeClientBuilder.Build(),
 		func() client.Object { return &corev1.Pod{} },
 		nil)
+	s.Require().NoError(err)
 	r.debouncer = s.debouncerMock
 
 	ns := utils.RandString(10)

--- a/controllers/resource_monitor/resource_monitor_controller_test.go
+++ b/controllers/resource_monitor/resource_monitor_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/mondoo-operator/controllers/resource_monitor/debouncer/mock"
 	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +35,7 @@ type ResourceMonitorControllerSuite struct {
 func (s *ResourceMonitorControllerSuite) BeforeTest(suiteName, testName string) {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.debouncerMock = mock.NewMockDebouncer(s.mockCtrl)
-	s.fakeClientBuilder = fake.NewClientBuilder()
+	s.fakeClientBuilder = fake.NewClientBuilder().WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})
 }
 
 func (s *ResourceMonitorControllerSuite) AfterTest(suiteName, testName string) {

--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -41,7 +41,7 @@ type Client interface {
 	HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error)
 	RunAdmissionReview(context.Context, *AdmissionReviewJob) (*ScanResult, error)
 	ScanKubernetesResources(ctx context.Context, integrationMrn string, scanContainerImages bool, managedBy string) (*ScanResult, error)
-	ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey string) (*Empty, error)
+	ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey, managedBy string) (*Empty, error)
 	GarbageCollectAssets(context.Context, *garbagecollection.GarbageCollectOptions) error
 
 	IntegrationRegister(context.Context, *IntegrationRegisterInput) (*IntegrationRegisterOutput, error)
@@ -316,7 +316,7 @@ type Empty struct{}
 
 const ScheduleKubernetesResourceScanEndpoint = "/Scan/Schedule"
 
-func (s *mondooClient) ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey string) (*Empty, error) {
+func (s *mondooClient) ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey, managedBy string) (*Empty, error) {
 	url := s.ApiEndpoint + ScheduleKubernetesResourceScanEndpoint
 	scanJob := ScanJob{
 		ReportType: ReportType_ERROR,
@@ -336,6 +336,10 @@ func (s *mondooClient) ScheduleKubernetesResourceScan(ctx context.Context, integ
 				},
 			},
 		},
+	}
+
+	if len(managedBy) > 0 {
+		scanJob.Inventory.Spec.Assets[0].ManagedBy = managedBy
 	}
 
 	setIntegrationMrn(integrationMrn, &scanJob)

--- a/pkg/mondooclient/mock/client_generated.go
+++ b/pkg/mondooclient/mock/client_generated.go
@@ -155,16 +155,16 @@ func (mr *MockClientMockRecorder) ScanKubernetesResources(ctx, integrationMrn, s
 }
 
 // ScheduleKubernetesResourceScan mocks base method.
-func (m *MockClient) ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey string) (*mondooclient.Empty, error) {
+func (m *MockClient) ScheduleKubernetesResourceScan(ctx context.Context, integrationMrn, resourceKey, managedBy string) (*mondooclient.Empty, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScheduleKubernetesResourceScan", ctx, integrationMrn, resourceKey)
+	ret := m.ctrl.Call(m, "ScheduleKubernetesResourceScan", ctx, integrationMrn, resourceKey, managedBy)
 	ret0, _ := ret[0].(*mondooclient.Empty)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ScheduleKubernetesResourceScan indicates an expected call of ScheduleKubernetesResourceScan.
-func (mr *MockClientMockRecorder) ScheduleKubernetesResourceScan(ctx, integrationMrn, resourceKey interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ScheduleKubernetesResourceScan(ctx, integrationMrn, resourceKey, managedBy interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleKubernetesResourceScan", reflect.TypeOf((*MockClient)(nil).ScheduleKubernetesResourceScan), ctx, integrationMrn, resourceKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleKubernetesResourceScan", reflect.TypeOf((*MockClient)(nil).ScheduleKubernetesResourceScan), ctx, integrationMrn, resourceKey, managedBy)
 }


### PR DESCRIPTION
There are certain resources that are not getting garbage collected correctly. I believe it's because they are missing the `managedBy` field. I cannot confirm 100% that this is the root cause for the issue, since I cannot check it in the database but this is a bug anyhow.