### PR TITLE
🐛 Do not use edge tag for cnspec

### DIFF
--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -13,6 +13,10 @@ func (s Settings) EnableCnspec() Settings {
 	return s
 }
 
+func (s Settings) GetEnableCnspec() bool {
+	return s.enableCnspec
+}
+
 func NewDefaultSettings() Settings {
 	return Settings{Namespace: MondooNamespace, installRelease: false}
 }

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -29,7 +29,7 @@ func init() {
 // make sure a test passes (e.g. setting the correct secret name). Values which have defaults are not set.
 // This means that using this function in unit tests might result in strange behavior. For unit tests use
 // DefaultAuditConfig instead.
-func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission bool) mondoov2.MondooAuditConfig {
+func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission, enableCnspec bool) mondoov2.MondooAuditConfig {
 	auditConfig := mondoov2.MondooAuditConfig{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "mondoo-client",
@@ -43,7 +43,8 @@ func DefaultAuditConfigMinimal(ns string, workloads, nodes, admission bool) mond
 		},
 	}
 
-	if mondooClientImageTag != "" {
+	// cnspec doesn't get edge releases at the moment, so we cannot test that
+	if mondooClientImageTag != "" && !enableCnspec {
 		auditConfig.Spec.Scanner.Image.Tag = mondooClientImageTag
 		zap.S().Infof("Using image %s:%s for mondoo-client", mondoo.MondooClientImage, mondooClientImageTag)
 	}

--- a/tests/integration/audit_config_cnspec_test.go
+++ b/tests/integration/audit_config_cnspec_test.go
@@ -15,34 +15,34 @@ type AuditConfigCnspecSuite struct {
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_AllDisabled() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigAllDisabled(auditConfig)
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_KubernetesResources() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_Nodes() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigNodes(auditConfig)
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionPermissive() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionEnforcing() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
 func (s *AuditConfigCnspecSuite) TestReconcile_AdmissionEnforcingScaleDownScanApi() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
 	auditConfig.Spec.Admission.Replicas = pointer.Int32(1)
 	auditConfig.Spec.Scanner.Replicas = pointer.Int32(1)

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -76,27 +76,27 @@ func (s *AuditConfigCustomNamespaceSuite) TearDownSuite() {
 }
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_KubernetesResources() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, true, false, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, true, false, false, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
 	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Nodes() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, true, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, true, false, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
 	s.testMondooAuditConfigNodes(auditConfig)
 }
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Admission() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
 	auditConfig.Spec.Admission.ServiceAccountName = s.webhookServiceAccount.Name
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_AdmissionMissingSA() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Scanner.ServiceAccountName = "missing-serviceaccount"
 	auditConfig.Spec.Admission.ServiceAccountName = s.webhookServiceAccount.Name
 	s.testMondooAuditConfigAdmissionMissingSA(auditConfig)

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -15,34 +15,34 @@ type AuditConfigSuite struct {
 }
 
 func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigAllDisabled(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.KubernetesResources.ContainerImageScanning = true
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_Nodes() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigNodes(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_AdmissionPermissive() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_AdmissionEnforcing() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
 	s.testMondooAuditConfigAdmission(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_AdmissionEnforcingScaleDownScanApi() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, s.testCluster.Settings.GetEnableCnspec())
 	auditConfig.Spec.Admission.Mode = v1alpha2.Enforcing
 	auditConfig.Spec.Admission.Replicas = pointer.Int32(1)
 	auditConfig.Spec.Scanner.Replicas = pointer.Int32(1)

--- a/tests/integration/audit_config_upgrade_test.go
+++ b/tests/integration/audit_config_upgrade_test.go
@@ -24,7 +24,7 @@ func (s *AuditConfigUpgradeSuite) TearDownSuite() {
 }
 
 func (s *AuditConfigUpgradeSuite) TestUpgradePreviousReleaseToLatest() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, true, true)
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, true, true, s.testCluster.Settings.GetEnableCnspec())
 	s.testUpgradePreviousReleaseToLatest(auditConfig)
 }
 


### PR DESCRIPTION
Since cnspec doesn't have edge releases at the moment, the edge tests are failing. This PR makes sure edge tag is not used for cnspec.