### PR TITLE
🧹 remove node garbage collect feature flag and extend tests

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
-	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	batchv1 "k8s.io/api/batch/v1"
@@ -118,10 +117,8 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 	}
 
-	if feature_flags.GetEnableNodeGC() {
-		if err := n.syncGCCronjob(ctx, mondooOperatorImage, clusterUid); err != nil {
-			return err
-		}
+	if err := n.syncGCCronjob(ctx, mondooOperatorImage, clusterUid); err != nil {
+		return err
 	}
 
 	// Delete dangling CronJobs for nodes that have been deleted from the cluster.

--- a/pkg/feature_flags/feature_flags.go
+++ b/pkg/feature_flags/feature_flags.go
@@ -10,7 +10,6 @@ import (
 const FeatureFlagPrefix = "FEATURE_"
 
 var (
-	enableNodeGC                   bool
 	enableAdmissionReviewDiscovery bool
 	allFeatureFlags                = make(map[string]string)
 )
@@ -39,10 +38,6 @@ func AllFeatureFlagsAsEnv() []corev1.EnvVar {
 	return env
 }
 
-func GetEnableNodeGC() bool {
-	return enableNodeGC
-}
-
 func GetAdmissionReviewDiscovery() bool {
 	return enableAdmissionReviewDiscovery
 }
@@ -52,8 +47,6 @@ func setGlobalFlags(k, v string) {
 		return
 	}
 	switch k {
-	case "FEATURE_ENABLE_NODE_GC":
-		enableNodeGC = true
 	case "FEATURE_ENABLE_ADMISSION_REVIEW_DISCOVERY":
 		enableAdmissionReviewDiscovery = true
 	}


### PR DESCRIPTION
Removed the node garbage collect flag and it is now enabled by default

I also extended the unit tests and integration tests to check that the new cronjob is properly created.