### PR TITLE
🐛 Fix nightly build and set operator commit in binary

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,6 +91,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=main
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
 
       - name: Build binaries
         run: VERSION=${{ steps.meta_clean.outputs.version }} TARGET_OS=${{ matrix.os }} TARGET_ARCH=${{ matrix.arch }} make build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= sha256-$(shell git rev-parse HEAD).sig
 
+COMMIT_SHA ?= $(shell git rev-parse HEAD)
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -73,7 +75,7 @@ TARGET_ARCH?=$(shell go env GOARCH)
 TARGET_OS?=$(shell go env GOOS)
 
 # Linker flags to build the operator binary
-LDFLAGS="-s -w -X go.mondoo.com/mondoo-operator/pkg/version.Version=$(VERSION)"
+LDFLAGS="-s -w -X go.mondoo.com/mondoo-operator/pkg/version.Version=$(VERSION) -X go.mondoo.com/mondoo-operator/pkg/version.Commit=$(COMMIT_SHA)"
 
 all: build
 

--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -146,7 +146,7 @@ func init() {
 			return err
 		}
 
-		setupLog.Info("starting manager", "operator-version", version.Version, "k8s-version", v.GitVersion)
+		setupLog.Info("starting manager", "operator-version", version.Version, "operator-commit", version.Commit, "k8s-version", v.GitVersion)
 		if err := mgr.Start(ctx); err != nil {
 			setupLog.Error(err, "problem running manager")
 			return err

--- a/cmd/mondoo-operator/version/cmd.go
+++ b/cmd/mondoo-operator/version/cmd.go
@@ -11,6 +11,6 @@ var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the Mondoo Operator version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.Version)
+		fmt.Println(fmt.Sprintf("Version: %s Commit: %s", version.Version, version.Commit))
 	},
 }

--- a/cmd/mondoo-operator/version/cmd.go
+++ b/cmd/mondoo-operator/version/cmd.go
@@ -11,6 +11,6 @@ var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the Mondoo Operator version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(fmt.Sprintf("Version: %s Commit: %s", version.Version, version.Commit))
+		fmt.Printf("Version: %s Commit: %s", version.Version, version.Commit)
 	},
 }

--- a/cmd/mondoo-operator/webhook/cmd.go
+++ b/cmd/mondoo-operator/webhook/cmd.go
@@ -72,7 +72,7 @@ func init() {
 		}
 
 		// Setup webhooks
-		webhookLog.Info("setting up webhook server", "version", version.Version)
+		webhookLog.Info("setting up webhook server", "version", version.Version, "commit", version.Commit)
 		hookServer := mgr.GetWebhookServer()
 
 		webhookLog.Info("registering webhooks to the webhook server")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,4 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 package version
 
-var Version = "latest"
+var (
+	Version = "latest"
+	Commit  = ""
+)


### PR DESCRIPTION
The cloud tests were broken because the version set in the `mondoo-operator` binary was `nightly` but the released container image is `main`. Due to this mismatch a very old operator binary was used with the latest mondoo client which is incompatible.

I also added the commit sha to the binary to be able to exactly pinpoint which version we are running (because`main` doesn't say much).