### PR TITLE
🐛 release the correct cnspec container flavours

### DIFF
--- a/.github/workflows/cnspec.yaml
+++ b/.github/workflows/cnspec.yaml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         suffix:
           - ""
-          - -rootless
-          - -ubi-rootless
           - -ubi
 
     steps:
@@ -67,7 +65,7 @@ jobs:
             type=semver,pattern={{major}},value=${{ env.VERSION }}
             type=raw,value=latest
           flavor: |
-            suffix=${{ matrix.suffix }},onlatest=true
+            suffix=${{ matrix.suffix }}-rootless,onlatest=true
 
       - name: Build and push cnspec image
         id: build-and-push-operator
@@ -75,8 +73,8 @@ jobs:
         with:
           context: .
           file: cnspec.Dockerfile
-          build-args: VERSION=${{ env.VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm
+          build-args: VERSION=${{ env.VERSION }}${{ matrix.suffix }}
+          platforms: linux/amd64,linux/arm64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/cnspec.Dockerfile
+++ b/cnspec.Dockerfile
@@ -8,3 +8,5 @@ FROM mondoo/cnspec:$VERSION
 RUN cnspec providers install os
 RUN cnspec providers install network
 RUN cnspec providers install k8s
+
+USER 100:101


### PR DESCRIPTION
currently, we always use the `root` image as base. This PR makes sure we always start with a `root` image, install the providers in the system directory and then we switch the user to `101` to make it rootless. We release only `X-rootless` and `X-ubi-rootless` images since those are the only ones that the operator uses