### PR TITLE
🧹 Use newer k8s versions for integration tests

### DIFF
--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.22", "1.23", "1.24"]
+        k8s-version: ["1.22", "1.23", "1.24", "1.25"]
 
     steps:
       - uses: actions/checkout@v3
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.22", "1.23"]
+        k8s-version: ["1.22", "1.23", "1.24"]
 
     env:
       TF_VAR_test_name: ${{ github.event.inputs.mondooOperatorImageTag }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.22.13, v1.23.10, v1.24.4]
+        k8s-version: [v1.23.14, v1.24.8, v1.25.4]
         k8s-distro: [minikube, k3d]
 
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -278,7 +278,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.22.13, v1.23.10, v1.24.4]
+        k8s-version: [v1.23.14, v1.24.8, v1.25.4]
 
     steps:
       - uses: actions/checkout@v3
@@ -383,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.22.13, v1.23.10, v1.24.4]
+        k8s-version: [v1.23.14, v1.24.8, v1.25.4]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
There has been several new(er) version of k8s since we last updated our integration tests. I did that now and also dropped 1.22 since that is no longer actively supported and in a couple of months it will be EOL.
![image](https://user-images.githubusercontent.com/16187050/206583117-a3217dd4-0ef1-4f77-81c4-60a39f8d2fe4.png)
