### PR TITLE
🧹 Debug report test

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -8,6 +8,10 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+    # This step gets called, even when the triggering workflow is skipped
+    # That's causing errors, so we need to check if the triggering workflow was skipped
+    # But that's not that easy: https://github.com/orgs/community/discussions/21090
+    - run: echo "${{ toJson(github.event) }}"
     - uses: dorny/test-reporter@v1
       with:
         artifact: test-results


### PR DESCRIPTION
For each PR it is called at least twice:
- Run Test
- Run Test (forks & dependabot)

But one of them was skipped and does not have an artifact. That results in errors.

With the data from the debug step, we should be able to write a condition which prevents this.