### PR TITLE
🧹 Add e2e OOM tests

### DIFF
--- a/controllers/admission/conditions.go
+++ b/controllers/admission/conditions.go
@@ -5,6 +5,7 @@ package admission
 
 import (
 	mondoov1alpha2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -22,18 +23,17 @@ func updateAdmissionConditions(config *mondoov1alpha2.MondooAuditConfig, degrade
 		status = corev1.ConditionFalse
 	} else if degradedStatus {
 		msg = "Admission controller is unavailable"
-		for _, pod := range pods.Items {
-			for i, containerStatus := range pod.Status.ContainerStatuses {
-				if containerStatus.Name != "webhook" {
-					continue
-				}
-				if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
-					(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
-					msg = "Admission controller is unavailable due to OOM"
-					affectedPods = append(affectedPods, pod.Name)
-					memoryLimit = pod.Spec.Containers[i].Resources.Limits.Memory().String()
-					break
-				}
+		currentPod := k8s.GetNewestPodFromList(pods)
+		for i, containerStatus := range currentPod.Status.ContainerStatuses {
+			if containerStatus.Name != "webhook" {
+				continue
+			}
+			if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
+				(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
+				msg = "Admission controller is unavailable due to OOM"
+				affectedPods = append(affectedPods, currentPod.Name)
+				memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+				break
 			}
 		}
 		reason = "AdmissionUnvailable"

--- a/controllers/admission/deployment_handler.go
+++ b/controllers/admission/deployment_handler.go
@@ -263,6 +263,22 @@ func (n *DeploymentHandler) syncWebhookDeployment(ctx context.Context) error {
 		return err
 	}
 
+	containerStillCreating := false
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "webhook" {
+			continue
+		}
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "ContainerCreating" {
+			containerStillCreating = true
+			break
+		}
+	}
+	if containerStillCreating {
+		// Wait a moment and refresh the pods
+		return fmt.Errorf("admissions pods are still creating")
+	}
+
 	updateAdmissionConditions(n.Mondoo, n.isWebhookDegraded(existingDeployment), pods)
 
 	// Not a full check for whether someone has modified our Deployment, but checking for some important bits so we know

--- a/controllers/container_image/conditions.go
+++ b/controllers/container_image/conditions.go
@@ -5,6 +5,7 @@ package container_image
 
 import (
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -26,16 +27,18 @@ func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedS
 		status = corev1.ConditionTrue
 	}
 
-	for _, pod := range pods.Items {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137 {
-				// TODO: double check container name?
-				msg = "Kubernetes Container Image Scanning is unavailable due to OOM"
-				affectedPods = append(affectedPods, pod.Name)
-				memoryLimit = pod.Spec.Containers[0].Resources.Limits.Memory().String()
-				reason = "KubernetesContainerImageScanningUnavailable"
-				status = corev1.ConditionTrue
-			}
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for i, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "mondoo-containers-scan" {
+			continue
+		}
+		if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
+			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
+			msg = "Kubernetes Container Image Scanning is unavailable due to OOM"
+			affectedPods = append(affectedPods, currentPod.Name)
+			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+			reason = "KubernetesContainerImageScanningUnavailable"
+			status = corev1.ConditionTrue
 		}
 	}
 

--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -5,6 +5,7 @@ package container_image
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
@@ -158,6 +159,22 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			logger.Error(err, "Failed to list Pods for Kubernetes Container Image Scanning")
 			return err
 		}
+	}
+
+	containerStillCreating := false
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "mondoo-container-scans" {
+			continue
+		}
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "ContainerCreating" {
+			containerStillCreating = true
+			break
+		}
+	}
+	if containerStillCreating {
+		// Wait a moment and refresh the pods
+		return fmt.Errorf("container image scan pods are still creating")
 	}
 
 	updateImageScanningConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)

--- a/controllers/k8s_scan/conditions.go
+++ b/controllers/k8s_scan/conditions.go
@@ -5,6 +5,7 @@ package k8s_scan
 
 import (
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -26,16 +27,18 @@ func updateWorkloadsConditions(config *v1alpha2.MondooAuditConfig, degradedStatu
 		status = corev1.ConditionTrue
 	}
 
-	for _, pod := range pods.Items {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137 {
-				// TODO: double check container name?
-				msg = "Kubernetes Resources Scanning is unavailable due to OOM"
-				affectedPods = append(affectedPods, pod.Name)
-				memoryLimit = pod.Spec.Containers[0].Resources.Limits.Memory().String()
-				reason = "KubernetesResourcesScanningUnavailable"
-				status = corev1.ConditionTrue
-			}
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for i, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "mondoo-k8s-scan" {
+			continue
+		}
+		if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
+			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
+			msg = "Kubernetes Resources Scanning is unavailable due to OOM"
+			affectedPods = append(affectedPods, currentPod.Name)
+			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+			reason = "KubernetesResourcesScanningUnavailable"
+			status = corev1.ConditionTrue
 		}
 	}
 

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -126,6 +126,22 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 	}
 
