### PR TITLE
🧹 Do not run too many tests in parallel

### DIFF
--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -132,6 +132,7 @@ jobs:
     
     strategy:
       fail-fast: false
+      max-parallel: 3 # Otherwise we will hit AWS VPC quota limits
       matrix:
         k8s-version: ["1.24", "1.25", "1.26", "1.27", "1.28"]
 


### PR DESCRIPTION
Otherwise we hit the VPC quota limit.