### PR TITLE
🧹 extend the timeout for the validating webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -32,3 +32,5 @@ webhooks:
     - jobs
     - cronjobs
   sideEffects: None
+  # The default is 10s but on slow clusters we may take longer
+  timeout: 20s

--- a/controllers/admission/webhook-manifests.yaml
+++ b/controllers/admission/webhook-manifests.yaml
@@ -31,3 +31,5 @@ webhooks:
     - jobs
     - cronjobs
   sideEffects: None
+  # The default is 10s but on slow clusters we may take longer
+  timeout: 20s


### PR DESCRIPTION
occasionally our integration tests fail because the scan api takes longer than 10s to respond to an admission call. Here we change the default 10s timeout to a longer one to make sure the tests succeed even on slower clusters