### PR TITLE
🐛 Fetch more assets from upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test/integration: manifests generate generate-manifests load-k3d
 else
 test/integration: manifests generate generate-manifests load-minikube
 endif
-	go test -ldflags $(LDFLAGS) -v -timeout 35m -p 1 ./tests/integration/...
+	go test -ldflags $(LDFLAGS) -v -timeout 45m -p 1 ./tests/integration/...
 
 ifeq ($(K8S_DISTRO),gke)
 test/integration/ci: manifests generate generate-manifests gotestsum
@@ -153,7 +153,7 @@ test/integration/ci: manifests generate generate-manifests gotestsum load-k3d
 else
 test/integration/ci: manifests generate generate-manifests gotestsum load-minikube
 endif
-	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -ldflags $(LDFLAGS) -v -timeout 35m -p 1
+	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -ldflags $(LDFLAGS) -v -timeout 45m -p 1
 
 ##@ Build
 

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -67,8 +67,8 @@ func (i *MondooInstaller) InstallOperator() error {
 		zap.S().Info("The Mondoo operator is installed externally. Skipping installation...")
 		// We had race conditions were the integration wasn't ready when the operator tried to exchange the token
 		// for a service account. This sleep should give the integration enough time to get ready.
-		zap.S().Infof("Sleeping for 30 seconds to allow the token to get active")
-		time.Sleep(30 * time.Second)
+		zap.S().Infof("Sleeping for 10 seconds to allow the token to get active")
+		time.Sleep(10 * time.Second)
 		return nil
 	}
 

--- a/tests/framework/nexus/assets/assets.go
+++ b/tests/framework/nexus/assets/assets.go
@@ -44,7 +44,7 @@ func ListAssetsWithScores(
 					AssetType string `graphql:"asset_type"`
 				}
 			}
-		} `graphql:"assets(spaceMrn: $spaceMrn)"`
+		} `graphql:"assets(spaceMrn: $spaceMrn, first: 100)"`
 	}
 
 	err := gqlClient.Query(ctx, &q, map[string]interface{}{"spaceMrn": mondoogql.String(spaceMrn)})

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -71,6 +71,7 @@ func (s *AuditConfigBaseSuite) SetupSuite() {
 	s.Require().NoError(err, "Failed to create Nexus client")
 	s.spaceClient, err = nexusClient.CreateSpace()
 	s.Require().NoError(err, "Failed to create Nexus space")
+	log.Log.Info("Created Nexus space", "space", s.spaceClient.Mrn())
 
 	// TODO: this is only needed because the integration creation is not part of the MondooInstaller struct.
 	// That code will move there once all tests are migrated to use the E2E approach.
@@ -192,11 +193,15 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigKubernetesResources(auditCon
 	// Verify the workloads have been sent upstream and have scores.
 	workloadNames, err := s.testCluster.K8sHelper.GetWorkloadNames(s.ctx)
 	s.NoError(err, "Failed to get workload names.")
+	zap.S().Info("number of workload", " amount ", len(workloadNames))
 
 	time.Sleep(10 * time.Second)
 
+	// The number of assets from upstream is limited by paganiation.
+	// In case we have more than 100 workloads, we need to call this mutlple times, with different page numbers.
 	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
 	s.NoError(err, "Failed to list assets with scores.")
+	zap.S().Info("number of assets from upstream: ", len(assets))
 
 	// TODO: the cluster name is non-deterministic currently so we cannot test for it
 	assetsExceptCluster := utils.ExcludeClusterAsset(assets)
@@ -267,6 +272,8 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigContainers(auditConfig mondo
 	time.Sleep(10 * time.Second)
 
 	// Verify the container images have been sent upstream and have scores.
+	// The number of assets from upstream is limited by paganiation.
+	// In case we have more than 100 workloads, we need to call this mutlple times, with different page numbers.
 	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
 	s.NoError(err, "Failed to list assets with scores")
 
@@ -372,6 +379,8 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.M
 
 	time.Sleep(10 * time.Second)
 
+	// The number of assets from upstream is limited by paganiation.
+	// In case we have more than 100 workloads, we need to call this mutlple times, with different page numbers.
 	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
 	s.NoError(err, "Failed to list assets")
 	assetNames := utils.AssetNames(assets)


### PR DESCRIPTION
This fixes the failing OLM tests where we have more workloads than for other tests. The default number of assets fetched from upstream is 25. That wasn't enough for OLM clusters.