### PR TITLE
🧹 make sure cnspec release works with versions containing 'v'

### DIFF
--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Sanitize version input
+        run: |
+          TAG=${{ github.event.inputs.version }}
+          echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -49,8 +54,8 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}},value=${{ github.event.inputs.version }}
-            type=semver,pattern={{major}},value=${{ github.event.inputs.version }}
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{major}},value=${{ env.VERSION }}
             type=raw,value=latest
           flavor: |
             suffix=${{ matrix.suffix }},onlatest=true
@@ -61,7 +66,7 @@ jobs:
         with:
           context: .
           file: cnspec.Dockerfile
-          build-args: VERSION=${{ github.event.inputs.version }}
+          build-args: VERSION=${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The cnspec releases always start with a leading `v`. The action that releases the pre-bundled cnspec with the required providers for the operator needs the version to have no leading `v`. After merging this we can add a step in the cnspec release flow to call this workflow and automatically build the container for every cnspec release

Successful run https://github.com/mondoohq/mondoo-operator/actions/runs/6402540882