### PR TITLE
🐛 Fix integration test reporting

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -1,7 +1,7 @@
 name: 'Test Report'
 on:
   workflow_run:
-    workflows: ['Tests', 'Edge integration tests'] # runs after tests
+    workflows: ['Integration tests', 'Edge integration tests'] # runs after tests
     types:
       - completed
 jobs:


### PR DESCRIPTION
The test reporting is currently broken for our integration tests. This PR fixes that