### PR TITLE
🧹 properly set the validating webhook timeout

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -11,3 +11,6 @@ images:
 - name: controller
   newName: ghcr.io/mondoohq/mondoo-operator
   newTag: v1.21.0
+
+patchesStrategicMerge:
+- webhook_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -32,5 +32,3 @@ webhooks:
     - jobs
     - cronjobs
   sideEffects: None
-  # The default is 10s but on slow clusters we may take longer
-  timeout: 20s

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: policy.k8s.mondoo.com
+  # The default is 10s but on slow clusters we may take longer
+  timeout: 20s

--- a/controllers/admission/webhook-manifests.yaml
+++ b/controllers/admission/webhook-manifests.yaml
@@ -1,7 +1,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mondoo-operator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -31,5 +30,4 @@ webhooks:
     - jobs
     - cronjobs
   sideEffects: None
-  # The default is 10s but on slow clusters we may take longer
   timeout: 20s


### PR DESCRIPTION
the files are auto-generate, so we have to add the timeout via a patch