### PR TITLE
:sparkles: add custom metrics

### DIFF
--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -26,6 +26,7 @@ import (
 	k8sv1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers"
 	"go.mondoo.com/mondoo-operator/controllers/integration"
+	"go.mondoo.com/mondoo-operator/controllers/metrics"
 	"go.mondoo.com/mondoo-operator/controllers/resource_monitor"
 	"go.mondoo.com/mondoo-operator/controllers/resource_monitor/scan_api_store"
 	"go.mondoo.com/mondoo-operator/controllers/status"
@@ -132,6 +133,11 @@ func init() {
 
 		if err = integration.Add(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Integration")
+			return err
+		}
+
+		if err = metrics.Add(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Metrics")
 			return err
 		}
 

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+)
+
+var metricsMondooAuditConfigTotal = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "mondoo_audit_configs",
+		Help: "Number of Mondoo audit configs",
+	},
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(metricsMondooAuditConfigTotal)
+}
+
+// Add creates a new metrics reconciler and adds it to the Manager.
+func Add(mgr manager.Manager) error {
+	logger := log.Log.WithName("metrics")
+	mr := &MetricsReconciler{
+		Client:   mgr.GetClient(),
+		Interval: 10 * time.Second,
+		log:      logger,
+	}
+	err := mgr.Add(mr)
+	if err != nil {
+		logger.Error(err, "failed to add metrics controller to manager")
+		return err
+	}
+	return nil
+}
+
+type MetricsReconciler struct {
+	Client client.Client
+
+	// Interval is the length of time we sleep between metrics calculations.
+	Interval time.Duration
+
+	log logr.Logger
+	ctx context.Context
+}
+
+// Start begins the metrics loop.
+func (mr *MetricsReconciler) Start(ctx context.Context) error {
+	mr.log.Info("started metrics controller goroutine")
+
+	mr.ctx = ctx
+	// Run forever, sleep at the end:
+	wait.Until(mr.metricsLoop, mr.Interval, ctx.Done())
+
+	return nil
+}
+
+func (mr *MetricsReconciler) metricsLoop() {
+	mr.log.Info("Updating metrics")
+	mondooAuditConfigs := &v1alpha2.MondooAuditConfigList{}
+	if err := mr.Client.List(mr.ctx, mondooAuditConfigs); err != nil {
+		mr.log.Error(err, "error listing MondooAuditConfigs")
+		return
+	}
+	mr.setMetricMondooAuditConfig(float64(len(mondooAuditConfigs.Items)))
+}
+
+func (mr *MetricsReconciler) setMetricMondooAuditConfig(num float64) {
+	metricsMondooAuditConfigTotal.Set(num)
+}
+
+func (mr *MetricsReconciler) getMetricMondooAuditConfig() float64 {
+	m := &dto.Metric{}
+	if err := metricsMondooAuditConfigTotal.Write(m); err != nil {
+		panic("failed to get metric value")
+	}
+	return m.Gauge.GetValue()
+}

--- a/controllers/metrics/metrics_test.go
+++ b/controllers/metrics/metrics_test.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace             = "mondoo-operator"
+	testMondooCredsSecretName = "mondoo-client"
+)
+
+type MetricsReconcilerSuite struct {
+	suite.Suite
+	fakeClientBuilder *fake.ClientBuilder
+}
+
+var testLogger logr.Logger
+
+func (s *MetricsReconcilerSuite) SetupSuite() {
+	utilruntime.Must(clientgoscheme.AddToScheme(clientgoscheme.Scheme))
+	utilruntime.Must(v1alpha2.AddToScheme(clientgoscheme.Scheme))
+
+	// Setup logging
+	var err error
+	cfg := zap.NewDevelopmentConfig()
+
+	cfg.InitialFields = map[string]interface{}{
+		"controller": "metrics-test",
+	}
+
+	zapLog, err := cfg.Build()
+	s.Require().NoError(err, "failed to set up logging for test cases")
+
+	testLogger = zapr.NewLogger(zapLog)
+}
+
+func (s *MetricsReconcilerSuite) BeforeTest(suiteName, testName string) {
+	s.fakeClientBuilder = fake.NewClientBuilder()
+}
+
+func (s *MetricsReconcilerSuite) TestMetricMondooAuditConfig() {
+	mondooAuditConfig := testMondooAuditConfig()
+
+	existingObjects := []runtime.Object{
+		mondooAuditConfig,
+	}
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).Build()
+	mockCtrl := gomock.NewController(s.T())
+	ctx := context.Background()
+	mr := &MetricsReconciler{
+		Client: fakeClient,
+		ctx:    ctx,
+		log:    testLogger,
+	}
+	mondooAuditConfigs := &v1alpha2.MondooAuditConfigList{}
+	if err := mr.Client.List(mr.ctx, mondooAuditConfigs); err != nil {
+		mr.log.Error(err, "error listing MondooAuditConfigs")
+		return
+	}
+	mr.setMetricMondooAuditConfig(float64(len(mondooAuditConfigs.Items)))
+	count := mr.getMetricMondooAuditConfig()
+	s.Assert().Equal(float64(len(mondooAuditConfigs.Items)), count)
+	mockCtrl.Finish()
+}
+
+func TestDeploymentHandlerSuite(t *testing.T) {
+	suite.Run(t, new(MetricsReconcilerSuite))
+}
+
+func testMondooAuditConfig() *v1alpha2.MondooAuditConfig {
+	return &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mondoo-config",
+			Namespace: testNamespace,
+		},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			MondooCredsSecretRef: corev1.LocalObjectReference{
+				Name: testMondooCredsSecretName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
#213 

Currently, this only adds one metrics `mondoo_audit_config` which shows the number of mondoAuditConfigs. 