### PR TITLE
🐛 run node scanning in privileged container for openshift

### DIFF
--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -234,6 +234,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		KubeClient:             r.Client,
 		MondooOperatorConfig:   config,
 		ContainerImageResolver: r.ContainerImageResolver,
+		IsOpenshift:            r.RunningOnOpenShift,
 	}
 
 	result, reconcileError = nodes.Reconcile(ctx)

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -30,6 +30,7 @@ type DeploymentHandler struct {
 	Mondoo                 *v1alpha2.MondooAuditConfig
 	ContainerImageResolver mondoo.ContainerImageResolver
 	MondooOperatorConfig   *v1alpha2.MondooOperatorConfig
+	IsOpenshift            bool
 }
 
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
@@ -74,7 +75,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 
 		existing := &batchv1.CronJob{}
-		desired := CronJob(mondooClientImage, node, *n.Mondoo)
+		desired := CronJob(mondooClientImage, node, *n.Mondoo, n.IsOpenshift)
 		if err := ctrl.SetControllerReference(n.Mondoo, desired, n.KubeClient.Scheme()); err != nil {
 			logger.Error(err, "Failed to set ControllerReference", "namespace", desired.Namespace, "name", desired.Name)
 			return err

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -236,7 +236,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	s.NoError(err)
 
 	for _, n := range nodes.Items {
-		expected := CronJob(image, n, s.auditConfig)
+		expected := CronJob(image, n, s.auditConfig, false)
 		s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 		// Set some fields that the kube client sets
@@ -266,7 +266,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.NoError(err)
 
 	// Make sure a cron job exists for one of the nodes
-	cronJob := CronJob(image, nodes.Items[1], s.auditConfig)
+	cronJob := CronJob(image, nodes.Items[1], s.auditConfig, false)
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, cronJob))
 
@@ -275,7 +275,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.True(result.IsZero())
 
 	for i, n := range nodes.Items {
-		expected := CronJob(image, n, s.auditConfig)
+		expected := CronJob(image, n, s.auditConfig, false)
 		s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 		// Set some fields that the kube client sets
@@ -324,7 +324,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 
 	s.Equal(1, len(cronJobs.Items))
 
-	expected := CronJob(image, nodes.Items[0], s.auditConfig)
+	expected := CronJob(image, nodes.Items[0], s.auditConfig, false)
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -152,10 +152,38 @@ func TestResources(t *testing.T) {
 				},
 			}
 			mac := *test.mondooauditconfig()
-			cronJobSepc := CronJob("test123", *testNode, mac)
+			cronJobSepc := CronJob("test123", *testNode, mac, false)
 			assert.Equal(t, test.expectedResources, cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 		})
 	}
+}
+
+func TestCronJob_PrivilegedOpenshift(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-name",
+		},
+	}
+	mac := testMondooAuditConfig()
+	cronJobSepc := CronJob("test123", *testNode, *mac, true)
+	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+}
+
+func TestCronJob_Privileged(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-name",
+		},
+	}
+	mac := testMondooAuditConfig()
+	cronJobSepc := CronJob("test123", *testNode, *mac, false)
+	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }
 
 func TestInventory(t *testing.T) {


### PR DESCRIPTION
When scanning Openshift nodes that run RHCOS it is required to run the scan in a privileged container since otherwise we have no access to `/proc`