### PR TITLE
🧹 Discover only container images when scanning containers

### DIFF
--- a/pkg/mondooclient/client.go
+++ b/pkg/mondooclient/client.go
@@ -248,7 +248,8 @@ type Score struct {
 }
 
 type ScanKubernetesResourcesOpts struct {
-	IntegrationMrn      string
+	IntegrationMrn string
+	// If set to true, the scan will discover only container images and not Kubernetes resources
 	ScanContainerImages bool
 	ManagedBy           string
 	IncludeNamespaces   []string
@@ -287,7 +288,7 @@ func (s *mondooClient) ScanKubernetesResources(ctx context.Context, scanOpts *Sc
 	setIntegrationMrn(scanOpts.IntegrationMrn, scanJob)
 
 	if scanOpts.ScanContainerImages {
-		scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets = append(scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets, "container-images")
+		scanJob.Inventory.Spec.Assets[0].Connections[0].Discover.Targets = []string{"container-images"}
 	}
 
 	reqBodyBytes, err := json.Marshal(scanJob)


### PR DESCRIPTION
Currently, all workloads are discovered when scanning container images. This works but makes the container image scan unnecessarily slower since we are scanning more assets than we are supposed to. This PR makes sure we discover only the container images when the container image scan job is running