+	containerStillCreating := false
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "mondoo-k8s-scan" {
+			continue
+		}
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "ContainerCreating" {
+			containerStillCreating = true
+			break
+		}
+	}
+	if containerStillCreating {
+		// Wait a moment and refresh the pods
+		return fmt.Errorf("k8s resource scan pods are still creating")
+	}
+
 	updateWorkloadsConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)
 	return n.cleanupWorkloadDeployment(ctx)
 }

--- a/controllers/nodes/conditions.go
+++ b/controllers/nodes/conditions.go
@@ -29,10 +29,10 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 	}
 
 	currentPod := k8s.GetNewestPodFromList(pods)
-	var managerContainer *corev1.Container
+	var cnspecContainer *corev1.Container
 	for _, container := range currentPod.Spec.Containers {
-		if container.Name == "manager" {
-			managerContainer = &container
+		if container.Name == "cnspec" {
+			cnspecContainer = &container
 			break
 		}
 	}
@@ -44,7 +44,7 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 			msg = "Node Scanning is unavailable due to OOM"
 			affectedPods = append(affectedPods, currentPod.Name)
-			memoryLimit = managerContainer.Resources.Limits.Memory().String()
+			memoryLimit = cnspecContainer.Resources.Limits.Memory().String()
 			reason = "NodeScanningUnavailable"
 			status = corev1.ConditionTrue
 		}

--- a/controllers/nodes/conditions.go
+++ b/controllers/nodes/conditions.go
@@ -5,6 +5,7 @@ package nodes
 
 import (
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,16 +28,25 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 		status = corev1.ConditionTrue
 	}
 
-	for _, pod := range pods.Items {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137 {
-				// TODO: double check container name?
-				msg = "Node Scanning is unavailable due to OOM"
-				affectedPods = append(affectedPods, pod.Name)
-				memoryLimit = pod.Spec.Containers[0].Resources.Limits.Memory().String()
-				reason = "NodeScanningUnavailable"
-				status = corev1.ConditionTrue
-			}
+	currentPod := k8s.GetNewestPodFromList(pods)
+	var managerContainer *corev1.Container
+	for _, container := range currentPod.Spec.Containers {
+		if container.Name == "manager" {
+			managerContainer = &container
+			break
+		}
+	}
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "cnspec" {
+			continue
+		}
+		if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
+			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
+			msg = "Node Scanning is unavailable due to OOM"
+			affectedPods = append(affectedPods, currentPod.Name)
+			memoryLimit = managerContainer.Resources.Limits.Memory().String()
+			reason = "NodeScanningUnavailable"
+			status = corev1.ConditionTrue
 		}
 	}
 

--- a/controllers/nodes/conditions.go
+++ b/controllers/nodes/conditions.go
@@ -29,14 +29,7 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 	}
 
 	currentPod := k8s.GetNewestPodFromList(pods)
-	var cnspecContainer *corev1.Container
-	for _, container := range currentPod.Spec.Containers {
-		if container.Name == "cnspec" {
-			cnspecContainer = &container
-			break
-		}
-	}
-	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+	for i, containerStatus := range currentPod.Status.ContainerStatuses {
 		if containerStatus.Name != "cnspec" {
 			continue
 		}
@@ -44,7 +37,7 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 			msg = "Node Scanning is unavailable due to OOM"
 			affectedPods = append(affectedPods, currentPod.Name)
-			memoryLimit = cnspecContainer.Resources.Limits.Memory().String()
+			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
 			reason = "NodeScanningUnavailable"
 			status = corev1.ConditionTrue
 		}

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -5,6 +5,7 @@ package nodes
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
@@ -145,6 +146,22 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			logger.Error(err, "Failed to list Pods for Node Scanning")
 			return err
 		}
