### PR TITLE
🐛 do not crash on failure to report state

### DIFF
--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -154,7 +154,6 @@ func init() {
 		err = checkForTerminatedState(ctx, client, v, setupLog)
 		if err != nil {
 			setupLog.Error(err, "unable to check for terminated state of mondoo-operator-controller")
-			return err
 		}
 
 		if err = resource_monitor.RegisterResourceMonitors(mgr, scanApiStore); err != nil {


### PR DESCRIPTION
Right now for new installations via the UI, the operator crashes because it cannot find the secret `mondoo-client` it only gets created when the registration token is exchanged for a service account. This means the operator can never start