### PR TITLE
✨ Expose CronJob schedule via config

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -86,11 +86,15 @@ type KubernetesResources struct {
 	// DEPRECATED: ContainerImageScanning determines whether container images are being scanned. The current implementation
 	// runs a separate job once every 24h that scans the container images running in the cluster.
 	ContainerImageScanning bool `json:"containerImageScanning,omitempty"`
+	// Specify a custom crontab schedule for the Kubernetes resource scanning job. If not specified, the default schedule is used.
+	Schedule string `json:"schedule,omitempty"`
 }
 
 type Nodes struct {
 	Enable    bool                        `json:"enable,omitempty"`
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Specify a custom crontab schedule for the node scanning job. If not specified, the default schedule is used.
+	Schedule string `json:"schedule,omitempty"`
 }
 
 type Admission struct {
@@ -118,6 +122,8 @@ type Admission struct {
 type Containers struct {
 	Enable    bool                        `json:"enable,omitempty"`
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Specify a custom crontab schedule for the container image scanning job. If not specified, the default schedule is used.
+	Schedule string `json:"schedule,omitempty"`
 }
 
 type Image struct {

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -143,6 +143,11 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  schedule:
+                    description: Specify a custom crontab schedule for the container
+                      image scanning job. If not specified, the default schedule is
+                      used.
+                    type: string
                 type: object
               filtering:
                 properties:
@@ -175,6 +180,11 @@ spec:
                     type: boolean
                   enable:
                     type: boolean
+                  schedule:
+                    description: Specify a custom crontab schedule for the Kubernetes
+                      resource scanning job. If not specified, the default schedule
+                      is used.
+                    type: string
                 type: object
               mondooCredsSecretRef:
                 description: Config is an example field of MondooAuditConfig. Edit
@@ -252,6 +262,10 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  schedule:
+                    description: Specify a custom crontab schedule for the node scanning
+                      job. If not specified, the default schedule is used.
+                    type: string
                 type: object
               scanner:
                 description: Scanner defines the settings for the Mondoo scanner that

--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -125,6 +125,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
+		existing.Spec.Schedule = desired.Spec.Schedule
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 		if err := n.KubeClient.Update(ctx, existing); err != nil {

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -93,6 +93,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
+		existing.Spec.Schedule = desired.Spec.Schedule
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 		if err := n.KubeClient.Update(ctx, existing); err != nil {

--- a/controllers/k8s_scan/deployment_handler_test.go
+++ b/controllers/k8s_scan/deployment_handler_test.go
@@ -319,6 +319,64 @@ func (s *DeploymentHandlerSuite) TestReconcile_Disable() {
 	s.Equal(0, len(cronJobs.Items))
 }
 
+func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
+	d := s.createDeploymentHandler()
+
+	scanApiUrl := scanapi.ScanApiServiceUrl(*d.Mondoo)
+	s.scanApiStoreMock.EXPECT().Add(&scan_api_store.ScanApiStoreAddOpts{
+		Url:   scanApiUrl,
+		Token: "token",
+	}).Times(1)
+
+	customSchedule := "0 0 * * *"
+	s.auditConfig.Spec.KubernetesResources.Schedule = customSchedule
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	s.NoError(err)
+
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, s.auditConfig)
+
+	created := &batchv1.CronJob{}
+	created.Name = expected.Name
+	created.Namespace = expected.Namespace
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
+
+	s.Equal(created.Spec.Schedule, customSchedule)
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
+	d := s.createDeploymentHandler()
+
+	scanApiUrl := scanapi.ScanApiServiceUrl(*d.Mondoo)
+	s.scanApiStoreMock.EXPECT().Add(&scan_api_store.ScanApiStoreAddOpts{
+		Url:   scanApiUrl,
+		Token: "token",
+	}).Times(1)
+
+	customSchedule := "this is not valid"
+	s.auditConfig.Spec.KubernetesResources.Schedule = customSchedule
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	s.NoError(err)
+
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, s.auditConfig)
+
+	created := &batchv1.CronJob{}
+	created.Name = expected.Name
+	created.Namespace = expected.Namespace
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
+
+	s.NotEqual(created.Spec.Schedule, customSchedule)
+}
+
 func (s *DeploymentHandlerSuite) createDeploymentHandler() DeploymentHandler {
 	return DeploymentHandler{
 		KubeClient:             s.fakeClientBuilder.Build(),

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	// That's the mod k8s relies on https://github.com/kubernetes/kubernetes/blob/master/go.mod#L63
+	"github.com/robfig/cron/v3"
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/controllers/scanapi"
 	"go.mondoo.com/mondoo-operator/pkg/feature_flags"
@@ -24,6 +26,15 @@ func CronJob(image, integrationMrn, clusterUid string, m v1alpha2.MondooAuditCon
 	ls := CronJobLabels(m)
 
 	cronTab := fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
+	if m.Spec.KubernetesResources.Schedule != "" {
+		_, err := cron.ParseStandard(m.Spec.KubernetesResources.Schedule)
+		if err != nil {
+			logger.Error(err, "invalid cron schedule specified in MondooAuditConfig Spec.KubernetesResources.Schedule; using default")
+		} else {
+			logger.Info("using cron custom schedule", "crontab", m.Spec.KubernetesResources.Schedule)
+			cronTab = m.Spec.KubernetesResources.Schedule
+		}
+	}
 	scanApiUrl := scanapi.ScanApiServiceUrl(m)
 
 	containerArgs := []string{

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -103,6 +103,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 		if !k8s.AreCronJobsEqual(*existing, *desired) {
 			existing.Spec.JobTemplate = desired.Spec.JobTemplate
+			existing.Spec.Schedule = desired.Spec.Schedule
 			existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 			if err := n.KubeClient.Update(ctx, existing); err != nil {

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -449,6 +449,25 @@ subjects:
 
 After some seconds, you should see that the operator picked up the new `MondooAuditConfig` and starts creating objects.
 
+## Adjust the scan interval
+
+You can adjust the interval for scans triggered via a CronJob.
+Edit the `MondooAuditConfig` to adjust the interval:
+```
+kubectl -n mondoo-operator edit mondooauditconfigs.k8s.mondoo.com mondoo-client
+```
+
+```
+  kubernetesResources:
+    enable: true
+    schedule: 41 * * * *
+```
+
+You can adjust the schedule for the following components:
+- Kubernetes Resources Scanning
+- Container Image Scanning
+- Node Scanning
+
 ## Uninstalling the Mondoo operator
 
 Before uninstalling the Mondoo operator, be sure to delete all `MondooAuditConfig` and `MondooOperatorConfig` objects. You can find any in your cluster by running:

--- a/go.mod
+++ b/go.mod
@@ -335,6 +335,7 @@ require (
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -793,6 +793,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/pkg/utils/k8s/equality.go
+++ b/pkg/utils/k8s/equality.go
@@ -80,6 +80,7 @@ func AreCronJobsEqual(a, b batchv1.CronJob) bool {
 		AreSecurityContextsEqual(aPodSpec.Containers[0].SecurityContext, bPodSpec.Containers[0].SecurityContext) &&
 		reflect.DeepEqual(aPodSpec.Volumes, bPodSpec.Volumes) &&
 		reflect.DeepEqual(a.Spec.SuccessfulJobsHistoryLimit, b.Spec.SuccessfulJobsHistoryLimit) &&
+		a.Spec.Schedule == b.Spec.Schedule &&
 		reflect.DeepEqual(a.Spec.FailedJobsHistoryLimit, b.Spec.FailedJobsHistoryLimit) &&
 		reflect.DeepEqual(a.GetOwnerReferences(), b.GetOwnerReferences())
 }

--- a/pkg/utils/k8s/equality_test.go
+++ b/pkg/utils/k8s/equality_test.go
@@ -578,6 +578,15 @@ func TestAreCronJobsEqual(t *testing.T) {
 			},
 			shouldBeEqual: false,
 		},
+		{
+			name: "should not be equal when schedules differ",
+			createB: func(a batchv1.CronJob) batchv1.CronJob {
+				b := *a.DeepCopy()
+				b.Spec.Schedule = "1 * * * *"
+				return b
+			},
+			shouldBeEqual: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
It is now possible to change the CronJob schedule for the different types of CronJobs via the `MondooAuditConfig`.

Fixes #888