### PR TITLE
🐛 Check for user login

### DIFF
--- a/.github/workflows/tests-forks.yaml
+++ b/.github/workflows/tests-forks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # sender.login is needed for runs re-triggered from GitHub UI
     if: |
-      ((github.actor == 'dependabot[bot]' || github.event.sender.login == 'dependabot[bot]') && contains(github.event.pull_request.labels.*.name, 'ok to test'))
+      (github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok to test'))
       || (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'ok to test'))
     permissions:
       issues: write


### PR DESCRIPTION
When we apply the label, the actor is changed to our user. Same for the previous login field. That prevented the checks from starting. Only a `@dependabot rebase` or `@dependabot recreate` triggered the checks again.

This field holds the dependabot user, even when we apply a label.

Signed-off-by: Christian Zunker <christian@mondoo.com>