### PR TITLE
🐛 Fix CronJob schedule

### DIFF
--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -109,7 +109,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	}
 
 	existing := &batchv1.CronJob{}
-	desired := CronJob(mondooClientImage, integrationMrn, clusterUid, privateRegistriesSecretName, *n.Mondoo, *n.MondooOperatorConfig)
+	desired := CronJob(mondooClientImage, integrationMrn, clusterUid, privateRegistriesSecretName, n.Mondoo, *n.MondooOperatorConfig)
 	if err := ctrl.SetControllerReference(n.Mondoo, desired, n.KubeClient.Scheme()); err != nil {
 		logger.Error(err, "Failed to set ControllerReference", "namespace", desired.Namespace, "name", desired.Name)
 		return err
@@ -123,6 +123,11 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 	if created {
 		logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
+		err = mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger)
+		if err != nil {
+			logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
+			return err
+		}
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
 		existing.Spec.Schedule = desired.Spec.Schedule

--- a/controllers/container_image/deployment_handler_test.go
+++ b/controllers/container_image/deployment_handler_test.go
@@ -54,6 +54,8 @@ func (s *DeploymentHandlerSuite) BeforeTest(suiteName, testName string) {
 
 func (s *DeploymentHandlerSuite) TestReconcile_Create() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	result, err := d.Reconcile(s.ctx)
 	s.NoError(err)
@@ -62,7 +64,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -81,6 +83,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomImage() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	s.auditConfig.Spec.Scanner.Image.Name = "ubuntu"
 	s.auditConfig.Spec.Scanner.Image.Tag = "22.04"
@@ -92,7 +96,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomImage() {
 	image, err := s.containerImageResolver.CnspecImage("ubuntu", "22.04", false)
 	s.NoError(err)
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -111,6 +115,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomImage() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	customSchedule := "0 0 * * *"
 	s.auditConfig.Spec.Containers.Schedule = customSchedule
@@ -122,7 +128,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 
 	created := &batchv1.CronJob{}
 	created.Name = expected.Name
@@ -134,6 +140,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	customSchedule := "this is not valid"
 	s.auditConfig.Spec.Containers.Schedule = customSchedule
@@ -145,7 +153,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	created := &batchv1.CronJob{}
 	created.Name = expected.Name
 	created.Namespace = expected.Namespace
@@ -156,6 +164,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	s.auditConfig.Spec.Scanner.PrivateRegistriesPullSecretRef.Name = "my-pull-secrets"
 
@@ -177,7 +187,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() 
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, s.auditConfig.Spec.Scanner.PrivateRegistriesPullSecretRef.Name, s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, s.auditConfig.Spec.Scanner.PrivateRegistriesPullSecretRef.Name, &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -197,6 +207,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() 
 func (s *DeploymentHandlerSuite) TestReconcile_Create_ConsoleIntegration() {
 	s.auditConfig.Spec.ConsoleIntegration.Enable = true
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	integrationMrn := utils.RandString(20)
 	clientSecret := &corev1.Secret{
@@ -216,7 +228,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_ConsoleIntegration() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, integrationMrn, test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, integrationMrn, test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -235,12 +247,14 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_ConsoleIntegration() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
 	// Make sure a cron job exists with different container command
-	cronJob := CronJob(image, "", "", "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	cronJob := CronJob(image, "", "", "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, cronJob))
 
@@ -248,7 +262,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -269,6 +283,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 
 func (s *DeploymentHandlerSuite) TestReconcile_K8sContainerImageScanningStatus() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create all resources
 	result, err := d.Reconcile(s.ctx)
@@ -336,6 +352,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_K8sContainerImageScanningStatus()
 
 func (s *DeploymentHandlerSuite) TestReconcile_DisableContainerImageScanning() {
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create all resources
 	result, err := d.Reconcile(s.ctx)

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -31,8 +31,8 @@ const (
 	InventoryConfigMapBase = "-containers-inventory"
 )
 
-func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName string, m v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
-	ls := CronJobLabels(m)
+func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
+	ls := CronJobLabels(*m)
 
 	cmd := []string{
 		"cnspec", "scan", "k8s",
@@ -59,6 +59,9 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 			logger.Info("using cron custom schedule", "crontab", m.Spec.Containers.Schedule)
 			cronTab = m.Spec.Containers.Schedule
 		}
+	} else {
+		logger.Info("using default cron schedule", "crontab", cronTab)
+		m.Spec.Containers.Schedule = cronTab
 	}
 
 	cronjob := &batchv1.CronJob{

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -22,8 +22,8 @@ import (
 
 const CronJobNameSuffix = "-k8s-scan"
 
-func CronJob(image, integrationMrn, clusterUid string, m v1alpha2.MondooAuditConfig) *batchv1.CronJob {
-	ls := CronJobLabels(m)
+func CronJob(image, integrationMrn, clusterUid string, m *v1alpha2.MondooAuditConfig) *batchv1.CronJob {
+	ls := CronJobLabels(*m)
 
 	cronTab := fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
 	if m.Spec.KubernetesResources.Schedule != "" {
@@ -34,8 +34,11 @@ func CronJob(image, integrationMrn, clusterUid string, m v1alpha2.MondooAuditCon
 			logger.Info("using cron custom schedule", "crontab", m.Spec.KubernetesResources.Schedule)
 			cronTab = m.Spec.KubernetesResources.Schedule
 		}
+	} else {
+		logger.Info("using default cron schedule", "crontab", cronTab)
+		m.Spec.KubernetesResources.Schedule = cronTab
 	}
-	scanApiUrl := scanapi.ScanApiServiceUrl(m)
+	scanApiUrl := scanapi.ScanApiServiceUrl(*m)
 
 	containerArgs := []string{
 		"k8s-scan",

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -83,7 +83,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 
 		existing := &batchv1.CronJob{}
-		desired := CronJob(mondooClientImage, node, *n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
+		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
 
 		if err := ctrl.SetControllerReference(n.Mondoo, desired, n.KubeClient.Scheme()); err != nil {
 			logger.Error(err, "Failed to set ControllerReference", "namespace", desired.Namespace, "name", desired.Name)
@@ -98,6 +98,11 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 		if created {
 			logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
+			err = mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger)
+			if err != nil {
+				logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
+				return err
+			}
 			continue
 		}
 

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -58,6 +58,8 @@ func (s *DeploymentHandlerSuite) BeforeTest(suiteName, testName string) {
 func (s *DeploymentHandlerSuite) TestReconcile_CreateConfigMap() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	result, err := d.Reconcile(s.ctx)
 	s.NoError(err)
@@ -108,6 +110,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateConfigMapWithIntegrationMRN
 	s.fakeClientBuilder = s.fakeClientBuilder.WithObjects(credsWithIntegration)
 
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	result, err := d.Reconcile(s.ctx)
 	s.NoError(err)
@@ -139,6 +143,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateConfigMapWithIntegrationMRN
 func (s *DeploymentHandlerSuite) TestReconcile_UpdateConfigMap() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	nodes := &corev1.NodeList{}
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
@@ -177,6 +183,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateConfigMap() {
 func (s *DeploymentHandlerSuite) TestReconcile_CleanConfigMapsForDeletedNodes() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create the initial cron jobs
 	result, err := d.Reconcile(s.ctx)
@@ -220,6 +228,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanConfigMapsForDeletedNodes() 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	result, err := d.Reconcile(s.ctx)
 	s.NoError(err)
@@ -233,7 +243,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	s.NoError(err)
 
 	for _, n := range nodes.Items {
-		expected := CronJob(image, n, s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		expected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 		// Set some fields that the kube client sets
@@ -274,6 +284,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	nodes := &corev1.NodeList{}
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
@@ -283,7 +295,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.NoError(err)
 
 	// Make sure a cron job exists for one of the nodes
-	cronJob := CronJob(image, nodes.Items[1], s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	cronJob := CronJob(image, nodes.Items[1], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, cronJob))
 
@@ -292,7 +304,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.True(result.IsZero())
 
 	for i, n := range nodes.Items {
-		expected := CronJob(image, n, s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		expected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 		// Set some fields that the kube client sets
@@ -315,6 +327,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create the initial cron jobs
 	result, err := d.Reconcile(s.ctx)
@@ -345,7 +359,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 
 	s.Equal(1, len(cronJobs.Items))
 
-	expected := CronJob(image, nodes.Items[0], s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 	s.NoError(ctrl.SetControllerReference(&s.auditConfig, expected, d.KubeClient.Scheme()))
 
 	// Set some fields that the kube client sets
@@ -365,6 +379,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningStatus() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create all resources
 	result, err := d.Reconcile(s.ctx)
@@ -437,6 +453,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningStatus() {
 func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create all resources
 	result, err := d.Reconcile(s.ctx)
@@ -530,6 +548,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 func (s *DeploymentHandlerSuite) TestReconcile_DisableNodeScanning() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	// Reconcile to create all resources
 	result, err := d.Reconcile(s.ctx)
@@ -554,6 +574,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_DisableNodeScanning() {
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	customSchedule := "0 0 * * *"
 	s.auditConfig.Spec.Nodes.Schedule = customSchedule
@@ -568,7 +590,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, nodes.Items[0], s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 
 	created := &batchv1.CronJob{}
 	created.Name = expected.Name
@@ -581,6 +603,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
 	customSchedule := "this is not valid"
 	s.auditConfig.Spec.Nodes.Schedule = customSchedule
@@ -595,7 +619,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
 	image, err := s.containerImageResolver.CnspecImage("", "", false)
 	s.NoError(err)
 
-	expected := CronJob(image, nodes.Items[0], s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	expected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 
 	created := &batchv1.CronJob{}
 	created.Name = expected.Name

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -36,8 +36,8 @@ const (
 	ignoreAnnotationValue = "ignore"
 )
 
-func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
-	ls := CronJobLabels(m)
+func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
+	ls := CronJobLabels(*m)
 
 	cronTab := fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
 	if m.Spec.Nodes.Schedule != "" {
@@ -48,6 +48,9 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig, isOpe
 			logger.Info("using cron custom schedule", "crontab", m.Spec.Nodes.Schedule)
 			cronTab = m.Spec.Nodes.Schedule
 		}
+	} else {
+		logger.Info("using default cron schedule", "crontab", cronTab)
+		m.Spec.Nodes.Schedule = cronTab
 	}
 	unsetHostPath := corev1.HostPathUnset
 
@@ -70,7 +73,7 @@ func CronJob(image string, node corev1.Node, m v1alpha2.MondooAuditConfig, isOpe
 			},
 			Name:      CronJobName(m.Name, node.Name),
 			Namespace: m.Namespace,
-			Labels:    CronJobLabels(m),
+			Labels:    CronJobLabels(*m),
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          cronTab,

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -148,7 +148,7 @@ func TestResources(t *testing.T) {
 				},
 			}
 			mac := *test.mondooauditconfig()
-			cronJobSepc := CronJob("test123", *testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+			cronJobSepc := CronJob("test123", *testNode, &mac, false, v1alpha2.MondooOperatorConfig{})
 			assert.Equal(t, test.expectedResources, cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 		})
 	}
@@ -161,7 +161,7 @@ func TestCronJob_PrivilegedOpenshift(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cronJobSepc := CronJob("test123", *testNode, *mac, true, v1alpha2.MondooOperatorConfig{})
+	cronJobSepc := CronJob("test123", *testNode, mac, true, v1alpha2.MondooOperatorConfig{})
 	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
 	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }
@@ -173,7 +173,7 @@ func TestCronJob_Privileged(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cronJobSepc := CronJob("test123", *testNode, *mac, false, v1alpha2.MondooOperatorConfig{})
+	cronJobSepc := CronJob("test123", *testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
 	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }

--- a/pkg/utils/mondoo/condition.go
+++ b/pkg/utils/mondoo/condition.go
@@ -201,3 +201,25 @@ func UpdateMondooAuditStatus(ctx context.Context, client client.Client, origMOC,
 	}
 	return nil
 }
+
+func UpdateMondooAuditConfig(ctx context.Context, k8sClient client.Client, newMAC *mondoov1alpha2.MondooAuditConfig, log logr.Logger) error {
+	currentMAC := &mondoov1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      newMAC.Name,
+			Namespace: newMAC.Namespace,
+		},
+	}
+	err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(currentMAC), currentMAC)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(currentMAC.Spec, newMAC.Spec) {
+		log.Info("status has changed, updating")
+		err := k8sClient.Update(ctx, newMAC)
+		if err != nil {
+			log.Error(err, "failed to update mondooauditconfig")
+			return err
+		}
+	}
+	return nil
+}

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -163,6 +163,7 @@ func (i *MondooInstaller) CleanupAuditConfigs() error {
 		if err := i.K8sHelper.WaitForResourceDeletion(&c); err != nil {
 			return err
 		}
+		zap.S().Infof("Deleted MondooAuditConfig %s/%s.", c.Namespace, c.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
The CronJob schedule was changed with every reconcile. This PR adds the schedule during CronJob creation to the MondooAuditConfig so that it can later be re-used.