### PR TITLE
🐛 Fix tar errors during golangci-lint execution

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,11 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "${{ env.golang-version }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49
+          version: v1.53
           args: --timeout=15m0s

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ $(GOTESTSUM): $(LOCALBIN)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49
+	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53
 
 GOMOCKGEN = $(LOCALBIN)/mockgen
 .PHONY: gomockgen


### PR DESCRIPTION
The errors polute the logs and make it hard to find real problems

For some background, see https://github.com/mondoohq/mondoo-operator/pull/812