### PR TITLE
🐛 Enable Scan API also for node scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,10 +405,13 @@ prep/tools/ranger:
 
 prep/repos:
 	test -x cnquery || git clone https://github.com/mondoohq/cnquery.git
+# workaround for now. Needs to be removed as we move to v9
+	cd cnquery && git fetch && git checkout v8
 	test -x cnspec || git clone https://github.com/mondoohq/cnspec.git
 
 prep/repos/update: prep/repos
-	cd cnquery; git checkout main && git pull; cd -;
+# workaround for now. Needs to be removed as we move to v9
+	cd cnquery; git fetch; git checkout v8 && git pull; cd -;
 	cd cnspec; git checkout main && git pull; cd -;
 
 prep/ci/protoc:

--- a/controllers/scanapi/deployment_handler.go
+++ b/controllers/scanapi/deployment_handler.go
@@ -35,7 +35,7 @@ type DeploymentHandler struct {
 
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
 	// If neither KubernetesResources, nor Admission is enabled, the scan API is not needed.
-	if (!n.Mondoo.Spec.KubernetesResources.Enable && !n.Mondoo.Spec.Admission.Enable) ||
+	if (!n.Mondoo.Spec.KubernetesResources.Enable && !n.Mondoo.Spec.Admission.Enable && !n.Mondoo.Spec.Nodes.Enable) ||
 		!n.Mondoo.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, n.down(ctx)
 	}

--- a/controllers/scanapi/deployment_handler_test.go
+++ b/controllers/scanapi/deployment_handler_test.go
@@ -274,6 +274,48 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_Admission() {
 	s.Equal(*service, ss.Items[0])
 }
 
+func (s *DeploymentHandlerSuite) TestReconcile_Create_NodeScanning() {
+	s.auditConfig = utils.DefaultAuditConfig("mondoo-operator", false, false, true, false)
+
+	d := s.createDeploymentHandler()
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: s.auditConfig.Namespace,
+			Name:      TokenSecretName(s.auditConfig.Name),
+		},
+	}
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret), "Error checking for token secret")
+	// This really should be checking tokenSecret.Data, but the fake kubeClient just takes and stores the objects given to it
+	// and our code populates the Secret through Secret.StringData["token"]
+	s.Contains(tokenSecret.StringData, "token")
+
+	ds := &appsv1.DeploymentList{}
+	s.NoError(d.KubeClient.List(s.ctx, ds))
+	s.Equal(1, len(ds.Items))
+
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+	s.NoError(err)
+
+	deployment := ScanApiDeployment(s.auditConfig.Namespace, image, s.auditConfig, "", false)
+	deployment.ResourceVersion = "1" // Needed because the fake client sets it.
+	s.NoError(ctrl.SetControllerReference(&s.auditConfig, deployment, s.scheme))
+	s.True(k8s.AreDeploymentsEqual(*deployment, ds.Items[0]))
+
+	ss := &corev1.ServiceList{}
+	s.NoError(d.KubeClient.List(s.ctx, ss))
+	s.Equal(1, len(ss.Items))
+
+	service := ScanApiService(d.Mondoo.Namespace, s.auditConfig)
+	service.ResourceVersion = "1" // Needed because the fake client sets it.
+	s.NoError(ctrl.SetControllerReference(&s.auditConfig, service, s.scheme))
+	s.Equal(*service, ss.Items[0])
+}
+
 func (s *DeploymentHandlerSuite) TestDeploy_CreateMissingServiceAccount() {
 	ns := "test-ns"
 	s.auditConfig = utils.DefaultAuditConfig(ns, false, false, false, true)


### PR DESCRIPTION
The node GC depends on the Scan API. Because of that we also need to create the Scan API when only node scanning is active.

Fixes https://github.com/mondoohq/server/issues/6267