### PR TITLE
🧹 check for multiple apis when determining openshift

### DIFF
--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -96,8 +96,7 @@ func init() {
 			return fmt.Errorf(msg)
 		}
 
-		// The API group "config.openshift.io" should be unique to an OpenShift cluster
-		isOpenShift, err := k8s.VerifyAPI("config.openshift.io", "v1", setupLog)
+		isOpenShift, err := k8s.IsOpenshift()
 		if err != nil {
 			setupLog.Error(err, "error while checking if running on OpenShift")
 			return err

--- a/controllers/service_monitor.go
+++ b/controllers/service_monitor.go
@@ -115,7 +115,7 @@ func (s *ServiceMonitor) serviceMonitorForMondoo(m *mondoov1alpha2.MondooOperato
 
 func (s *ServiceMonitor) Reconcile(ctx context.Context, clt client.Client, scheme *runtime.Scheme, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
-	found, err := k8s.VerifyAPI(monitoringv1.SchemeGroupVersion.Group, monitoringv1.SchemeGroupVersion.Version, log)
+	found, err := k8s.VerifyAPI(monitoringv1.SchemeGroupVersion.Group, monitoringv1.SchemeGroupVersion.Version)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/utils/k8s/api.go
+++ b/pkg/utils/k8s/api.go
@@ -9,7 +9,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 package k8s
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -26,16 +25,14 @@ const (
 
 // VerifyAPI will query the underlying k8s cluster for the existence
 // of the provided group/version.
-func VerifyAPI(group, version string, log logr.Logger) (bool, error) {
+func VerifyAPI(group, version string) (bool, error) {
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Error(err, "unable to get k8s config")
 		return false, err
 	}
 
 	k8s, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.Error(err, "unable to create k8s client")
 		return false, err
 	}
 
@@ -52,8 +49,6 @@ func VerifyAPI(group, version string, log logr.Logger) (bool, error) {
 		}
 		return false, err
 	}
-
-	log.Info(fmt.Sprintf("%s/%s API verified", group, version))
 	return true, nil
 }
 

--- a/pkg/utils/k8s/openshift.go
+++ b/pkg/utils/k8s/openshift.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+package k8s
+
+var openshiftAPIs = [][]string{{"config.openshift.io", "v1"}, {"nodes.config.openshift.io", "v1"}}
+
+// IsOpenshift returns a value indicating whether the current cluster is an OpenShift cluster.
+func IsOpenshift() (bool, error) {
+	for _, a := range openshiftAPIs {
+		exists, err := VerifyAPI(a[0], a[1])
+		if err != nil {
+			return false, err
+		}
+
+		// If the API exists, then this is an OpenShift cluster
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
When testing with ROSA it seem like `config.openshift.io` isn't present there. I added another API that I saw available to the openshift check