### PR TITLE
🧹 set node scan conditions before setting up node gc

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -126,10 +126,6 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 	}
 
-	if err := n.syncGCCronjob(ctx, mondooOperatorImage, clusterUid); err != nil {
-		return err
-	}
-
 	// Delete dangling CronJobs for nodes that have been deleted from the cluster.
 	if err := n.cleanupCronJobsForDeletedNodes(ctx, *nodes); err != nil {
 		return err
@@ -156,6 +152,10 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	}
 
 	updateNodeConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)
+
+	if err := n.syncGCCronjob(ctx, mondooOperatorImage, clusterUid); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
first update the node scan conditions and then configure node GC. This makes sure the node GC doesn't interfere with status reporting