### PR TITLE
feat: support setting pod security context for controller manager

### DIFF
--- a/charts/mondoo-operator/templates/deployment.yaml
+++ b/charts/mondoo-operator/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
-      securityContext:
-        runAsNonRoot: true
+      securityContext: {{- toYaml .Values.controllerManager.manager.podSecurityContext
+        | nindent 10 }}
       serviceAccountName: {{ include "mondoo-operator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10

--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -5,6 +5,8 @@ controllerManager:
     - --health-probe-bind-address=:8081
     - --metrics-bind-address=:8080
     - --leader-elect
+    podSecurityContext:
+      runAsNonRoot: true
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
# Changes
This pull request updates how security contexts are configured for the controller manager in the `mondoo-operator` Helm chart.

Security context configuration improvements:

* The `deployment.yaml` template now sets the pod-level `securityContext` using the new `.Values.controllerManager.manager.podSecurityContext` value, instead of hardcoding `runAsNonRoot: true`. This allows for easier customization and consistency across deployments.
* The `values.yaml` file introduces a new `podSecurityContext` section under `controllerManager.manager`, with `runAsNonRoot: true` as the default, enabling users to override pod-level security settings as needed.

We need this feature to be able to rollout mondoo in our environment, which has quite restrictive policies, that require setting more things in pod security context. 