### PR TITLE
🧹 Bump k8s versions

### DIFF
--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.24", "1.25", "1.26"]
+        k8s-version: ["1.25", "1.26", "1.27"]
 
     steps:
       - uses: actions/checkout@v3
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.23", "1.24", "1.25", "1.26"]
+        k8s-version: ["1.23", "1.24", "1.25", "1.26", "1.27"]
 
     env:
       TF_VAR_test_name: ${{ github.event.inputs.mondooOperatorImageTag }}
@@ -215,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.23", "1.24", "1.25", "1.26"]
+        k8s-version: ["1.24", "1.25", "1.26", "1.27"]
 
     env:
       GOOGLE_APPLICATION_CREDENTIALS: ${{ format('{0}/{1}', github.workspace, 'gcp_sa.json') }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.24.12, v1.25.8, v1.26.3, v1.27.1]
+        k8s-version: [v1.24.16, v1.25.12, v1.26.7, v1.27.4]
         k8s-distro: [minikube, k3d]
 
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -274,7 +274,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.24.12, v1.25.8, v1.26.3, v1.27.1]
+        k8s-version: [v1.24.16, v1.25.12, v1.26.7, v1.27.4]
 
     steps:
       - uses: actions/checkout@v3
@@ -386,7 +386,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.24.12, v1.25.8, v1.26.3, v1.27.1]
+        k8s-version: [v1.24.16, v1.25.12, v1.26.7, v1.27.4]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Update minikube and k3s to the latest minor versions and managed k8s to the latest major.