### PR TITLE
🧹 add repository dispatch event for cnspec container build

### DIFF
--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -1,6 +1,8 @@
 name: Publish cnspec container with providers
 
 on:
+  repository_dispatch:
+    types: [update]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This is needed in order to call the workflow from the cnspec repo