### PR TITLE
⭐️ Extended operator status reporting

### DIFF
--- a/controllers/mondooauditconfig_controller_test.go
+++ b/controllers/mondooauditconfig_controller_test.go
@@ -244,6 +244,11 @@ func TestTokenRegistration(t *testing.T) {
 								Status:     mondooclient.MessageStatus_MESSAGE_INFO,
 							},
 							{
+								Message:    "Container image scanning is disabled",
+								Identifier: status.ContainerImageScanningIdentifier,
+								Status:     mondooclient.MessageStatus_MESSAGE_INFO,
+							},
+							{
 								Message:    "Node scanning is disabled",
 								Identifier: status.NodeScanningIdentifier,
 								Status:     mondooclient.MessageStatus_MESSAGE_INFO,

--- a/controllers/status/operator_status_test.go
+++ b/controllers/status/operator_status_test.go
@@ -42,6 +42,7 @@ func TestReportStatusRequestFromAuditConfig_AllDisabled(t *testing.T) {
 	}, reportStatus.LastState)
 	messages := []mondooclient.IntegrationMessage{
 		{Identifier: K8sResourcesScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: "Kubernetes resources scanning is disabled"},
+		{Identifier: ContainerImageScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: "Container image scanning is disabled"},
 		{Identifier: NodeScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: "Node scanning is disabled"},
 		{Identifier: AdmissionControllerIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: "Admission controller is disabled"},
 		{Identifier: ScanApiIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: "Scan API is disabled"},
@@ -59,11 +60,13 @@ func TestReportStatusRequestFromAuditConfig_AllEnabled(t *testing.T) {
 
 	m := testMondooAuditConfig()
 	m.Spec.KubernetesResources.Enable = true
+	m.Spec.KubernetesResources.ContainerImageScanning = true
 	m.Spec.Nodes.Enable = true
 	m.Spec.Admission.Enable = true
 
 	m.Status.Conditions = []v1alpha2.MondooAuditConfigCondition{
 		{Message: "Kubernetes Resources Scanning is Available", Status: v1.ConditionFalse, Type: v1alpha2.K8sResourcesScanningDegraded},
+		{Message: "Kubernetes Container Image Scanning is Available", Status: v1.ConditionFalse, Type: v1alpha2.K8sContainerImageScanningDegraded},
 		{Message: "Node Scanning is available", Status: v1.ConditionFalse, Type: v1alpha2.NodeScanningDegraded},
 		{Message: "Admission controller is available", Status: v1.ConditionFalse, Type: v1alpha2.AdmissionDegraded},
 		{Message: "ScanAPI controller is available", Status: v1.ConditionFalse, Type: v1alpha2.ScanAPIDegraded},
@@ -73,16 +76,21 @@ func TestReportStatusRequestFromAuditConfig_AllEnabled(t *testing.T) {
 	assert.Equal(t, integrationMrn, reportStatus.Mrn)
 	assert.Equal(t, mondooclient.Status_ACTIVE, reportStatus.Status)
 	assert.Equal(t, OperatorCustomState{
-		Nodes:             []string{"node1", "node2"},
-		KubernetesVersion: v.GitVersion,
-		MondooAuditConfig: MondooAuditConfig{Name: m.Name, Namespace: m.Namespace},
-		OperatorVersion:   version.Version,
+		Nodes:                  []string{"node1", "node2"},
+		KubernetesVersion:      v.GitVersion,
+		MondooAuditConfig:      MondooAuditConfig{Name: m.Name, Namespace: m.Namespace},
+		OperatorVersion:        version.Version,
+		K8sResourcesScanning:   m.Spec.KubernetesResources.Enable,
+		ContainerImageScanning: m.Spec.KubernetesResources.ContainerImageScanning,
+		NodeScanning:           m.Spec.Nodes.Enable,
+		AdmissionController:    m.Spec.Admission.Enable,
 	}, reportStatus.LastState)
 	messages := []mondooclient.IntegrationMessage{
 		{Identifier: K8sResourcesScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[0].Message},
-		{Identifier: NodeScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[1].Message},
-		{Identifier: AdmissionControllerIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[2].Message},
-		{Identifier: ScanApiIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[3].Message},
+		{Identifier: ContainerImageScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[1].Message},
+		{Identifier: NodeScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[2].Message},
+		{Identifier: AdmissionControllerIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[3].Message},
+		{Identifier: ScanApiIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[4].Message},
 	}
 	assert.ElementsMatch(t, messages, reportStatus.Messages.Messages)
 }
@@ -97,11 +105,13 @@ func TestReportStatusRequestFromAuditConfig_AllError(t *testing.T) {
 
 	m := testMondooAuditConfig()
 	m.Spec.KubernetesResources.Enable = true
+	m.Spec.KubernetesResources.ContainerImageScanning = true
 	m.Spec.Nodes.Enable = true
 	m.Spec.Admission.Enable = true
 
 	m.Status.Conditions = []v1alpha2.MondooAuditConfigCondition{
 		{Message: "Kubernetes Resources Scanning error", Status: v1.ConditionTrue, Type: v1alpha2.K8sResourcesScanningDegraded},
+		{Message: "Kubernetes Container Image Scanning error", Status: v1.ConditionFalse, Type: v1alpha2.K8sContainerImageScanningDegraded},
 		{Message: "Node Scanning error", Status: v1.ConditionTrue, Type: v1alpha2.NodeScanningDegraded},
 		{Message: "Admission controller error", Status: v1.ConditionTrue, Type: v1alpha2.AdmissionDegraded},
 		{Message: "ScanAPI controller error", Status: v1.ConditionTrue, Type: v1alpha2.ScanAPIDegraded},
@@ -111,16 +121,21 @@ func TestReportStatusRequestFromAuditConfig_AllError(t *testing.T) {
 	assert.Equal(t, integrationMrn, reportStatus.Mrn)
 	assert.Equal(t, mondooclient.Status_ERROR, reportStatus.Status)
 	assert.Equal(t, OperatorCustomState{
-		Nodes:             []string{"node1", "node2"},
-		KubernetesVersion: v.GitVersion,
-		MondooAuditConfig: MondooAuditConfig{Name: m.Name, Namespace: m.Namespace},
-		OperatorVersion:   version.Version,
+		Nodes:                  []string{"node1", "node2"},
+		KubernetesVersion:      v.GitVersion,
+		MondooAuditConfig:      MondooAuditConfig{Name: m.Name, Namespace: m.Namespace},
+		OperatorVersion:        version.Version,
+		K8sResourcesScanning:   m.Spec.KubernetesResources.Enable,
+		ContainerImageScanning: m.Spec.KubernetesResources.ContainerImageScanning,
+		NodeScanning:           m.Spec.Nodes.Enable,
+		AdmissionController:    m.Spec.Admission.Enable,
 	}, reportStatus.LastState)
 	messages := []mondooclient.IntegrationMessage{
 		{Identifier: K8sResourcesScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[0].Message},
-		{Identifier: NodeScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[1].Message},
-		{Identifier: AdmissionControllerIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[2].Message},
-		{Identifier: ScanApiIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[3].Message},
+		{Identifier: ContainerImageScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_INFO, Message: m.Status.Conditions[1].Message},
+		{Identifier: NodeScanningIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[2].Message},
+		{Identifier: AdmissionControllerIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[3].Message},
+		{Identifier: ScanApiIdentifier, Status: mondooclient.MessageStatus_MESSAGE_ERROR, Message: m.Status.Conditions[4].Message},
 	}
 	assert.ElementsMatch(t, messages, reportStatus.Messages.Messages)
 }


### PR DESCRIPTION
I addressed the problem described in #713. I discussed the changes with @preslavgerchev and we concluded that it's best to not add the booleans to the messages but to actually include them in the `LastState` object that we send upstream.

I know yesterday we discussed defining the enumeration for the different types of scans in nexus but now that I think of it I don't think it makes sense. It seems like the operator should define what it can or cannot do so the possible message identifiers are defined here.

While looking at this I also noticed that we didn't have a message for the container image scanning, so I added that now.

Fixes #713 