### PR TITLE
⭐️ allow using deployments for node scans

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -90,11 +90,23 @@ type KubernetesResources struct {
 	Schedule string `json:"schedule,omitempty"`
 }
 
+// NodeScanStyle specifies the scan style for nodes
+type NodeScanStyle string
+
+const (
+	NodeScanStyle_CronJob    NodeScanStyle = "cronjob"
+	NodeScanStyle_Deployment NodeScanStyle = "deployment"
+)
+
 type Nodes struct {
 	Enable    bool                        `json:"enable,omitempty"`
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Specify a custom crontab schedule for the node scanning job. If not specified, the default schedule is used.
 	Schedule string `json:"schedule,omitempty"`
+	// Style is the style of the node scanning. The default is "cronjob" which will create a CronJob for the node scanning.
+	// +kubebuilder:validation:Enum=cronjob;deployment
+	// +kubebuilder:default=cronjob
+	Style NodeScanStyle `json:"style,omitempty"`
 }
 
 type Admission struct {

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -101,8 +101,13 @@ const (
 type Nodes struct {
 	Enable    bool                        `json:"enable,omitempty"`
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	// Specify a custom crontab schedule for the node scanning job. If not specified, the default schedule is used.
+	// Schedule specifies a custom crontab schedule for the node scanning job. If not specified, the default schedule is
+	// used. Only applicable for CronJob style
 	Schedule string `json:"schedule,omitempty"`
+	// IntervalTimer is the interval (in minutes) for the node scanning. The default is "60". Only applicable for Deployment
+	// style.
+	// +kubebuilder:default=60
+	IntervalTimer int `json:"intervalTimer,omitempty"`
 	// Style is the style of the node scanning. The default is "cronjob" which will create a CronJob for the node scanning.
 	// +kubebuilder:validation:Enum=cronjob;deployment
 	// +kubebuilder:default=cronjob

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -108,7 +108,7 @@ type Nodes struct {
 	// style.
 	// +kubebuilder:default=60
 	IntervalTimer int `json:"intervalTimer,omitempty"`
-	// Style is the style of the node scanning. The default is "cronjob" which will create a CronJob for the node scanning.
+	// Style specifies how node scanning is deployed. The default is "cronjob" which will create a CronJob for the node scanning.
 	// +kubebuilder:validation:Enum=cronjob;deployment
 	// +kubebuilder:default=cronjob
 	Style NodeScanStyle `json:"style,omitempty"`

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -112,6 +112,8 @@ type Nodes struct {
 	// +kubebuilder:validation:Enum=cronjob;deployment
 	// +kubebuilder:default=cronjob
 	Style NodeScanStyle `json:"style,omitempty"`
+	// PriorityClassName specifies the name of the PriorityClass for the node scanning workloads.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type Admission struct {

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -275,8 +275,9 @@ spec:
                     type: string
                   style:
                     default: cronjob
-                    description: Style is the style of the node scanning. The default
-                      is "cronjob" which will create a CronJob for the node scanning.
+                    description: Style specifies how node scanning is deployed. The
+                      default is "cronjob" which will create a CronJob for the node
+                      scanning.
                     enum:
                     - cronjob
                     - deployment

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -218,6 +218,10 @@ spec:
                       node scanning. The default is "60". Only applicable for Deployment
                       style.
                     type: integer
+                  priorityClassName:
+                    description: PriorityClassName specifies the name of the PriorityClass
+                      for the node scanning workloads.
+                    type: string
                   resources:
                     description: ResourceRequirements describes the compute resource
                       requirements.

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -212,6 +212,12 @@ spec:
                 properties:
                   enable:
                     type: boolean
+                  intervalTimer:
+                    default: 60
+                    description: IntervalTimer is the interval (in minutes) for the
+                      node scanning. The default is "60". Only applicable for Deployment
+                      style.
+                    type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -263,8 +269,9 @@ spec:
                         type: object
                     type: object
                   schedule:
-                    description: Specify a custom crontab schedule for the node scanning
-                      job. If not specified, the default schedule is used.
+                    description: Schedule specifies a custom crontab schedule for
+                      the node scanning job. If not specified, the default schedule
+                      is used. Only applicable for CronJob style
                     type: string
                   style:
                     default: cronjob

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -266,6 +266,14 @@ spec:
                     description: Specify a custom crontab schedule for the node scanning
                       job. If not specified, the default schedule is used.
                     type: string
+                  style:
+                    default: cronjob
+                    description: Style is the style of the node scanning. The default
+                      is "cronjob" which will create a CronJob for the node scanning.
+                    enum:
+                    - cronjob
+                    - deployment
+                    type: string
                 type: object
               scanner:
                 description: Scanner defines the settings for the Mondoo scanner that

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -375,7 +375,7 @@ func isCronJobScanPod(a v1alpha2.MondooAuditConfig, podLabels map[string]string)
 
 	// Check whether it is a Pod for node scanning
 	if a.Spec.Nodes.Enable {
-		nodeCronJobLabels := nodes.CronJobLabels(a)
+		nodeCronJobLabels := nodes.NodeScanningLabels(a)
 		// podLabels should include all of the labels from type of the CronJobs
 		for k, v := range nodeCronJobLabels {
 			if val, ok := podLabels[k]; ok {

--- a/controllers/mondooauditconfig_controller_test.go
+++ b/controllers/mondooauditconfig_controller_test.go
@@ -654,7 +654,7 @@ func TestIsCronJobScanPod(t *testing.T) {
 		},
 	}
 
-	nodeCronJobLabels := nodes.CronJobLabels(a)
+	nodeCronJobLabels := nodes.NodeScanningLabels(a)
 	resourceCronJobLabels := k8s_scan.CronJobLabels(a)
 	imageCronJobLabels := container_image.CronJobLabels(a)
 

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -400,6 +400,14 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 			return err
 		}
 
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: DeploymentName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace},
+		}
+		if err := k8s.DeleteIfExists(ctx, n.KubeClient, dep); err != nil {
+			logger.Error(err, "Failed to clean up node scanning Deployment", "namespace", dep.Namespace, "name", dep.Name)
+			return err
+		}
+
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace},
 		}

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -357,7 +357,7 @@ func (n *DeploymentHandler) cleanupDeploymentsForDeletedNodes(ctx context.Contex
 		logger.Info("Deleted Deployment", "namespace", d.Namespace, "name", d.Name)
 
 		configMap := &corev1.ConfigMap{}
-		configMap.Name = ConfigMapName(n.Mondoo.Name, d.Spec.Template.Spec.NodeName)
+		configMap.Name = ConfigMapName(n.Mondoo.Name, d.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"])
 		configMap.Namespace = n.Mondoo.Namespace
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
 			logger.Error(err, "Failed to delete ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -5,17 +5,18 @@ package nodes
 
 import (
 	"context"
-	"reflect"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var logger = ctrl.Log.WithName("node-scanning")
@@ -33,8 +34,14 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 		return ctrl.Result{}, n.down(ctx)
 	}
 
-	if err := n.syncCronJob(ctx); err != nil {
-		return ctrl.Result{}, err
+	if n.Mondoo.Spec.Nodes.Style == v1alpha2.NodeScanStyle_CronJob {
+		if err := n.syncCronJob(ctx); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else if n.Mondoo.Spec.Nodes.Style == v1alpha2.NodeScanStyle_Deployment {
+		if err := n.syncDeployment(ctx); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	return ctrl.Result{}, nil
 }
@@ -159,53 +166,118 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	return nil
 }
 
+func (n *DeploymentHandler) syncDeployment(ctx context.Context) error {
+	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
+		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+	if err != nil {
+		logger.Error(err, "Failed to resolve mondoo-client container image")
+		return err
+	}
+
+	mondooOperatorImage, err := n.ContainerImageResolver.MondooOperatorImage(ctx, "", "", n.MondooOperatorConfig.Spec.SkipContainerResolution)
+	if err != nil {
+		logger.Error(err, "Failed to resolve mondoo-operator container image")
+		return err
+	}
+
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	if err != nil {
+		logger.Error(err, "Failed to get cluster's UID")
+		return err
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := n.KubeClient.List(ctx, nodes); err != nil {
+		logger.Error(err, "Failed to list cluster nodes")
+		return err
+	}
+
+	// Create/update Deployments for nodes
+	for _, node := range nodes.Items {
+		updated, err := n.syncConfigMap(ctx, node, clusterUid)
+		if err != nil {
+			return err
+		}
+
+		if updated {
+			logger.Info(
+				"Inventory ConfigMap was just updated. The deployment will use the new config during the next scheduled run.",
+				"namespace", n.Mondoo.Namespace,
+				"name", DeploymentName(n.Mondoo.Name, node.Name))
+		}
+
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
+		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, dep, n.Mondoo, logger, func() error {
+			UpdateDeployment(dep, node, *n.Mondoo, n.IsOpenshift, mondooClientImage, *n.MondooOperatorConfig)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		if op == controllerutil.OperationResultCreated {
+			// TODO: fix the status update
+			err = mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger)
+			if err != nil {
+				logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
+				return err
+			}
+			continue
+		}
+	}
+
+	// Delete dangling Deployments for nodes that have been deleted from the cluster.
+	if err := n.cleanupDeploymentsForDeletedNodes(ctx, *nodes); err != nil {
+		return err
+	}
+
+	// List the Deployments again after they have been synced.
+	deployments, err := n.getDeploymentsForAuditConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get Pods for these Deployments
+	pods := &corev1.PodList{}
+	if len(deployments) > 0 {
+		opts := &client.ListOptions{
+			Namespace:     n.Mondoo.Namespace,
+			LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
+		}
+		err = n.KubeClient.List(ctx, pods, opts)
+		if err != nil {
+			logger.Error(err, "Failed to list Pods for Node Scanning")
+			return err
+		}
+	}
+
+	// updateNodeConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)
+
+	if err := n.syncGCCronjob(ctx, mondooOperatorImage, clusterUid); err != nil {
+		return err
+	}
+	return nil
+}
+
 // syncConfigMap syncs the inventory ConfigMap. Returns a boolean indicating whether the ConfigMap has been updated. It
 // can only be "true", if the ConfigMap existed before this reconcile cycle and the inventory was different from the
 // desired state.
 func (n *DeploymentHandler) syncConfigMap(ctx context.Context, node corev1.Node, clusterUid string) (bool, error) {
-	existing := &corev1.ConfigMap{}
-
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
 		logger.Error(err, "failed to retrieve IntegrationMRN")
 		return false, err
 	}
 
-	desired, err := ConfigMap(node, integrationMrn, clusterUid, *n.Mondoo)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
+	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cm, n.Mondoo, logger, func() error {
+		return UpdateConfigMap(cm, node, integrationMrn, clusterUid, *n.Mondoo)
+	})
 	if err != nil {
-		logger.Error(err, "failed to generate desired ConfigMap with inventory")
 		return false, err
 	}
 
-	if err := ctrl.SetControllerReference(n.Mondoo, desired, n.KubeClient.Scheme()); err != nil {
-		logger.Error(err, "Failed to set ControllerReference", "namespace", desired.Namespace, "name", desired.Name)
-		return false, err
-	}
-
-	created, err := k8s.CreateIfNotExist(ctx, n.KubeClient, existing, desired)
-	if err != nil {
-		logger.Error(err, "Failed to create inventory ConfigMap", "namespace", desired.Namespace, "name", desired.Name)
-		return false, err
-	}
-
-	if created {
-		logger.Info("Created inventory ConfigMap", "namespace", desired.Namespace, "name", desired.Name)
-		return false, nil
-	}
-
-	updated := false
-	if existing.Data["inventory"] != desired.Data["inventory"] ||
-		!reflect.DeepEqual(existing.GetOwnerReferences(), desired.GetOwnerReferences()) {
-		existing.Data["inventory"] = desired.Data["inventory"]
-		existing.SetOwnerReferences(desired.GetOwnerReferences())
-
-		if err := n.KubeClient.Update(ctx, existing); err != nil {
-			logger.Error(err, "Failed to update inventory ConfigMap", "namespace", existing.Namespace, "name", existing.Name)
-			return false, err
-		}
-		updated = true
-	}
-	return updated, nil
+	return op == controllerutil.OperationResultUpdated, nil
 }
 
 // cleanupCronJobsForDeletedNodes deletes dangling CronJobs for nodes that have been deleted from the cluster.
@@ -239,6 +311,46 @@ func (n *DeploymentHandler) cleanupCronJobsForDeletedNodes(ctx context.Context, 
 
 		configMap := &corev1.ConfigMap{}
 		configMap.Name = ConfigMapName(n.Mondoo.Name, c.Spec.JobTemplate.Spec.Template.Spec.NodeName)
+		configMap.Namespace = n.Mondoo.Namespace
+		if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
+			logger.Error(err, "Failed to delete ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupDeploymentsForDeletedNodes deletes dangling Deployments for nodes that have been deleted from the cluster.
+func (n *DeploymentHandler) cleanupDeploymentsForDeletedNodes(ctx context.Context, currentNodes corev1.NodeList) error {
+	deployments, err := n.getDeploymentsForAuditConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range deployments {
+		// Check if the node for that Deployment is still present in the cluster.
+		found := false
+		for _, node := range currentNodes.Items {
+			if DeploymentName(n.Mondoo.Name, node.Name) == d.Name {
+				found = true
+				break
+			}
+		}
+
+		// If the node is still there, there is nothing to update.
+		if found {
+			continue
+		}
+
+		// If the node for the Deployment has been deleted from the cluster, the Deployment needs to be deleted.
+		if err := k8s.DeleteIfExists(ctx, n.KubeClient, &d); err != nil {
+			logger.Error(err, "Failed to deleted Deployment", "namespace", d.Namespace, "name", d.Name)
+			return err
+		}
+		logger.Info("Deleted Deployment", "namespace", d.Namespace, "name", d.Name)
+
+		configMap := &corev1.ConfigMap{}
+		configMap.Name = ConfigMapName(n.Mondoo.Name, d.Spec.Template.Spec.NodeName)
 		configMap.Namespace = n.Mondoo.Namespace
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
 			logger.Error(err, "Failed to delete ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
@@ -292,6 +404,19 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 		return nil, err
 	}
 	return cronJobs.Items, nil
+}
+
+func (n *DeploymentHandler) getDeploymentsForAuditConfig(ctx context.Context) ([]appsv1.Deployment, error) {
+	deps := &appsv1.DeploymentList{}
+	depLabels := CronJobLabels(*n.Mondoo)
+
+	// Lists only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
+	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(depLabels)}
+	if err := n.KubeClient.List(ctx, deps, listOpts); err != nil {
+		logger.Error(err, "Failed to list Deployments in namespace", "namespace", n.Mondoo.Namespace)
+		return nil, err
+	}
+	return deps.Items, nil
 }
 
 func (n *DeploymentHandler) down(ctx context.Context) error {

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -117,7 +117,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			// Remove any old jobs because they won't be updated when the cronjob changes
 			if err := n.KubeClient.DeleteAllOf(ctx, &batchv1.Job{},
 				client.InNamespace(n.Mondoo.Namespace),
-				client.MatchingLabels(CronJobLabels(*n.Mondoo)),
+				client.MatchingLabels(NodeScanningLabels(*n.Mondoo)),
 				client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	if len(cronJobs) > 0 {
 		opts := &client.ListOptions{
 			Namespace:     n.Mondoo.Namespace,
-			LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
+			LabelSelector: labels.SelectorFromSet(NodeScanningLabels(*n.Mondoo)),
 		}
 		err = n.KubeClient.List(ctx, pods, opts)
 		if err != nil {
@@ -241,7 +241,7 @@ func (n *DeploymentHandler) syncDeployment(ctx context.Context) error {
 	if len(deployments) > 0 {
 		opts := &client.ListOptions{
 			Namespace:     n.Mondoo.Namespace,
-			LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
+			LabelSelector: labels.SelectorFromSet(NodeScanningLabels(*n.Mondoo)),
 		}
 		err = n.KubeClient.List(ctx, pods, opts)
 		if err != nil {
@@ -378,7 +378,7 @@ func (n *DeploymentHandler) syncGCCronjob(ctx context.Context, mondooOperatorIma
 
 func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]batchv1.CronJob, error) {
 	cronJobs := &batchv1.CronJobList{}
-	cronJobLabels := CronJobLabels(*n.Mondoo)
+	cronJobLabels := NodeScanningLabels(*n.Mondoo)
 
 	// Lists only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
@@ -391,7 +391,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 
 func (n *DeploymentHandler) getDeploymentsForAuditConfig(ctx context.Context) ([]appsv1.Deployment, error) {
 	deps := &appsv1.DeploymentList{}
-	depLabels := CronJobLabels(*n.Mondoo)
+	depLabels := NodeScanningLabels(*n.Mondoo)
 
 	// Lists only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(depLabels)}

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -304,7 +304,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_Switch() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	cronjobs := &batchv1.CronJobList{}
 	s.NoError(d.KubeClient.List(s.ctx, cronjobs, listOpts))
@@ -384,7 +384,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	cronJobs := &batchv1.CronJobList{}
 	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
@@ -472,7 +472,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDeployments_Switch() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	deployments := &appsv1.DeploymentList{}
 	s.NoError(d.KubeClient.List(s.ctx, deployments, listOpts))
@@ -554,7 +554,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanDeploymentsForDeletedNodes()
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	deployments := &appsv1.DeploymentList{}
 	s.NoError(d.KubeClient.List(s.ctx, deployments, listOpts))
@@ -590,7 +590,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CronJob_NodeScanningStatus() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	cronJobs := &batchv1.CronJobList{}
 	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
@@ -665,7 +665,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Deployment_NodeScanningStatus() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	deployments := &appsv1.DeploymentList{}
 	s.NoError(d.KubeClient.List(s.ctx, deployments, listOpts))
@@ -738,7 +738,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 
 	listOpts := &client.ListOptions{
 		Namespace:     s.auditConfig.Namespace,
-		LabelSelector: labels.SelectorFromSet(CronJobLabels(s.auditConfig)),
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
 	}
 	cronJobs := &batchv1.CronJobList{}
 	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
@@ -747,7 +747,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_NodeScanningOOMStatus() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-scan-123",
 			Namespace: s.auditConfig.Namespace,
-			Labels:    CronJobLabels(s.auditConfig),
+			Labels:    NodeScanningLabels(s.auditConfig),
 			CreationTimestamp: metav1.Time{
 				Time: time.Now(),
 			},

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -39,7 +39,7 @@ const (
 )
 
 func UpdateCronJob(cj *batchv1.CronJob, image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) {
-	ls := CronJobLabels(*m)
+	ls := NodeScanningLabels(*m)
 	cmd := []string{
 		"cnspec", "scan", "local",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
@@ -180,7 +180,7 @@ func UpdateDeployment(
 	image string,
 	cfg v1alpha2.MondooOperatorConfig,
 ) {
-	labels := CronJobLabels(m)
+	labels := NodeScanningLabels(m)
 	cmd := []string{
 		"cnspec", "serve",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
@@ -308,7 +308,7 @@ func UpdateDeployment(
 }
 
 func UpdateGarbageCollectCronJob(cj *batchv1.CronJob, image, clusterUid string, m v1alpha2.MondooAuditConfig) {
-	ls := CronJobLabels(m)
+	ls := NodeScanningLabels(m)
 
 	cronTab := fmt.Sprintf("%d */12 * * *", time.Now().Add(1*time.Minute).Minute())
 	scanApiUrl := scanapi.ScanApiServiceUrl(m)
@@ -470,7 +470,7 @@ func Inventory(node corev1.Node, integrationMRN, clusterUID string, m v1alpha2.M
 	return string(invBytes), nil
 }
 
-func CronJobLabels(m v1alpha2.MondooAuditConfig) map[string]string {
+func NodeScanningLabels(m v1alpha2.MondooAuditConfig) map[string]string {
 	return map[string]string{
 		"app":       "mondoo",
 		"scan":      "nodes",

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -182,7 +182,7 @@ func UpdateDeployment(
 		"cnspec", "serve",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
 		"--inventory-file", "/etc/opt/mondoo/inventory.yml",
-		// TODO: specify interval
+		"--timer", fmt.Sprintf("%d", m.Spec.Nodes.IntervalTimer),
 	}
 	if cfg.Spec.HttpProxy != nil {
 		cmd = append(cmd, []string{"--api-proxy", *cfg.Spec.HttpProxy}...)

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -203,7 +203,10 @@ func UpdateDeployment(
 	dep.Spec.Template.Annotations = map[string]string{
 		ignoreQueryAnnotationPrefix + "mondoo-kubernetes-security-pod-runasnonroot": ignoreAnnotationValue,
 	}
-	dep.Spec.Template.Spec.NodeName = node.Name
+	dep.Spec.Template.Spec.PriorityClassName = m.Spec.Nodes.PriorityClassName
+	dep.Spec.Template.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": node.Name,
+	}
 	dep.Spec.Template.Spec.Tolerations = k8s.TaintsToTolerations(node.Spec.Taints)
 	// The node scanning does not use the Kubernetes API at all, therefore the service account token
 	// should not be mounted at all.

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -13,6 +13,7 @@ import (
 	"go.mondoo.com/mondoo-operator/pkg/constants"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mondoo-operator/tests/framework/utils"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,8 +149,9 @@ func TestResources(t *testing.T) {
 				},
 			}
 			mac := *test.mondooauditconfig()
-			cronJobSepc := CronJob("test123", *testNode, &mac, false, v1alpha2.MondooOperatorConfig{})
-			assert.Equal(t, test.expectedResources, cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
+			cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: mac.Namespace}}
+			UpdateCronJob(cj, "test123", *testNode, &mac, false, v1alpha2.MondooOperatorConfig{})
+			assert.Equal(t, test.expectedResources, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 		})
 	}
 }
@@ -161,9 +163,10 @@ func TestCronJob_PrivilegedOpenshift(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cronJobSepc := CronJob("test123", *testNode, mac, true, v1alpha2.MondooOperatorConfig{})
-	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
-	assert.True(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: mac.Namespace}}
+	UpdateCronJob(cj, "test123", *testNode, mac, true, v1alpha2.MondooOperatorConfig{})
+	assert.True(t, *cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+	assert.True(t, *cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }
 
 func TestCronJob_Privileged(t *testing.T) {
@@ -173,9 +176,10 @@ func TestCronJob_Privileged(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cronJobSepc := CronJob("test123", *testNode, mac, false, v1alpha2.MondooOperatorConfig{})
-	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
-	assert.False(t, *cronJobSepc.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: mac.Namespace}}
+	UpdateCronJob(cj, "test123", *testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	assert.False(t, *cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+	assert.False(t, *cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }
 
 func TestInventory(t *testing.T) {

--- a/pkg/utils/k8s/create_update.go
+++ b/pkg/utils/k8s/create_update.go
@@ -1,0 +1,43 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func CreateOrUpdate(ctx context.Context, clnt client.Client, obj, owner client.Object, logger logr.Logger, mutate controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	op, err := ctrl.CreateOrUpdate(ctx, clnt, obj, func() error {
+		if err := mutate(); err != nil {
+			return err
+		}
+		if err := ctrl.SetControllerReference(owner, obj, clnt.Scheme()); err != nil {
+			logger.Error(err,
+				fmt.Sprintf("failed to set controller reference on %s", obj.GetObjectKind().GroupVersionKind().String()),
+				"key", client.ObjectKeyFromObject(obj).String(),
+				"owner", client.ObjectKeyFromObject(owner).String())
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Error(err,
+			fmt.Sprintf("error while creating/updating %s", obj.GetObjectKind().GroupVersionKind().String()),
+			"key", client.ObjectKeyFromObject(obj).String())
+		return op, err
+	}
+	if op != controllerutil.OperationResultNone {
+		logger.Info(
+			fmt.Sprintf("%s reconciled", obj.GetObjectKind().GroupVersionKind().String()),
+			"operation", op,
+			"key", client.ObjectKeyFromObject(obj).String())
+	}
+	return op, nil
+}

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -59,6 +59,7 @@ func DefaultAuditConfigMinimal(ns string, workloads, containers, nodes, admissio
 			Nodes: mondoov2.Nodes{
 				Enable:   nodes,
 				Schedule: schedule,
+				Style:    mondoov2.NodeScanStyle_CronJob,
 			},
 			Admission: mondoov2.Admission{Enable: admission},
 		},

--- a/tests/framework/utils/audit_config.go
+++ b/tests/framework/utils/audit_config.go
@@ -85,7 +85,7 @@ func DefaultAuditConfig(ns string, workloads, containers, nodes, admission bool)
 			MondooCredsSecretRef: corev1.LocalObjectReference{Name: MondooClientSecret},
 			KubernetesResources:  mondoov2.KubernetesResources{Enable: workloads, Schedule: "0 * * * *"},
 			Containers:           mondoov2.Containers{Enable: containers, Schedule: "0 0 * * *"},
-			Nodes:                mondoov2.Nodes{Enable: nodes, Schedule: "0 * * * *"},
+			Nodes:                mondoov2.Nodes{Enable: nodes, Schedule: "0 * * * *", Style: mondoov2.NodeScanStyle_CronJob},
 			Admission:            mondoov2.Admission{Enable: admission},
 			Scanner: mondoov2.Scanner{
 				Image:    mondoov2.Image{Name: "test", Tag: "latest"},

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -135,7 +135,7 @@ func (s *AuditConfigBaseSuite) AfterTest(suiteName, testName string) {
 		err = s.testCluster.K8sHelper.EnsureNoPodsPresent(containerScanListOpts)
 		s.NoErrorf(err, "Failed to wait for container scan pods to be gone")
 
-		nodeScanListOpts := &client.ListOptions{Namespace: s.auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(nodes.CronJobLabels(s.auditConfig))}
+		nodeScanListOpts := &client.ListOptions{Namespace: s.auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(nodes.NodeScanningLabels(s.auditConfig))}
 		err = s.testCluster.K8sHelper.EnsureNoPodsPresent(nodeScanListOpts)
 		s.NoErrorf(err, "Failed to wait for node scan pods to be gone")
 
@@ -334,7 +334,7 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesCronjobs(auditConfig mo
 	zap.S().Info("Verify the nodes scanning cron jobs are created.")
 
 	cronJobs := &batchv1.CronJobList{}
-	cronJobLabels := nodes.CronJobLabels(auditConfig)
+	cronJobLabels := nodes.NodeScanningLabels(auditConfig)
 
 	// List only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
@@ -453,7 +453,7 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesDeployments(auditConfig
 	zap.S().Info("Verify the nodes scanning deployments are created.")
 
 	deployments := &appsv1.DeploymentList{}
-	lbls := nodes.CronJobLabels(auditConfig)
+	lbls := nodes.NodeScanningLabels(auditConfig)
 
 	// List only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(lbls)}
@@ -483,17 +483,6 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesDeployments(auditConfig
 		}
 		s.Truef(found, "Deployment %s/%s does not have a corresponding cluster node.", d.Namespace, d.Name)
 	}
-
-	// Make sure we have 1 successful run for each CronJob
-	// selector := utils.LabelsToLabelSelector(lbls)
-	// s.True(s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(selector, auditConfig.Namespace), "Not all CronJobs have run successfully.")
-
-	// base := fmt.Sprintf("%s%s", auditConfig.Name, nodes.CronJobNameBase)
-	// for _, node := range nodeList.Items {
-	// 	nodeIdentifier := nodes.NodeNameOrHash(k8s.ResourceNameMaxLength-len(base), node.Name)
-	// 	err := s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-node-"+nodeIdentifier)
-	// 	s.NoErrorf(err, "Couldn't find NodeScan Pod for node "+node.Name+" in Podlist of the MondooAuditConfig Status")
-	// }
 
 	// Verify the garbage collect cron job
 	gcCronJobs := &batchv1.CronJobList{}

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -477,7 +477,7 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesDeployments(auditConfig
 	for _, d := range deployments.Items {
 		found := false
 		for _, n := range nodeList.Items {
-			if n.Name == d.Spec.Template.Spec.NodeName {
+			if n.Name == d.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"] {
 				found = true
 			}
 		}

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -317,7 +317,7 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigContainers(auditConfig mondo
 	s.Equal("ACTIVE", status)
 }
 
-func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.MondooAuditConfig) {
+func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesCronjobs(auditConfig mondoov2.MondooAuditConfig) {
 	s.auditConfig = auditConfig
 
 	// Disable container image resolution to be able to run the k8s resources scan CronJob with a local image.
@@ -424,6 +424,132 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodes(auditConfig mondoov2.M
 
 	// The number of assets from upstream is limited by paganiation.
 	// In case we have more than 100 workloads, we need to call this mutlple times, with different page numbers.
+	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
+	s.NoError(err, "Failed to list assets")
+	assetNames := utils.AssetNames(assets)
+
+	s.ElementsMatch(assetNames, nodeNames, "Node names do not match")
+	s.AssetsNotUnscored(assets)
+
+	status, err := s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ACTIVE", status)
+}
+
+func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesDeployments(auditConfig mondoov2.MondooAuditConfig) {
+	s.auditConfig = auditConfig
+
+	// Disable container image resolution to be able to run the k8s resources scan CronJob with a local image.
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	zap.S().Info("Create an audit config that enables only nodes scanning.")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
+
+	zap.S().Info("Verify the nodes scanning deployments are created.")
+
+	deployments := &appsv1.DeploymentList{}
+	lbls := nodes.CronJobLabels(auditConfig)
+
+	// List only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
+	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(lbls)}
+
+	nodeList := &corev1.NodeList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, nodeList))
+
+	// Verify the amount of Deployments created is equal to the amount of nodes
+	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, deployments, listOpts))
+		if len(nodeList.Items) == len(deployments.Items) {
+			return true, nil
+		}
+		return false, nil
+	})
+	s.NoErrorf(
+		err,
+		"The amount of node scanning Deployments is not equal to the amount of cluster nodes. expected: %d; actual: %d",
+		len(nodeList.Items), len(deployments.Items))
+
+	for _, d := range deployments.Items {
+		found := false
+		for _, n := range nodeList.Items {
+			if n.Name == d.Spec.Template.Spec.NodeName {
+				found = true
+			}
+		}
+		s.Truef(found, "Deployment %s/%s does not have a corresponding cluster node.", d.Namespace, d.Name)
+	}
+
+	// Make sure we have 1 successful run for each CronJob
+	// selector := utils.LabelsToLabelSelector(lbls)
+	// s.True(s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(selector, auditConfig.Namespace), "Not all CronJobs have run successfully.")
+
+	// base := fmt.Sprintf("%s%s", auditConfig.Name, nodes.CronJobNameBase)
+	// for _, node := range nodeList.Items {
+	// 	nodeIdentifier := nodes.NodeNameOrHash(k8s.ResourceNameMaxLength-len(base), node.Name)
+	// 	err := s.testCluster.K8sHelper.CheckForPodInStatus(&auditConfig, "client-node-"+nodeIdentifier)
+	// 	s.NoErrorf(err, "Couldn't find NodeScan Pod for node "+node.Name+" in Podlist of the MondooAuditConfig Status")
+	// }
+
+	// Verify the garbage collect cron job
+	gcCronJobs := &batchv1.CronJobList{}
+	gcCronJobLabels := nodes.GarbageCollectCronJobLabels(auditConfig)
+
+	// List only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
+	gcListOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(gcCronJobLabels)}
+
+	// Verify the amount of CronJobs created is 1
+	err = s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, gcCronJobs, gcListOpts))
+		if len(gcCronJobs.Items) == 1 {
+			return true, nil
+		}
+		return false, nil
+	})
+	s.NoErrorf(
+		err,
+		"The amount of garbage collect CronJobs is not 1 expected: 1; actual: %d", len(gcCronJobs.Items))
+
+	err = s.testCluster.K8sHelper.CheckForReconciledOperatorVersion(&auditConfig, version.Version)
+	s.NoErrorf(err, "Couldn't find expected version in MondooAuditConfig.Status.ReconciledByOperatorVersion")
+
+	// Sleep for a while since the scan happens only in about 1min since the deployment has started.
+	time.Sleep(40 * time.Second)
+
+	// Verify nodes are sent upstream and have scores.
+	nodes := &corev1.NodeList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, nodes))
+
+	nodeNames := make([]string, 0, len(nodes.Items))
+	for _, node := range nodes.Items {
+		nodeNames = append(nodeNames, node.Name)
+	}
+
+	// Retry until we see the assets in the space. We have no other way of checking whether the scan happened,
+	// since the deployment provides us with no feedback.
+	err = s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
+		if err != nil {
+			return false, err
+		}
+		if len(assets) == len(nodes.Items) {
+			for _, asset := range assets {
+				if asset.Grade == "U" {
+					return false, nil
+				}
+			}
+			return true, nil
+		}
+		return false, nil
+	})
+	s.Require().NoError(err)
+
+	// The number of assets from upstream is limited by paganiation.
+	// In case we have more than 100 workloads, we need to call this multiple times, with different page numbers.
 	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
 	s.NoError(err, "Failed to list assets")
 	assetNames := utils.AssetNames(assets)

--- a/tests/integration/audit_config_namespace_test.go
+++ b/tests/integration/audit_config_namespace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/tests/framework/utils"
 	"go.uber.org/zap"
 
@@ -95,10 +96,18 @@ func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Containers() {
 	s.testMondooAuditConfigContainers(auditConfig)
 }
 
-func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Nodes() {
+func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Nodes_CronJobs() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true, false)
 	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
-	s.testMondooAuditConfigNodes(auditConfig)
+	s.testMondooAuditConfigNodesCronjobs(auditConfig)
+}
+
+func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Nodes_Deployments() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.ns.Name, false, false, true, false)
+	auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment
+	auditConfig.Spec.Nodes.IntervalTimer = 1
+	auditConfig.Spec.Scanner.ServiceAccountName = s.sa.Name
+	s.testMondooAuditConfigNodesDeployments(auditConfig)
 }
 
 func (s *AuditConfigCustomNamespaceSuite) TestReconcile_Admission() {

--- a/tests/integration/audit_config_oom_test.go
+++ b/tests/integration/audit_config_oom_test.go
@@ -205,7 +205,7 @@ func (s *AuditConfigOOMSuite) TestOOMNodeScan_CronJob() {
 	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
 
 	cronJobs := &batchv1.CronJobList{}
-	cronJobLabels := nodes.CronJobLabels(auditConfig)
+	cronJobLabels := nodes.NodeScanningLabels(auditConfig)
 
 	// List only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
@@ -298,7 +298,7 @@ func (s *AuditConfigOOMSuite) TestOOMNodeScan_Deployment() {
 	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
 
 	deployments := &appsv1.DeploymentList{}
-	lbls := nodes.CronJobLabels(auditConfig)
+	lbls := nodes.NodeScanningLabels(auditConfig)
 
 	// List only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(lbls)}

--- a/tests/integration/audit_config_oom_test.go
+++ b/tests/integration/audit_config_oom_test.go
@@ -185,7 +185,7 @@ func (s *AuditConfigOOMSuite) TestOOMScanAPI() {
 	s.Equal("ACTIVE", status)
 }
 
-func (s *AuditConfigOOMSuite) TestOOMNodeScan() {
+func (s *AuditConfigOOMSuite) TestOOMNodeScan_CronJob() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
 	s.auditConfig = auditConfig
 
@@ -254,6 +254,99 @@ func (s *AuditConfigOOMSuite) TestOOMNodeScan() {
 			corev1.ResourceMemory: resource.MustParse("200Mi"), // this should be enough to get the ScanAPI running again
 		}
 		foundMondooAuditConfig.Spec.Nodes.Schedule = "*/1 * * * *"
+	})
+	s.Require().NoError(err)
+
+	// Wait for the next run of the CronJob
+	time.Sleep(30 * time.Second)
+
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.NodeScanningDegraded, corev1.ConditionFalse, "")
+	s.Require().NoError(err, "Failed to find degraded condition")
+	foundMondooAuditConfig, err = s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	cond = mondoo.FindMondooAuditConditions(foundMondooAuditConfig.Status.Conditions, mondoov2.ScanAPIDegraded)
+	s.Require().NotNil(cond)
+	s.NotContains(cond.Message, "OOM", "Found OOMKilled message in condition")
+	s.Len(cond.AffectedPods, 0, "Found a pod in condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err = s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ACTIVE", status)
+}
+
+func (s *AuditConfigOOMSuite) TestOOMNodeScan_Deployment() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
+	auditConfig.Spec.Nodes.Style = mondoov2.NodeScanStyle_Deployment
+	s.auditConfig = auditConfig
+
+	auditConfig.Spec.Nodes.Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("10Mi"), // this should be low enough to trigger an OOMkilled
+	}
+
+	// Disable container image resolution to be able to run the k8s resources scan CronJob with a local image.
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	zap.S().Info("Create an audit config that enables only nodes scanning. (with reduced memory limit)")
+	s.NoErrorf(
+		s.testCluster.K8sHelper.Clientset.Create(s.ctx, &auditConfig),
+		"Failed to create Mondoo audit config.")
+
+	s.Require().True(s.testCluster.K8sHelper.WaitUntilMondooClientSecretExists(s.ctx, s.auditConfig.Namespace), "Mondoo SA not created")
+
+	deployments := &appsv1.DeploymentList{}
+	lbls := nodes.CronJobLabels(auditConfig)
+
+	// List only the Deployments in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
+	listOpts := &client.ListOptions{Namespace: auditConfig.Namespace, LabelSelector: labels.SelectorFromSet(lbls)}
+
+	nodeList := &corev1.NodeList{}
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, nodeList))
+
+	// Verify the amount of Deployments created is equal to the amount of nodes
+	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, deployments, listOpts))
+		if len(nodeList.Items) == len(deployments.Items) {
+			return true, nil
+		}
+		return false, nil
+	})
+	s.NoErrorf(
+		err,
+		"The amount of node scanning Deployments is not equal to the amount of cluster nodes. expected: %d; actual: %d",
+		len(nodeList.Items), len(deployments.Items))
+
+	// This will take some time, because:
+	// reconcile needs to happen
+	// a new replicaset should be created
+	// the first Pod tries to start and gets killed
+	// on the 2nd start we should get an OOMkilled status update
+	err = s.testCluster.K8sHelper.CheckForDegradedCondition(&auditConfig, mondoov2.NodeScanningDegraded, corev1.ConditionTrue, "OOM")
+	s.Require().NoError(err, "Failed to find degraded condition")
+
+	foundMondooAuditConfig, err := s.testCluster.K8sHelper.GetMondooAuditConfigFromCluster(auditConfig.Name, auditConfig.Namespace)
+	s.NoError(err, "Failed to find MondooAuditConfig")
+	cond := mondoo.FindMondooAuditConditions(foundMondooAuditConfig.Status.Conditions, mondoov2.NodeScanningDegraded)
+	s.Require().NotNil(cond)
+	s.Containsf(cond.Message, "OOM", "Failed to find OOMKilled message in degraded condition")
+	s.Len(cond.AffectedPods, 1, "Failed to find only one pod in degraded condition")
+
+	// Give the integration a chance to update
+	time.Sleep(2 * time.Second)
+
+	status, err := s.integration.GetStatus(s.ctx)
+	s.NoError(err, "Failed to get status")
+	s.Equal("ERROR", status)
+
+	zap.S().Info("Increasing memory limit to get node Scans running again.")
+	err = s.testCluster.K8sHelper.UpdateAuditConfigWithRetries(auditConfig.Name, auditConfig.Namespace, func(config *mondoov2.MondooAuditConfig) {
+		config.Spec.Nodes.Resources.Limits = corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("200Mi"), // this should be enough to get the ScanAPI running again
+		}
+		foundMondooAuditConfig.Spec.Nodes.IntervalTimer = 1
 	})
 	s.Require().NoError(err)
 

--- a/tests/integration/audit_config_test.go
+++ b/tests/integration/audit_config_test.go
@@ -41,9 +41,16 @@ func (s *AuditConfigSuite) TestReconcile_Containers() {
 	s.testMondooAuditConfigContainers(auditConfig)
 }
 
-func (s *AuditConfigSuite) TestReconcile_Nodes() {
+func (s *AuditConfigSuite) TestReconcile_Nodes_CronJobs() {
 	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
-	s.testMondooAuditConfigNodes(auditConfig)
+	s.testMondooAuditConfigNodesCronjobs(auditConfig)
+}
+
+func (s *AuditConfigSuite) TestReconcile_Nodes_Deployments() {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, false, true, false)
+	auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment
+	auditConfig.Spec.Nodes.IntervalTimer = 1
+	s.testMondooAuditConfigNodesDeployments(auditConfig)
 }
 
 func (s *AuditConfigSuite) TestReconcile_AdmissionPermissive() {


### PR DESCRIPTION
Allow using deployments for node scans instead of cronjob. For fully utilized clusters, cronjobs may not be able to run. Even if we can schedule the job now, there is no guarantee the node will have resources 1h from now. Using deployments ensures that once the deployment is scheduled it will always run a node scan, because the resources are already reserved.