### PR TITLE
🐛 Fix failing test reporter

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -396,6 +396,8 @@ jobs:
 
     permissions:
       contents: read
+      checks: write
+      statuses: write
 
     strategy:
       fail-fast: false
@@ -478,7 +480,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This partially reverts https://github.com/mondoohq/mondoo-operator/pull/742

Permission are taken from these:
https://github.com/dorny/test-reporter/issues/149
https://github.com/mondoohq/cnquery/pull/105
https://github.com/helm/chart-releaser-action\#example-workflow