### PR TITLE
🐛 fix endless updates of cronjobs

### DIFF
--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -124,11 +124,6 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 	if created {
 		logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
-		err = mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger)
-		if err != nil {
-			logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
-			return err
-		}
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
 		existing.Spec.Schedule = desired.Spec.Schedule

--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -132,6 +132,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
 		existing.Spec.Schedule = desired.Spec.Schedule
+		existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 		// Remove any old jobs because they won't be updated when the cronjob changes

--- a/controllers/container_image/deployment_handler_test.go
+++ b/controllers/container_image/deployment_handler_test.go
@@ -138,30 +138,6 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	s.Equal(created.Spec.Schedule, customSchedule)
 }
 
-func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
-	d := s.createDeploymentHandler()
-	mondooAuditConfig := &s.auditConfig
-	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
-
-	customSchedule := "this is not valid"
-	s.auditConfig.Spec.Containers.Schedule = customSchedule
-
-	result, err := d.Reconcile(s.ctx)
-	s.NoError(err)
-	s.True(result.IsZero())
-
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
-	s.NoError(err)
-
-	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
-	created := &batchv1.CronJob{}
-	created.Name = expected.Name
-	created.Namespace = expected.Namespace
-	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
-
-	s.NotEqual(created.Spec.Schedule, customSchedule)
-}
-
 func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() {
 	d := s.createDeploymentHandler()
 	mondooAuditConfig := &s.auditConfig

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -6,10 +6,9 @@ package container_image
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	// That's the mod k8s relies on https://github.com/kubernetes/kubernetes/blob/master/go.mod#L63
-	"github.com/robfig/cron/v3"
+
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/constants"
@@ -48,19 +47,6 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 	envVars := feature_flags.AllFeatureFlagsAsEnv()
 	envVars = append(envVars, corev1.EnvVar{Name: "MONDOO_AUTO_UPDATE", Value: "false"})
 
-	// We want to start the cron job one minute after it was enabled.
-	cronStart := time.Now().Add(1 * time.Minute)
-	cronTab := fmt.Sprintf("%d %d * * *", cronStart.Minute(), cronStart.Hour())
-	if m.Spec.Containers.Schedule != "" {
-		_, err := cron.ParseStandard(m.Spec.Containers.Schedule)
-		if err != nil {
-			logger.Error(err, "invalid cron schedule specified in MondooAuditConfig Spec.Containers.Schedule; using default")
-		} else {
-			logger.Info("using cron custom schedule", "crontab", m.Spec.Containers.Schedule)
-			cronTab = m.Spec.Containers.Schedule
-		}
-	}
-
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      CronJobName(m.Name),
@@ -68,7 +54,7 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 			Labels:    ls,
 		},
 		Spec: batchv1.CronJobSpec{
-			Schedule:          cronTab,
+			Schedule:          m.Spec.Containers.Schedule,
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -59,9 +59,6 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 			logger.Info("using cron custom schedule", "crontab", m.Spec.Containers.Schedule)
 			cronTab = m.Spec.Containers.Schedule
 		}
-	} else {
-		logger.Info("using default cron schedule", "crontab", cronTab)
-		m.Spec.Containers.Schedule = cronTab
 	}
 
 	cronjob := &batchv1.CronJob{

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -91,11 +91,6 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 	if created {
 		logger.Info("Created CronJob", "namespace", desired.Namespace, "name", desired.Name)
-		err = mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger)
-		if err != nil {
-			logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
-			return err
-		}
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
 		existing.Spec.Schedule = desired.Spec.Schedule

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -99,6 +99,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	} else if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
 		existing.Spec.Schedule = desired.Spec.Schedule
+		existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 		// Remove any old jobs because they won't be updated when the cronjob changes

