### PR TITLE
🧹 increase operator and node scanning requests and limits

### DIFF
--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -6,10 +6,10 @@ controllerManager:
     resources:
       limits:
         cpu: 200m
-        memory: 60Mi
+        memory: 140Mi
       requests:
         cpu: 100m
-        memory: 35Mi
+        memory: 70Mi
   replicas: 1
 kubernetesClusterDomain: cluster.local
 managerConfig:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,9 +65,9 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 60Mi
+            memory: 140Mi
           requests:
             cpu: 100m
-            memory: 35Mi
+            memory: 70Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/pkg/utils/k8s/resources_requirements.go
+++ b/pkg/utils/k8s/resources_requirements.go
@@ -40,12 +40,12 @@ func ResourcesRequirementsWithDefaults(m corev1.ResourceRequirements) corev1.Res
 // DefaultNodeScanningResources for Mondoo Client container when scanning nodes
 var DefaultNodeScanningResources corev1.ResourceRequirements = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("100M"),
+		corev1.ResourceMemory: resource.MustParse("160M"),
 		corev1.ResourceCPU:    resource.MustParse("200m"),
 	},
 
 	Requests: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("60M"),
+		corev1.ResourceMemory: resource.MustParse("100M"),
 		corev1.ResourceCPU:    resource.MustParse("50m"),
 	},
 }


### PR DESCRIPTION
We have seen several OOM issues. This PR increases the default requests and limits for the operator itself and for the node scanning jobs. I use these values on my cluster and it seems to be working fine with them. However, for larger cluster it is possible that the operator might need a more memory than what I have set here