### PR TITLE
🧹 assert scored policies in e2e tests

### DIFF
--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -1150,7 +1150,7 @@ func (s *AuditConfigBaseSuite) AssetsNotUnscored(assets []assets.AssetWithScore)
 			expectedPolicies := defaultK8sNodePolicyMrns
 			if strings.Contains(asset.Platform.Name, "k8s") {
 				expectedPolicies = defaultK8sPolicyMrns
-			} else if strings.Contains(asset.Name, "nginx") || strings.Contains(asset.Name, "redis") {
+			} else if strings.Contains(asset.Name, "nginx") || strings.Contains(asset.Name, "redis") || strings.Contains(asset.Name, "k3d") {
 				expectedPolicies = defaultOsPolicyMrns
 			}
 			s.ElementsMatchf(expectedPolicies, scoredPolicies, "Scored policies for asset %s should be the default k8s policies", asset.Name)


### PR DESCRIPTION
Explicitly assert which policies have been scored for each asset. Useful to make sure we aren't scoring policies that shouldn't be scored for a specific asset type