+	}
+
+	containerStillCreating := false
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "cnspec" {
+			continue
+		}
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "ContainerCreating" {
+			containerStillCreating = true
+			break
+		}
+	}
+	if containerStillCreating {
+		// Wait a moment and refresh the pods
+		return fmt.Errorf("node scanning pods are still creating")
 	}
 
 	updateNodeConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -481,11 +481,14 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 			Name:      "node-scan-123",
 			Namespace: s.auditConfig.Namespace,
 			Labels:    CronJobLabels(s.auditConfig),
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name: "node-scan",
+					Name: "cnspec",
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceMemory: *resource.NewQuantity(1, resource.BinarySI),
@@ -497,7 +500,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "node-scan",
+					Name: "cnspec",
 					LastTerminationState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 137,

--- a/controllers/scanapi/conditions.go
+++ b/controllers/scanapi/conditions.go
@@ -36,12 +36,15 @@ func updateScanAPIConditions(config *mondoov1alpha2.MondooAuditConfig, degradedS
 		}
 
 		for _, pod := range pods.Items {
-			for _, status := range pod.Status.ContainerStatuses {
-				if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode == 137 {
-					// TODO: double check container name?
+			for i, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.Name != "cnspec" {
+					continue
+				}
+				if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
+					(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 					msg = "ScanAPI controller is unavailable due to OOM"
 					affectedPods = append(affectedPods, pod.Name)
-					memoryLimit = pod.Spec.Containers[0].Resources.Limits.Memory().String()
+					memoryLimit = pod.Spec.Containers[i].Resources.Limits.Memory().String()
 				}
 			}
 		}

--- a/controllers/scanapi/deployment_handler.go
+++ b/controllers/scanapi/deployment_handler.go
@@ -5,6 +5,7 @@ package scanapi
 
 import (
 	"context"
+	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -154,6 +155,22 @@ func (n *DeploymentHandler) syncDeployment(ctx context.Context) error {
 	if err != nil {
 		logger.Error(err, "Failed to list Pods for scan API")
 		return err
+	}
+
+	containerStillCreating := false
+	currentPod := k8s.GetNewestPodFromList(pods)
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
+		if containerStatus.Name != "cnspec" {
+			continue
+		}
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "ContainerCreating" {
+			containerStillCreating = true
+			break
+		}
+	}
+	if containerStillCreating {
+		// Wait a moment and refresh the pods
+		return fmt.Errorf("ScanAPI controller pods are still creating")
 	}
 
 	updateScanAPIConditions(n.Mondoo, existingDeployment.Status.UnavailableReplicas != 0, existingDeployment.Status.Conditions, pods)

--- a/controllers/scanapi/deployment_handler_test.go
+++ b/controllers/scanapi/deployment_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
@@ -378,11 +379,14 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateOOMCondition() {
 			Name:      "scan-api-123",
 			Namespace: ns,
 			Labels:    labels,
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "scan-api",
+					Name:  "cnspec",
 					Image: image,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
@@ -395,7 +399,7 @@ func (s *DeploymentHandlerSuite) TestDeploy_CreateOOMCondition() {
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "scan-api",
+					Name: "cnspec",
 					LastTerminationState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 137,

--- a/pkg/utils/mondoo/condition.go
+++ b/pkg/utils/mondoo/condition.go
@@ -202,6 +202,8 @@ func UpdateMondooAuditStatus(ctx context.Context, client client.Client, origMOC,
 	return nil
 }
 
+// UpdateMondooAuditConfig updates only the spec of the MondooAuditConfig
+// The status is not updated
 func UpdateMondooAuditConfig(ctx context.Context, k8sClient client.Client, newMAC *mondoov1alpha2.MondooAuditConfig, log logr.Logger) error {
 	currentMAC := &mondoov1alpha2.MondooAuditConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -213,13 +215,18 @@ func UpdateMondooAuditConfig(ctx context.Context, k8sClient client.Client, newMA
 	if err != nil {
 		return err
 	}
+	log.Info("updating mondooauditconfig", "namespace", newMAC.Namespace, "name", newMAC.Name, "config", currentMAC)
 	if !reflect.DeepEqual(currentMAC.Spec, newMAC.Spec) {
-		log.Info("status has changed, updating")
 		err := k8sClient.Update(ctx, newMAC)
 		if err != nil {
 			log.Error(err, "failed to update mondooauditconfig")
 			return err
 		}
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(currentMAC), currentMAC)
+		if err != nil {
+			return err
+		}
+		log.Info("updating mondooauditconfig", "namespace", newMAC.Namespace, "name", newMAC.Name, "config", currentMAC)
 	}
 	return nil
 }

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -521,6 +521,179 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.M
 	s.Equal("ACTIVE", status)
 }
 
+func (s *AuditConfigBaseSuite) testOOMScanAPI(auditConfig mondoov2.MondooAuditConfig) {
+	s.auditConfig = auditConfig
+
+	// Disable container image resolution to be able to run the k8s resources scan CronJob with a local image.
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	zap.S().Info("Create an audit config that enables only workloads scanning.")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
+
+	// Verify scan API deployment and service
+	s.validateScanApiDeployment(auditConfig)
+
+	err := s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-k8s-scan")
+	s.NoErrorf(err, "Couldn't find k8s scan pod in Podlist of the MondooAuditConfig Status")
+
+	// Wait for first scan to finish
+	// It might interfere with this test
+	cronJobLabels := k8s_scan.CronJobLabels(auditConfig)
+	s.True(
+		s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(utils.LabelsToLabelSelector(cronJobLabels), auditConfig.Namespace),
+		"Kubernetes resources scan CronJob did not run successfully.")
+
+	// Verify scan API deployment and service
+	s.validateScanApiDeployment(auditConfig)
+
+	foundMondooAuditConfig, err := s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	foundMondooAuditConfig.Spec.Scanner.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("10Mi"), // this should be low enough to trigger an OOMkilled
+	}
+
+	zap.S().Info("Reducing memory limit to trigger OOM.")
+	s.NoError(s.testCluster.K8sHelper.Clientset.Update(s.ctx, foundMondooAuditConfig))
+
+	// Wait some time for the new RS to come up
+	time.Sleep(10 * time.Second)
+
+	// This will take some time, because:
+	// reconcile needs to happen
+	// a new replicaset should be created
+	// the first Pod tries to start and gets killed
+	// on the 2nd start we should get an OOMkilled status update
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.ScanAPIDegraded, corev1.ConditionTrue)
+	s.NoError(err, "Failed to find degraded condition")
+
+	foundMondooAuditConfig, err = s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	s.Contains(foundMondooAuditConfig.Status.Conditions[4].Message, "OOM", "Failed to find OOMKilled message in degraded condition")
+	s.Len(foundMondooAuditConfig.Status.Conditions[4].AffectedPods, 1, "Failed to find only one pod in degraded condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err := s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ERROR", status)
+
+	foundMondooAuditConfig.Spec.Scanner.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("200Mi"), // this should be enough to get the ScanAPI running again
+	}
+
+	zap.S().Info("Increasing memory limit to get ScanAPI running again.")
+	s.NoError(s.testCluster.K8sHelper.Clientset.Update(s.ctx, foundMondooAuditConfig))
+
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.ScanAPIDegraded, corev1.ConditionFalse)
+	s.NoError(err, "Failed to find degraded condition")
+	foundMondooAuditConfig, err = s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	s.NotContains(foundMondooAuditConfig.Status.Conditions[4].Message, "OOM", "Found OOMKilled message in condition")
+	s.Len(foundMondooAuditConfig.Status.Conditions[4].AffectedPods, 0, "Found a pod in condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err = s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ACTIVE", status)
+}
+
+func (s *AuditConfigBaseSuite) testOOMNodeScan(auditConfig mondoov2.MondooAuditConfig) {
+	s.auditConfig = auditConfig
+
+	auditConfig.Spec.Nodes.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("10Mi"), // this should be low enough to trigger an OOMkilled
+	}
+
+	// Disable container image resolution to be able to run the k8s resources scan CronJob with a local image.
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	zap.S().Info("Create an audit config that enables only nodes scanning.")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
+
+	cronJobs := &batchv1.CronJobList{}
+	cronJobLabels := nodes.CronJobLabels(auditConfig)
+
+	// List only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
+	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
+
+	nodeList := &corev1.NodeList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, nodeList))
+
+	// Verify the amount of CronJobs created is equal to the amount of nodes
+	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, cronJobs, listOpts))
+		if len(nodeList.Items) == len(cronJobs.Items) {
+			return true, nil
+		}
+		return false, nil
+	})
+	s.NoErrorf(
+		err,
+		"The amount of node scanning CronJobs is not equal to the amount of cluster nodes. expected: %d; actual: %d",
+		len(nodeList.Items), len(cronJobs.Items))
+
+	// Wait some time for the CronJob to trigger
+	time.Sleep(30 * time.Second)
+
+	// This will take some time, because:
+	// reconcile needs to happen
+	// a new replicaset should be created
+	// the first Pod tries to start and gets killed
+	// on the 2nd start we should get an OOMkilled status update
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.NodeScanningDegraded, corev1.ConditionTrue)
+	s.NoError(err, "Failed to find degraded condition")
+
+	foundMondooAuditConfig, err := s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	s.Contains(foundMondooAuditConfig.Status.Conditions[0].Message, "OOM", "Failed to find OOMKilled message in degraded condition")
+	s.Len(foundMondooAuditConfig.Status.Conditions[0].AffectedPods, 1, "Failed to find only one pod in degraded condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err := s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ERROR", status)
+
+	foundMondooAuditConfig.Spec.Nodes.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("200Mi"), // this should be enough to get the ScanAPI running again
+	}
+	foundMondooAuditConfig.Spec.Nodes.Schedule = "*/1 * * * *"
+
+	zap.S().Info("Increasing memory limit to get node Scans running again.")
+	s.NoError(s.testCluster.K8sHelper.Clientset.Update(s.ctx, foundMondooAuditConfig))
+
+	// Wait for the next run of the CronJob
+	time.Sleep(30 * time.Second)
+
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.NodeScanningDegraded, corev1.ConditionFalse)
+	s.NoError(err, "Failed to find degraded condition")
+	foundMondooAuditConfig, err = s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	s.NotContains(foundMondooAuditConfig.Status.Conditions[0].Message, "OOM", "Found OOMKilled message in condition")
+	s.Len(foundMondooAuditConfig.Status.Conditions[0].AffectedPods, 0, "Found a pod in condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err = s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ACTIVE", status)
+}
+
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmission(auditConfig mondoov2.MondooAuditConfig) {
 	// Disable imageResolution for the webhook image to be runnable.
 	// Otherwise, mondoo-operator will try to resolve the locally-built mondoo-operator container

--- a/tests/integration/audit_config_oom_test.go
+++ b/tests/integration/audit_config_oom_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.mondoo.com/mondoo-operator/tests/framework/utils"
+	"go.uber.org/zap"
+)
+
+type AuditConfigOOMSuite struct {
+	AuditConfigBaseSuite
+}
+
+func (s *AuditConfigOOMSuite) TestOOMControllerReporting() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, false)
+	s.testOOMMondooOperatorController(auditConfig)
+}
+
+func (s *AuditConfigOOMSuite) TestOOMScanAPI() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, false)
+	s.testOOMScanAPI(auditConfig)
+}
+
+func (s *AuditConfigOOMSuite) TestOOMNodeScan() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
+	s.testOOMNodeScan(auditConfig)
+}
+
+func TestAuditConfigOOMSuite(t *testing.T) {
+	s := new(AuditConfigOOMSuite)
+	defer func(s *AuditConfigOOMSuite) {
+		HandlePanics(recover(), func() {
+			if err := s.testCluster.UninstallOperator(); err != nil {
+				zap.S().Errorf("Failed to uninstall Mondoo operator. %v", err)
+			}
+			if s.spaceClient != nil {
+				if err := s.spaceClient.Delete(s.ctx); err != nil {
+					zap.S().Errorf("Failed to delete Mondoo space. %v", err)
+				}
+			}
+		}, s.T)
+	}(s)
+	suite.Run(t, s)
+}

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -32,6 +32,16 @@ func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
 }
 
