### PR TITLE
🐛 Use error report type for admission controller

### DIFF
--- a/pkg/webhooks/handler/webhook.go
+++ b/pkg/webhooks/handler/webhook.go
@@ -180,8 +180,9 @@ func (a *webhookValidator) Handle(ctx context.Context, req admission.Request) (r
 		return
 	}
 	scanJob := &mondooclient.AdmissionReviewJob{
-		Data:   data,
-		Labels: k8sLabels,
+		Data:       data,
+		Labels:     k8sLabels,
+		ReportType: mondooclient.ReportType_ERROR,
 	}
 
 	scanJob.Discovery = &inventory.Discovery{}


### PR DESCRIPTION
Lowers the memory usage for the admission controller by not requesting the full scan report from the scan API