### PR TITLE
⭐️ Add cnspec feature flag

### DIFF
--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -12,6 +12,7 @@ const FeatureFlagPrefix = "FEATURE_"
 var (
 	enableGarbageCollection        bool
 	enableAdmissionReviewDiscovery bool
+	enableCnspec                   bool
 	allFeatureFlags                = make(map[string]string)
 )
 
@@ -47,11 +48,17 @@ func GetAdmissionReviewDiscovery() bool {
 	return enableAdmissionReviewDiscovery
 }
 
+func GetEnableCnspec() bool {
+	return enableCnspec
+}
+
 func setGlobalFlags(k, v string) {
 	switch k {
 	case "FEATURE_ENABLE_GARBAGE_COLLECTION":
 		enableGarbageCollection = true
 	case "FEATURE_ENABLE_ADMISSION_REVIEW_DISCOVERY":
 		enableAdmissionReviewDiscovery = true
+	case "FEATURE_ENABLE_CNSPEC":
+		enableCnspec = true
 	}
 }

--- a/pkg/utils/mondoo/container_image_resolver.go
+++ b/pkg/utils/mondoo/container_image_resolver.go
@@ -15,13 +15,18 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 	"go.mondoo.com/mondoo-operator/pkg/imagecache"
 	"go.mondoo.com/mondoo-operator/pkg/version"
 )
 
 const (
-	MondooClientImage        = "docker.io/mondoo/client"
-	MondooClientTag          = "7-rootless"
+	MondooClientImage = "docker.io/mondoo/client"
+	MondooClientTag   = "7-rootless"
+	CnspecImage       = "docker.io/ivanmilchev/test"
+	// CnspecImage              = "docker.io/mondoo/cnspec"
+	// CnspecTag                = "7-rootless"
+	CnspecTag                = "api"
 	OpenShiftMondooClientTag = "7-ubi-rootless"
 	MondooOperatorImage      = "ghcr.io/mondoohq/mondoo-operator"
 )
@@ -58,10 +63,21 @@ func NewContainerImageResolver(isOpenShift bool) ContainerImageResolver {
 
 func (c *containerImageResolver) MondooClientImage(userImage, userTag string, skipImageResolution bool) (string, error) {
 	defaultTag := MondooClientTag
-	if c.resolveForOpenShift {
+
+	// TODO: we don't have a UBI container for cnspec yet so we cannot use this tag
+	if c.resolveForOpenShift && !feature_flags.GetEnableCnspec() {
 		defaultTag = OpenShiftMondooClientTag
 	}
-	image := userImageOrDefault(MondooClientImage, defaultTag, userImage, userTag)
+
+	if feature_flags.GetEnableCnspec() {
+		defaultTag = CnspecTag
+	}
+
+	defaultImage := MondooClientImage
+	if feature_flags.GetEnableCnspec() {
+		defaultImage = CnspecImage
+	}
+	image := userImageOrDefault(defaultImage, defaultTag, userImage, userTag)
 	return c.resolveImage(image, skipImageResolution)
 }
 

--- a/pkg/utils/mondoo/container_image_resolver.go
+++ b/pkg/utils/mondoo/container_image_resolver.go
@@ -21,12 +21,10 @@ import (
 )
 
 const (
-	MondooClientImage = "docker.io/mondoo/client"
-	MondooClientTag   = "7-rootless"
-	CnspecImage       = "docker.io/ivanmilchev/test"
-	// CnspecImage              = "docker.io/mondoo/cnspec"
-	// CnspecTag                = "7-rootless"
-	CnspecTag                = "api"
+	MondooClientImage        = "docker.io/mondoo/client"
+	MondooClientTag          = "7-rootless"
+	CnspecImage              = "docker.io/mondoo/cnspec"
+	CnspecTag                = "7-rootless"
 	OpenShiftMondooClientTag = "7-ubi-rootless"
 	MondooOperatorImage      = "ghcr.io/mondoohq/mondoo-operator"
 )

--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -5,6 +5,12 @@ const MondooNamespace = "mondoo-operator"
 type Settings struct {
 	Namespace      string
 	installRelease bool
+	enableCnspec   bool
+}
+
+func (s Settings) EnableCnspec() Settings {
+	s.enableCnspec = true
+	return s
 }
 
 func NewDefaultSettings() Settings {

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -49,15 +49,21 @@ type AuditConfigBaseSuite struct {
 	testCluster    *TestCluster
 	auditConfig    mondoov2.MondooAuditConfig
 	installRelease bool
+	enableCnspec   bool
 }
 
 func (s *AuditConfigBaseSuite) SetupSuite() {
 	s.ctx = context.Background()
+	settings := installer.NewDefaultSettings()
 	if s.installRelease {
-		s.testCluster = StartTestCluster(installer.NewReleaseSettings(), s.T)
-	} else {
-		s.testCluster = StartTestCluster(installer.NewDefaultSettings(), s.T)
+		settings = installer.NewReleaseSettings()
 	}
+
+	if s.enableCnspec {
+		settings = settings.EnableCnspec()
+	}
+
+	s.testCluster = StartTestCluster(settings, s.T)
 }
 
 func (s *AuditConfigBaseSuite) TearDownSuite() {

--- a/tests/integration/audit_config_cnspec_test.go
+++ b/tests/integration/audit_config_cnspec_test.go
@@ -1,0 +1,63 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/tests/framework/utils"
+	"go.uber.org/zap"
+	"k8s.io/utils/pointer"
+)
+
+type AuditConfigCnspecSuite struct {
+	AuditConfigBaseSuite
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_AllDisabled() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false)
+	s.testMondooAuditConfigAllDisabled(auditConfig)
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_KubernetesResources() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false)
+	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
+	s.testMondooAuditConfigKubernetesResources(auditConfig)
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_Nodes() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false)
+	s.testMondooAuditConfigNodes(auditConfig)
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionPermissive() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	s.testMondooAuditConfigAdmission(auditConfig)
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionEnforcing() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
+	s.testMondooAuditConfigAdmission(auditConfig)
+}
+
+func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionEnforcingScaleDownScanApi() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
+	auditConfig.Spec.Admission.Replicas = pointer.Int32(1)
+	auditConfig.Spec.Scanner.Replicas = pointer.Int32(1)
+	s.testMondooAuditConfigAdmissionScaleDownScanApi(auditConfig)
+}
+
+func TestAuditConfigCnspecSuite(t *testing.T) {
+	s := new(AuditConfigCnspecSuite)
+	s.enableCnspec = true
+	defer func(s *AuditConfigCnspecSuite) {
+		HandlePanics(recover(), func() {
+			if err := s.testCluster.UninstallOperator(); err != nil {
+				zap.S().Errorf("Failed to uninstall Mondoo operator. %v", err)
+			}
+		}, s.T)
+	}(s)
+	suite.Run(t, s)
+}


### PR DESCRIPTION
Integrate cnspec into the operator. For now I added a feature flag that allows us to switch between mondoo and cnspec so we can easily test the cnspec integration without bothering other users:

- [x] add feature flag
- [x] get proper cnspec container released that includes the scan API
- [x] validate admission controller works
- [x] validate nodes scanning works
- [x] validate cluster scanning works
- [x] extend integration tests to verify the cnspec flow 