### PR TITLE
🐛 fix admission update flow

### DIFF
--- a/controllers/admission/deployment_handler.go
+++ b/controllers/admission/deployment_handler.go
@@ -268,14 +268,9 @@ func (n *DeploymentHandler) syncWebhookDeployment(ctx context.Context) error {
 	// Not a full check for whether someone has modified our Deployment, but checking for some important bits so we know
 	// if an Update() is needed.
 	if !k8s.AreDeploymentsEqual(*existingDeployment, *desiredDeployment) {
-		// Note: changes to the labels/selector labels means we can't Update() the
-		// Deployment, so we'll do a delete/create instead.
-		if err := k8s.DeleteIfExists(ctx, n.KubeClient, existingDeployment); err != nil {
-			webhookLog.Error(err, "failed to delete exising webhook Deployment")
-			return err
-		}
-		if _, err := k8s.CreateIfNotExist(ctx, n.KubeClient, existingDeployment, desiredDeployment); err != nil {
-			webhookLog.Error(err, "failed to replace exising webhook Deployment")
+		k8s.UpdateDeployment(existingDeployment, *desiredDeployment)
+		if err := n.KubeClient.Update(ctx, existingDeployment); err != nil {
+			webhookLog.Error(err, "failed to update exising webhook Deployment")
 			return err
 		}
 	}


### PR DESCRIPTION
I don't understand why we ever did that. It is causing issues in enforcing mode since we are deleting the only available webhook and then we brick the cluster because nothing can pass

We do the same type of update flow for the scan api, for example, with no issues