### PR TITLE
🧹 restructure test logs for e2e tests

### DIFF
--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -138,7 +138,8 @@ func (i *MondooInstaller) UninstallOperator() error {
 		zap.S().Warn("Operator not installed. Skip gathering logs...")
 		return nil
 	}
-	i.K8sHelper.GetLogsFromNamespace(i.Settings.Namespace, i.T().Name())
+
+	i.K8sHelper.GetLogsFromNamespace(i.Settings.Namespace, i.Settings.SuiteName, i.T().Name())
 
 	if err := i.CleanupAuditConfigs(); err != nil {
 		return err
@@ -210,9 +211,9 @@ func (i *MondooInstaller) CreateClientSecret(ns string) error {
 func (i *MondooInstaller) GatherAllMondooLogs(testName string, namespaces ...string) {
 	zap.S().Infof("gathering all logs from the test")
 	for _, namespace := range namespaces {
-		i.K8sHelper.GetLogsFromNamespace(namespace, testName)
-		i.K8sHelper.GetDescribeFromNamespace(namespace, testName)
-		i.K8sHelper.GetEventsFromNamespace(namespace, testName)
+		i.K8sHelper.GetLogsFromNamespace(namespace, i.Settings.SuiteName, testName)
+		i.K8sHelper.GetDescribeFromNamespace(namespace, i.Settings.SuiteName, testName)
+		i.K8sHelper.GetEventsFromNamespace(namespace, i.Settings.SuiteName, testName)
 	}
 }
 

--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -12,6 +12,7 @@ import (
 const MondooNamespace = "mondoo-operator"
 
 type Settings struct {
+	SuiteName      string
 	Namespace      string
 	token          string
 	installRelease bool

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -26,6 +26,7 @@ type AuditConfigCustomNamespaceSuite struct {
 
 func (s *AuditConfigCustomNamespaceSuite) SetupSuite() {
 	s.AuditConfigBaseSuite.SetupSuite()
+	s.testCluster.MondooInstaller.Settings.SuiteName = "AuditConfigCustomNamespaceSuite"
 
 	s.ns = &corev1.Namespace{}
 	s.ns.Name = "some-namespace"

--- a/tests/integration/audit_config_oom_test.go
+++ b/tests/integration/audit_config_oom_test.go
@@ -26,6 +26,11 @@ type AuditConfigOOMSuite struct {
 	AuditConfigBaseSuite
 }
 
+func (s *AuditConfigOOMSuite) SetupSuite() {
+	s.AuditConfigBaseSuite.SetupSuite()
+	s.testCluster.MondooInstaller.Settings.SuiteName = "AuditConfigOOMSuite"
+}
+
 func (s *AuditConfigOOMSuite) TestOOMControllerReporting() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, false)
 	s.auditConfig = auditConfig

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -17,6 +17,11 @@ type AuditConfigSuite struct {
 	AuditConfigBaseSuite
 }
 
+func (s *AuditConfigSuite) SetupSuite() {
+	s.AuditConfigBaseSuite.SetupSuite()
+	s.testCluster.MondooInstaller.Settings.SuiteName = "AuditConfigSuite"
+}
+
 func (s *AuditConfigSuite) TestReconcile_AllDisabled() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, false, false)
 	s.testMondooAuditConfigAllDisabled(auditConfig)

--- a/tests/integration/audit_config_upgrade_test.go
+++ b/tests/integration/audit_config_upgrade_test.go
@@ -16,6 +16,11 @@ type AuditConfigUpgradeSuite struct {
 	AuditConfigBaseSuite
 }
 
+func (s *AuditConfigUpgradeSuite) SetupSuite() {
+	s.AuditConfigBaseSuite.SetupSuite()
+	s.testCluster.MondooInstaller.Settings.SuiteName = "AuditConfigUpgradeSuite"
+}
+
 func (s *AuditConfigUpgradeSuite) AfterTest(suiteName, testName string) {
 	if s.testCluster != nil {
 		s.testCluster.GatherAllMondooLogs(testName, installer.MondooNamespace)


### PR DESCRIPTION
this doesn't change anything functionally but makes a more human-friendly structure of the test logs. We now store the logs for a suite in a separate folder. Inside there is a folder for each individual test:
![image](https://github.com/mondoohq/mondoo-operator/assets/16187050/5abe1432-b10b-4f81-9f70-620902e799ec)
