### PR TITLE
🧹 Remove AKS 1.22

### DIFF
--- a/.github/terraform/aks/variables.tf
+++ b/.github/terraform/aks/variables.tf
@@ -9,6 +9,6 @@ variable "resource_group_location" {
 }
 
 variable "k8s_version" {
-  default = "1.22"
+  default = "1.25"
   description = "Kubernetes version to use for the cluster."
 }

--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.22", "1.23", "1.24", "1.25"]
+        k8s-version: ["1.23", "1.24", "1.25"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The **Mondoo Operator** can be installed via different methods depending on your
 
 The following Kubernetes environments are tested:
 
-- AWS EKS 1.22 and 1.23
-- Azure AKS 1.22, 1.23 and 1.24
-- GCP GKE 1.22, 1.23 and 1.24
+- AWS EKS 1.22, 1.23, and 1.24
+- Azure AKS 1.23, 1.24, and 1.25
+- GCP GKE 1.22, 1.23, and 1.24
 - Minikube with Kubernetes versions 1.22, 1.23 and 1.24
 - Rancher RKE1 1.22 and 1.23
 - K3S 1.22, 1.23 and 1.24


### PR DESCRIPTION
AKS 1.22 is no longer supported:
https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions\?tabs\=azure-cli\#aks-kubernetes-release-calendar

Signed-off-by: Christian Zunker <christian@mondoo.com>