### PR TITLE
🧹 Add debugging output to publish workflow

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,57 @@
+name: Publish Container Images (workflow_run)
+on:
+  workflow_run:
+    workflows: ['Publish Container Images']
+    types:
+      - completed
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  RELEASE: ${{ github.ref_name }}
+
+jobs:
+  debug-event:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Print workflow actor
+        run: echo "${{ toJSON(github.actor) }}"
+      - name: Print workflow event
+        run: jq '.' $GITHUB_EVENT_PATH
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [amd64, arm64, arm]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=main
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+          flavor: |
+            suffix=-${{ matrix.arch }},onlatest=true
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata (without suffixes)
+        id: meta_clean
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,13 @@ env:
   RELEASE: ${{ github.ref_name }}
 
 jobs:
+  debug-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print workflow actor
+        run: echo "${{ toJSON(github.actor) }}"
+      - name: Print workflow event
+        run: jq '.' $GITHUB_EVENT_PATH
   build-operator:
     name: Build operator binaries
     runs-on: ubuntu-latest
@@ -399,9 +406,7 @@ jobs:
           kubernetes-version: ${{ matrix.k8s-version }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: "v3.8.0" # default is latest stable
+        uses: azure/setup-helm@v3
         id: install
 
       - name: Store creds
@@ -457,9 +462,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: "v3.8.0" # default is latest stable
+        uses: azure/setup-helm@v3
         id: install
 
       - name: Run chart-releaser


### PR DESCRIPTION
Our workflows currently fail when publish is triggered by a dependabot PR. Again becasue of missing access to secrets.

This debug output should provide the data to decide on how to progress.

Signed-off-by: Christian Zunker <christian@mondoo.com>