### PR TITLE
🐛 cnspec v9 action

### DIFF
--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -34,10 +34,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into registry ghcr.io
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into registry ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -22,12 +22,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [linux]
-        tag:
-          - ${{ github.event.inputs.version }}
-          - ${{ github.event.inputs.version }}-rootless
-          - ${{ github.event.inputs.version }}-ubi-rootless
-          - ${{ github.event.inputs.version }}-ubi
+        suffix:
+          - ""
+          - -rootless
+          - -ubi-rootless
+          - -ubi
 
     steps:
       - name: Checkout repository
@@ -44,6 +43,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.event.inputs.version }}
+            type=semver,pattern={{major}},value=${{ github.event.inputs.version }}
+            type=raw,value=latest
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
+
       - name: Build and push cnspec image
         id: build-and-push-operator
         uses: docker/build-push-action@v4
@@ -54,4 +65,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ env.IMAGE }}:${{ matrix.tag }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -10,7 +10,7 @@ on:
         default: 'latest'
 
 env:
-  IMAGE: ghcr.io/mondoo-operator/cnspec
+  IMAGE: ghcr.io/mondoohq/mondoo-operator/cnspec
 
 jobs:
   build-cnspec:

--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        arch: [amd64, arm64, arm]
         tag:
           - ${{ github.event.inputs.version }}
           - ${{ github.event.inputs.version }}-rootless
@@ -52,44 +51,7 @@ jobs:
           context: .
           file: cnspec.Dockerfile
           build-args: VERSION=${{ github.event.inputs.version }}
-          platforms: ${{ matrix.os }}/${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ env.IMAGE }}:${{ matrix.tag }}-${{ matrix.arch }}
-
-  push-virtual-tag:
-    name: Push multi-platform virtual tag
-    runs-on: ubuntu-latest
-    needs:
-      - build-cnspec
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.IMAGE }}
-
-      - name: Push multi-platform virtual tag and sign
-        run: bash scripts/push-virtual-tag.sh
-        env:
-          TAGS: ${{ steps.meta.outputs.tags }}
-          CPU_ARCHS: amd64 arm64 arm
+          tags: ${{ env.IMAGE }}:${{ matrix.tag }}


### PR DESCRIPTION
Can be triggered manually. As input we provide the version of cnspec to release and the action will build the following container flavours:
- normal
- rootless
- ubi
- ubi rootless

Run: https://github.com/mondoohq/mondoo-operator/actions/runs/6324829721