### PR TITLE
🐛 do not use numbers for feature flags

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
         - --leader-elect
         env:
         - name: FEATURE_ENABLE_GARBAGE_COLLECTION
-          value: "1"
+          value: "true"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -48,6 +48,9 @@ func GetAdmissionReviewDiscovery() bool {
 }
 
 func setGlobalFlags(k, v string) {
+	if v != "true" && v != "1" {
+		return
+	}
 	switch k {
 	case "FEATURE_ENABLE_GARBAGE_COLLECTION":
 		enableGarbageCollection = true


### PR DESCRIPTION
It seems like helmify changed the way it sets env vars in the chart. It is now using a reference instead of directly setting the value in the template. Since we use "1" for feature flags, it is causing issues. When the value is loaded as a reference it doesn't understand it is a string and sets 1 as a number, which Kubernetes doesn't accept. It causes the following failure https://github.com/mondoohq/mondoo-operator/actions/runs/4407953231/jobs/7722399178

In this PR I made sure we can use "true" or "1" for the operator's feature flags. As a workaround for helmify, I set the variable to "true" instead of "1" which should work.

@joelddiaz I think we can also just remove the garbage collection feature flag completely. If you agree, let's do that. I still want to make a patch release with this change though to verify that the env var problem and helm is resolved for the future