### PR TITLE
🐛 Fix integration test with external installation

### DIFF
--- a/tests/framework/nexus/client.go
+++ b/tests/framework/nexus/client.go
@@ -37,6 +37,8 @@ func NewClient() (*Client, error) {
 	if apiToken == "" {
 		return nil, fmt.Errorf("missing environment variable %s", MONDOO_API_TOKEN_VAR)
 	}
+	fmt.Printf("Using GraphQL endpoint %s\n", gqlEndpoint)
+	fmt.Printf("Using org MRN %s\n", orgMrn)
 	// Initialize the client
 	client, err := mondoogql.NewClient(option.WithEndpoint(gqlEndpoint), option.WithAPIToken(apiToken))
 	if err != nil {


### PR DESCRIPTION
Before this PR, we saw errors like:
'failed to parse response: http status 500: {"code":2,"message":"integration not found"}}'

That happened because of timing and re-use issues. This PR takes of this.