### PR TITLE
Disable cnspec provider auto-updates

### DIFF
--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -45,6 +45,7 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 
 	envVars := feature_flags.AllFeatureFlagsAsEnv()
 	envVars = append(envVars, corev1.EnvVar{Name: "MONDOO_AUTO_UPDATE", Value: "false"})
+	envVars = append(envVars, corev1.EnvVar{Name: "MONDOO_DISABLE_PROVIDER_UPDATES", Value: "true"})
 	envVars = k8s.MergeEnv(envVars, m.Spec.Containers.Env)
 
 	cronjob := &batchv1.CronJob{

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -129,6 +129,10 @@ func UpdateCronJob(cj *batchv1.CronJob, image string, node corev1.Node, m *v1alp
 					Value: "false",
 				},
 				{
+					Name:  "MONDOO_DISABLE_PROVIDER_UPDATES",
+					Value: "true",
+				},
+				{
 					Name:  "NODE_NAME",
 					Value: node.Name,
 				},
@@ -275,6 +279,10 @@ func UpdateDaemonSet(
 				{
 					Name:  "MONDOO_AUTO_UPDATE",
 					Value: "false",
+				},
+				{
+					Name:  "MONDOO_DISABLE_PROVIDER_UPDATES",
+					Value: "true",
 				},
 				{
 					Name:  "GOMEMLIMIT",

--- a/controllers/scanapi/resources.go
+++ b/controllers/scanapi/resources.go
@@ -153,6 +153,7 @@ func ScanApiDeployment(ns, image string, m v1alpha2.MondooAuditConfig, cfg v1alp
 							{Name: "MONDOO_PROCFS", Value: "on"},
 							{Name: "PORT", Value: fmt.Sprintf("%d", Port)},
 							{Name: "MONDOO_AUTO_UPDATE", Value: "false"},
+							{Name: "MONDOO_DISABLE_PROVIDER_UPDATES", Value: "true"},
 
 							// Required so the scan API knows it is running as a Kubernetes integration
 							{Name: "KUBERNETES_ADMISSION_CONTROLLER", Value: "true"},


### PR DESCRIPTION
The Mondoo Kubernetes Operator's embedded cnspec scanner was repeatedly attempting to self-update its providers (e.g., 'k8s' provider), leading to failed write operations to a read-only filesystem (`/.config/mondoo/providers`) and generating excessive network traffic.