--- a/controllers/k8s_scan/deployment_handler_test.go
+++ b/controllers/k8s_scan/deployment_handler_test.go
@@ -351,26 +351,6 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithDefaultSchedule() {
 	created.Name = expected.Name
 	created.Namespace = expected.Namespace
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
-
-	// Wait a bit to longer, to later check, whether the CronJob schedule was changed.
-	time.Sleep(61 * time.Second)
-
-	s.scanApiStoreMock.EXPECT().Add(&scan_api_store.ScanApiStoreAddOpts{
-		Url:   scanApiUrl,
-		Token: "token",
-	}).Times(1)
-	result, err = d.Reconcile(s.ctx)
-	s.NoError(err)
-	s.True(result.IsZero())
-
-	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
-	foundMAC := &mondoov1alpha2.MondooAuditConfig{}
-	foundMAC.Name = mondooAuditConfig.Name
-	foundMAC.Namespace = mondooAuditConfig.Namespace
-	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(foundMAC), foundMAC))
-
-	s.Equal(created.Spec.Schedule, expected.Spec.Schedule)
-	s.Equal(foundMAC.Spec.KubernetesResources.Schedule, expected.Spec.Schedule)
 }
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -34,9 +34,6 @@ func CronJob(image, integrationMrn, clusterUid string, m *v1alpha2.MondooAuditCo
 			logger.Info("using cron custom schedule", "crontab", m.Spec.KubernetesResources.Schedule)
 			cronTab = m.Spec.KubernetesResources.Schedule
 		}
-	} else {
-		logger.Info("using default cron schedule", "crontab", cronTab)
-		m.Spec.KubernetesResources.Schedule = cronTab
 	}
 	scanApiUrl := scanapi.ScanApiServiceUrl(*m)
 

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -164,6 +165,30 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			return ctrl.Result{}, reconcileError
 		}
