### PR TITLE
✨ Use GOMEMLIMIT for scanning Pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ build: manifests generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o bin/mondoo-operator -ldflags $(LDFLAGS) cmd/mondoo-operator/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	MONDOO_OPERATOR_NAMESPACE=mondoo-operator go run ./cmd/mondoo-operator/main.go operator
+	MONDOO_NAMESPACE_OVERRIDE=mondoo-operator go run ./cmd/mondoo-operator/main.go operator
 
 docker-build: TARGET_OS=linux
 docker-build: build ## Build docker image with the manager.

--- a/controllers/scanapi/resources_test.go
+++ b/controllers/scanapi/resources_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testMondooAuditConfigName = "mondoo-config"
+	testNamespace             = "mondoo-operator"
+)
+
+func TestResources_GOMEMLIMIT(t *testing.T) {
+	tests := []struct {
+		name               string
+		mondooauditconfig  func() *v1alpha2.MondooAuditConfig
+		expectedGoMemLimit string
+	}{
+		{
+			name: "resources should match default",
+			mondooauditconfig: func() *v1alpha2.MondooAuditConfig {
+				return testMondooAuditConfig()
+			},
+			expectedGoMemLimit: "405000000",
+		},
+		{
+			name: "resources should match spec",
+			mondooauditconfig: func() *v1alpha2.MondooAuditConfig {
+				mac := testMondooAuditConfig()
+				mac.Spec.Scanner.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				}
+				return mac
+			},
+			expectedGoMemLimit: "94371840",
+		},
+		{
+			name: "resources should match off",
+			mondooauditconfig: func() *v1alpha2.MondooAuditConfig {
+				mac := testMondooAuditConfig()
+				mac.Spec.Scanner.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				}
+				return mac
+			},
+			expectedGoMemLimit: "off",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mac := *test.mondooauditconfig()
+			dep := ScanApiDeployment(testNamespace, "test123", mac, v1alpha2.MondooOperatorConfig{}, "", false)
+			goMemLimitEnv := corev1.EnvVar{}
+			for _, env := range dep.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "GOMEMLIMIT" {
+					goMemLimitEnv = env
+					break
+				}
+			}
+			assert.Equal(t, test.expectedGoMemLimit, goMemLimitEnv.Value)
+		})
+	}
+}
+
+func testMondooAuditConfig() *v1alpha2.MondooAuditConfig {
+	return &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testMondooAuditConfigName,
+			Namespace: testNamespace,
+		},
+	}
+}

--- a/pkg/utils/gomemlimit/gomemlimit.go
+++ b/pkg/utils/gomemlimit/gomemlimit.go
@@ -1,0 +1,30 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package gomemlimit
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func CalculateGoMemLimit(containerResources v1.ResourceRequirements) string {
+	// https://cs.opensource.google/go/go/+/master:src/runtime/mgcpacer.go;l=96?q=GOMEMLIMIT&ss=go%2Fgo
+	// Initialized from GOMEMLIMIT. GOMEMLIMIT=off is equivalent to MaxInt64
+	// which means no soft memory limit in practice.
+	gcLimit := "off"
+	memoryLimit := containerResources.Limits.Memory()
+
+	if memoryLimit != nil {
+		// https://go.dev/doc/gc-guide#Suggested_uses
+		// deployment ... into containers with a fixed amount of available memory.
+		// In this case, a good rule of thumb is to leave an additional 5-10% of headroom to account for memory sources the Go runtime is unaware of.
+		gcLimit = fmt.Sprintf("%.0f", (float64(memoryLimit.Value()) * 0.9))
+		if gcLimit == "0" {
+			gcLimit = "off"
+		}
+	}
+
+	return gcLimit
+}

--- a/pkg/utils/gomemlimit/gomemlimit_test.go
+++ b/pkg/utils/gomemlimit/gomemlimit_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package gomemlimit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestCalculateGoMemLimit(t *testing.T) {
+	tests := []struct {
+		name               string
+		resources          v1.ResourceRequirements
+		expectedGoMemLimit string
+	}{
+		{
+			name: "resources should match default",
+			resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("250M"),
+				},
+			},
+			expectedGoMemLimit: "225000000",
+		},
+		{
+			name: "resources should match spec",
+			resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			expectedGoMemLimit: "94371840",
+		},
+		{
+			name: "resources should match off",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expectedGoMemLimit: "off",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedGoMemLimit, CalculateGoMemLimit(test.resources))
+		})
+	}
+}


### PR DESCRIPTION
This should further help reduce OOMkills for the modified Pods.

This is the official doc for this: https://go.dev/doc/gc-guide#Suggested_uses

An example of another software using this: https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-production#setting-soft-memory-limits-on-dapr-sidecar