### PR TITLE
🐛 fix node scanning deployments update loop

### DIFF
--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -192,17 +192,19 @@ func UpdateDeployment(
 	}
 
 	dep.Labels = labels
-	dep.Annotations = map[string]string{
-		ignoreQueryAnnotationPrefix + "mondoo-kubernetes-security-deployment-runasnonroot": ignoreAnnotationValue,
+	if dep.Annotations == nil {
+		dep.Annotations = map[string]string{}
 	}
+	dep.Annotations[ignoreQueryAnnotationPrefix+"mondoo-kubernetes-security-deployment-runasnonroot"] = ignoreAnnotationValue
 	dep.Spec.Replicas = ptr.To(int32(1))
 	dep.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: labels,
 	}
 	dep.Spec.Template.Labels = labels
-	dep.Spec.Template.Annotations = map[string]string{
-		ignoreQueryAnnotationPrefix + "mondoo-kubernetes-security-pod-runasnonroot": ignoreAnnotationValue,
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
 	}
+	dep.Spec.Template.Annotations[ignoreQueryAnnotationPrefix+"mondoo-kubernetes-security-pod-runasnonroot"] = ignoreAnnotationValue
 	dep.Spec.Template.Spec.PriorityClassName = m.Spec.Nodes.PriorityClassName
 	dep.Spec.Template.Spec.NodeSelector = map[string]string{
 		"kubernetes.io/hostname": node.Name,

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -549,6 +549,12 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesDeployments(auditConfig
 	status, err := s.integration.GetStatus(s.ctx)
 	s.NoError(err, "Failed to get status")
 	s.Equal("ACTIVE", status)
+
+	// Verify that the node scanning deployments aren't constantly updating
+	s.NoError(s.testCluster.K8sHelper.Clientset.List(s.ctx, deployments, listOpts))
+	for _, d := range deployments.Items {
+		s.Less(d.Generation, int64(10))
+	}
 }
 
 func (s *AuditConfigBaseSuite) testMondooAuditConfigAdmission(auditConfig mondoov2.MondooAuditConfig) {


### PR DESCRIPTION
The node scanning deployments were constantly updating because we were overriding annotations.