### PR TITLE
🐛 Fix upload artifact

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/upload-artifact@v4  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:                             # upload a combined archive with unit and integration test results
-          name: test-results
+          name: test-results-${{ matrix.k8s-distro }}-${{ matrix.k8s-version }}
           path: integration-tests-${{ matrix.k8s-distro }}-${{ matrix.k8s-version }}.xml
 
       - name: Upload test logs artifact


### PR DESCRIPTION
Fixes '(409) Conflict: an artifact with this name already exists on the workflow run'.

For background: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md