### PR TITLE
🐛 Update printing of operator version

### DIFF
--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -91,7 +91,7 @@ jobs:
           echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
 
       - name: Get operator version
-        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version)" >> $GITHUB_ENV
+        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version --simple)" >> $GITHUB_ENV
 
       - name: Wait a bit for the cluster to become more stable
         run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=60s
@@ -174,7 +174,7 @@ jobs:
           echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
 
       - name: Get operator version
-        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version)" >> $GITHUB_ENV
+        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version --simple)" >> $GITHUB_ENV
 
       - name: Wait a bit for the cluster to become more stable
         run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=60s
@@ -256,7 +256,7 @@ jobs:
           echo ${{ secrets.MONDOO_CLIENT }} | base64 -d > creds.json
 
       - name: Get operator version
-        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version)" >> $GITHUB_ENV
+        run: echo "OPERATOR_VERSION=$(docker run ghcr.io/mondoohq/mondoo-operator:${{ env.MONDOO_OPERATOR_IMAGE_TAG }} version --simple)" >> $GITHUB_ENV
 
       - name: Wait a bit for the cluster to become more stable
         run: kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=60s

--- a/cmd/mondoo-operator/version/cmd.go
+++ b/cmd/mondoo-operator/version/cmd.go
@@ -15,13 +15,12 @@ var Cmd = &cobra.Command{
 func init() {
 	simple := Cmd.Flags().Bool("simple", false, "Shows only the version of the binary")
 
-	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
+	Cmd.Run = func(cmd *cobra.Command, args []string) {
 		if *simple {
 			fmt.Println(version.Version)
-			return nil
+			return
 		}
 
 		fmt.Printf("Version: %s Commit: %s", version.Version, version.Commit)
-		return nil
 	}
 }

--- a/cmd/mondoo-operator/version/cmd.go
+++ b/cmd/mondoo-operator/version/cmd.go
@@ -10,7 +10,18 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the Mondoo Operator version",
-	Run: func(cmd *cobra.Command, args []string) {
+}
+
+func init() {
+	simple := Cmd.Flags().Bool("simple", false, "Shows only the version of the binary")
+
+	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if *simple {
+			fmt.Println(version.Version)
+			return nil
+		}
+
 		fmt.Printf("Version: %s Commit: %s", version.Version, version.Commit)
-	},
+		return nil
+	}
 }


### PR DESCRIPTION
The cloud tests are actually parsing the version output so it broke when I changed it. This PR makes sure the version can be printed in a way that the workflow can parse it