### PR TITLE
🐛 Do not show stack traces on error

### DIFF
--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -8,8 +8,9 @@ import (
 
 func NewLogger() logr.Logger {
 	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.RFC3339TimeEncoder,
+		Development:     true,
+		StacktraceLevel: zapcore.DPanicLevel,
+		TimeEncoder:     zapcore.RFC3339TimeEncoder,
 	}
 	return zap.New(zap.UseFlagOptions(&opts))
 }


### PR DESCRIPTION
This setting will only show stack traces on panic.

Fixes #684

Signed-off-by: Christian Zunker <christian@mondoo.com>