### PR TITLE
🧹 Disable cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-mondoo-space.yaml
+++ b/.github/workflows/cleanup-mondoo-space.yaml
@@ -1,7 +1,5 @@
 name: "Cleanup Mondoo space"
 on:
-  schedule:
-  - cron: "11 3 * * *" # 3:11am UTC
   workflow_dispatch:
     secrets:
       MONDOO_CLIENT_EDITOR:


### PR DESCRIPTION
Only disable for now. Let's see how the new automatic cleanup works out. We can remove this completly in a couple of days.