### PR TITLE
🧹 Monitor workflows for least privileges

### DIFF
--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -55,6 +55,9 @@ jobs:
         k8s-version: ["1.24", "1.25", "1.26"]
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch is needed for "git tag --list" in the Makefile
@@ -141,6 +144,9 @@ jobs:
       AWS_REGION: us-east-2
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch is needed for "git tag --list" in the Makefile
@@ -222,6 +228,9 @@ jobs:
       KUBECONFIG: ${{ format('{0}/{1}', github.workspace, '.github/terraform/gke/kubeconfig') }}
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch is needed for "git tag --list" in the Makefile
@@ -302,6 +311,9 @@ jobs:
     needs: [eks-integration-test,aks-integration-test,gke-integration-test]
     if: always()
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      with:
+        config: ${{ vars.PERMISSIONS_CONFIG }}
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetch is needed for "git tag --list" in the Makefile
@@ -325,6 +337,9 @@ jobs:
     # Run only if the previous job has failed and only if it's running against the main branch
     if: ${{ always() && contains(join(needs.*.result, ','), 'fail') && github.ref_name == 'main' }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV


### PR DESCRIPTION
This adds the GHA monitor to some of our workflows: https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor 
These workflows do not have permissions specified. The action should tell us the least needed privileges.