### PR TITLE
🐛 fix private image container scans

### DIFF
--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -34,8 +34,8 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 
 	cmd := []string{
 		"cnspec", "scan", "k8s",
-		"--config", "/etc/opt/mondoo/mondoo.yml",
-		"--inventory-file", "/etc/opt/mondoo/inventory.yml",
+		"--config", "/etc/opt/mondoo/config/mondoo.yml",
+		"--inventory-file", "/etc/opt/mondoo/config/inventory.yml",
 		"--score-threshold", "0",
 	}
 
@@ -89,7 +89,7 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 										{
 											Name:      "config",
 											ReadOnly:  true,
-											MountPath: "/etc/opt/",
+											MountPath: "/etc/opt/mondoo/config",
 										},
 										{
 											Name:      "temp",
@@ -118,7 +118,7 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 														LocalObjectReference: corev1.LocalObjectReference{Name: ConfigMapName(m.Name)},
 														Items: []corev1.KeyToPath{{
 															Key:  "inventory",
-															Path: "mondoo/inventory.yml",
+															Path: "inventory.yml",
 														}},
 													},
 												},
@@ -127,7 +127,7 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 														LocalObjectReference: m.Spec.MondooCredsSecretRef,
 														Items: []corev1.KeyToPath{{
 															Key:  "config",
-															Path: "mondoo/mondoo.yml",
+															Path: "mondoo.yml",
 														}},
 													},
 												},

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -1119,13 +1119,11 @@ var (
 	}
 	defaultK8sNodePolicyMrns = []string{
 		"//policy.api.mondoo.app/policies/platform-eol",
-		"//policy.api.mondoo.app/policies/platform-vulnerability",
 		"//policy.api.mondoo.app/policies/mondoo-kubernetes-security",
 		"//policy.api.mondoo.app/policies/mondoo-linux-security",
 	}
 	defaultOsPolicyMrns = []string{
 		"//policy.api.mondoo.app/policies/platform-eol",
-		"//policy.api.mondoo.app/policies/platform-vulnerability",
 		"//policy.api.mondoo.app/policies/mondoo-linux-security",
 	}
 )


### PR DESCRIPTION
makes sure private container image scans work. The issue was that the container pull secrets were overriding the mondoo folder, so the mondoo config was no longer available. That resulted in failure to communicate with upstream