+	}
+
+	// Set the default cron tab if none is set
+	defaultCronTab := fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
+	shouldUpdate := false
+	if mondooAuditConfig.Spec.Nodes.Schedule == "" {
+		mondooAuditConfig.Spec.Nodes.Schedule = defaultCronTab
+		shouldUpdate = true
+	}
+	if mondooAuditConfig.Spec.KubernetesResources.Schedule == "" {
+		mondooAuditConfig.Spec.KubernetesResources.Schedule = defaultCronTab
+		shouldUpdate = true
+	}
+	if mondooAuditConfig.Spec.Containers.Schedule == "" {
+		mondooAuditConfig.Spec.Containers.Schedule = defaultCronTab
+		shouldUpdate = true
+	}
+	if shouldUpdate {
+		err := r.Update(ctx, mondooAuditConfig)
+		if err != nil {
+			log.Error(reconcileError, "failed to update MondooAuditConfig with default schedule")
+			return ctrl.Result{}, reconcileError
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	mondooAuditConfigCopy := mondooAuditConfig.DeepCopy()

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -168,18 +168,18 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Set the default cron tab if none is set
-	defaultCronTab := fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
 	shouldUpdate := false
-	if mondooAuditConfig.Spec.Nodes.Schedule == "" {
-		mondooAuditConfig.Spec.Nodes.Schedule = defaultCronTab
+	if mondooAuditConfig.Spec.Nodes.Enable && mondooAuditConfig.Spec.Nodes.Schedule == "" {
+		mondooAuditConfig.Spec.Nodes.Schedule = fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
 		shouldUpdate = true
 	}
-	if mondooAuditConfig.Spec.KubernetesResources.Schedule == "" {
-		mondooAuditConfig.Spec.KubernetesResources.Schedule = defaultCronTab
+	if mondooAuditConfig.Spec.KubernetesResources.Enable && mondooAuditConfig.Spec.KubernetesResources.Schedule == "" {
+		mondooAuditConfig.Spec.KubernetesResources.Schedule = fmt.Sprintf("%d * * * *", time.Now().Add(1*time.Minute).Minute())
 		shouldUpdate = true
 	}
-	if mondooAuditConfig.Spec.Containers.Schedule == "" {
-		mondooAuditConfig.Spec.Containers.Schedule = defaultCronTab
+	if mondooAuditConfig.Spec.Containers.Enable && mondooAuditConfig.Spec.Containers.Schedule == "" {
+		cronStart := time.Now().Add(1 * time.Minute)
+		mondooAuditConfig.Spec.Containers.Schedule = fmt.Sprintf("%d %d * * *", cronStart.Minute(), cronStart.Hour())
 		shouldUpdate = true
 	}
 	if shouldUpdate {

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -110,6 +110,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		if !k8s.AreCronJobsEqual(*existing, *desired) {
 			existing.Spec.JobTemplate = desired.Spec.JobTemplate
 			existing.Spec.Schedule = desired.Spec.Schedule
+			existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 			existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 			// Remove any old jobs because they won't be updated when the cronjob changes
@@ -287,6 +288,7 @@ func (n *DeploymentHandler) syncGCCronjob(ctx context.Context, mondooOperatorIma
 
 	if !k8s.AreCronJobsEqual(*existing, *desired) {
 		existing.Spec.JobTemplate = desired.Spec.JobTemplate
+		existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 		if err := n.KubeClient.Update(ctx, existing); err != nil {

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -603,35 +603,6 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	s.Equal(created.Spec.Schedule, customSchedule)
 }
 
-func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomScheduleFail() {
-	s.seedNodes()
-	d := s.createDeploymentHandler()
-	mondooAuditConfig := &s.auditConfig
-	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
-
-	customSchedule := "this is not valid"
-	s.auditConfig.Spec.Nodes.Schedule = customSchedule
-
-	result, err := d.Reconcile(s.ctx)
-	s.NoError(err)
-	s.True(result.IsZero())
-
-	nodes := &corev1.NodeList{}
-	s.NoError(d.KubeClient.List(s.ctx, nodes))
-
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
-	s.NoError(err)
-
-	expected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
-
-	created := &batchv1.CronJob{}
-	created.Name = expected.Name
-	created.Namespace = expected.Namespace
-	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(created), created))
-
-	s.NotEqual(created.Spec.Schedule, customSchedule)
-}
-
 func (s *DeploymentHandlerSuite) createDeploymentHandler() DeploymentHandler {
 	return DeploymentHandler{
 		KubeClient:             s.fakeClientBuilder.Build(),

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -48,9 +48,6 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 			logger.Info("using cron custom schedule", "crontab", m.Spec.Nodes.Schedule)
 			cronTab = m.Spec.Nodes.Schedule
 		}
-	} else {
-		logger.Info("using default cron schedule", "crontab", cronTab)
-		m.Spec.Nodes.Schedule = cronTab
 	}
 	unsetHostPath := corev1.HostPathUnset
 

--- a/go.mod
+++ b/go.mod
@@ -342,7 +342,6 @@ require (
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -918,8 +918,6 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
-github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/pkg/utils/k8s/equality.go
+++ b/pkg/utils/k8s/equality.go
@@ -67,23 +67,60 @@ func AreServicesEqual(a, b corev1.Service) bool {
 func AreCronJobsEqual(a, b batchv1.CronJob) bool {
 	aPodSpec := a.Spec.JobTemplate.Spec.Template.Spec
 	bPodSpec := b.Spec.JobTemplate.Spec.Template.Spec
-	return len(aPodSpec.Containers) == len(bPodSpec.Containers) &&
-		aPodSpec.ServiceAccountName == bPodSpec.ServiceAccountName &&
-		reflect.DeepEqual(aPodSpec.Tolerations, bPodSpec.Tolerations) &&
-		reflect.DeepEqual(aPodSpec.NodeName, bPodSpec.NodeName) &&
-		reflect.DeepEqual(aPodSpec.Containers[0].Image, bPodSpec.Containers[0].Image) &&
-		reflect.DeepEqual(aPodSpec.Containers[0].Command, bPodSpec.Containers[0].Command) &&
-		reflect.DeepEqual(aPodSpec.Containers[0].Args, bPodSpec.Containers[0].Args) &&
-		reflect.DeepEqual(aPodSpec.Containers[0].VolumeMounts, bPodSpec.Containers[0].VolumeMounts) &&
-		AreEnvVarsEqual(aPodSpec.Containers[0].Env, bPodSpec.Containers[0].Env) &&
-		AreResouceRequirementsEqual(aPodSpec.Containers[0].Resources, bPodSpec.Containers[0].Resources) &&
-		AreSecurityContextsEqual(aPodSpec.Containers[0].SecurityContext, bPodSpec.Containers[0].SecurityContext) &&
-		reflect.DeepEqual(aPodSpec.Volumes, bPodSpec.Volumes) &&
-		reflect.DeepEqual(a.Spec.SuccessfulJobsHistoryLimit, b.Spec.SuccessfulJobsHistoryLimit) &&
-		reflect.DeepEqual(a.Spec.ConcurrencyPolicy, b.Spec.ConcurrencyPolicy) &&
-		a.Spec.Schedule == b.Spec.Schedule &&
-		reflect.DeepEqual(a.Spec.FailedJobsHistoryLimit, b.Spec.FailedJobsHistoryLimit) &&
-		reflect.DeepEqual(a.GetOwnerReferences(), b.GetOwnerReferences())
+
+	if len(aPodSpec.Containers) != len(bPodSpec.Containers) {
+		return false
+	}
+	if aPodSpec.ServiceAccountName != bPodSpec.ServiceAccountName {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Tolerations, bPodSpec.Tolerations) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.NodeName, bPodSpec.NodeName) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Containers[0].Image, bPodSpec.Containers[0].Image) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Containers[0].Command, bPodSpec.Containers[0].Command) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Containers[0].Args, bPodSpec.Containers[0].Args) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Containers[0].VolumeMounts, bPodSpec.Containers[0].VolumeMounts) {
+		return false
+	}
+	if !AreEnvVarsEqual(aPodSpec.Containers[0].Env, bPodSpec.Containers[0].Env) {
+		return false
+	}
+	if !AreResouceRequirementsEqual(aPodSpec.Containers[0].Resources, bPodSpec.Containers[0].Resources) {
+		return false
+	}
+	if !AreSecurityContextsEqual(aPodSpec.Containers[0].SecurityContext, bPodSpec.Containers[0].SecurityContext) {
+		return false
+	}
+	if !reflect.DeepEqual(aPodSpec.Volumes, bPodSpec.Volumes) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Spec.SuccessfulJobsHistoryLimit, b.Spec.SuccessfulJobsHistoryLimit) {
+		return false
+	}
+	if a.Spec.ConcurrencyPolicy != b.Spec.ConcurrencyPolicy {
+		return false
+	}
+	if a.Spec.Schedule != b.Spec.Schedule {
+		return false
+	}
+	if !reflect.DeepEqual(a.Spec.FailedJobsHistoryLimit, b.Spec.FailedJobsHistoryLimit) {
+		return false
+	}
+	if !reflect.DeepEqual(a.GetOwnerReferences(), b.GetOwnerReferences()) {
+		return false
+	}
+
+	return true
 }
 
 // AreResouceRequirementsEqual returns a value indicating whether 2 resource requirements are equal.

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -69,9 +69,9 @@ func DefaultAuditConfig(ns string, workloads, containers, nodes, admission bool)
 		},
 		Spec: mondoov2.MondooAuditConfigSpec{
 			MondooCredsSecretRef: corev1.LocalObjectReference{Name: MondooClientSecret},
-			KubernetesResources:  mondoov2.KubernetesResources{Enable: workloads},
-			Containers:           mondoov2.Containers{Enable: containers},
-			Nodes:                mondoov2.Nodes{Enable: nodes},
+			KubernetesResources:  mondoov2.KubernetesResources{Enable: workloads, Schedule: "0 * * * *"},
+			Containers:           mondoov2.Containers{Enable: containers, Schedule: "0 0 * * *"},
+			Nodes:                mondoov2.Nodes{Enable: nodes, Schedule: "0 * * * *"},
 			Admission:            mondoov2.Admission{Enable: admission},
 			Scanner: mondoov2.Scanner{
 				Image:    mondoov2.Image{Name: "test", Tag: "latest"},


### PR DESCRIPTION
2 issues here make the cronjobs be updated endlessly and never execute:
- the concurrency policy for cronjobs wasn't properly set in the update flow
- the crontab was never updated in the `MondooAuditConfig` when cronjobs just had to be updated. This meant that for existing installations of the operator, the cronjobs would never match what is in the `MondooAuditConfig`. The CRD would always have an empty `Schedule` and the cronjobs would always try to use the current time to create a schedule