+func (s *AuditConfigSuite) TestOOMScanAPI() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, false)
+	s.testOOMScanAPI(auditConfig)
+}
+
+func (s *AuditConfigSuite) TestOOMNodeScan() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
+	s.testOOMNodeScan(auditConfig)
+}
+
 func (s *AuditConfigSuite) TestReconcile_Containers() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false, false)
 

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -17,11 +17,6 @@ type AuditConfigSuite struct {
 	AuditConfigBaseSuite
 }
 
-func (s *AuditConfigSuite) TestOOMControllerReporting() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, false)
-	s.testOOMMondooOperatorController(auditConfig)
-}
-
 func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, false)
 	s.testMondooAuditConfigAllDisabled(auditConfig)
@@ -30,16 +25,6 @@ func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
 func (s *AuditConfigSuite) TestReconcile_KubernetesResources() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, false)
 	s.testMondooAuditConfigKubernetesResources(auditConfig)
-}
-
-func (s *AuditConfigSuite) TestOOMScanAPI() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, true, false, false, false)
-	s.testOOMScanAPI(auditConfig)
-}
-
-func (s *AuditConfigSuite) TestOOMNodeScan() {
-	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
-	s.testOOMNodeScan(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_Containers() {


### PR DESCRIPTION
This adds e2e tests for OOM of Scan API and node scan. This covers the two different cases we currently have: Deployment and CronJob.

Fixes #940