### PR TITLE
🧹 release helm chart only after tests and a tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -318,6 +318,7 @@ jobs:
     name: Release helm chart
     needs:
       - push-virtual-tag
+      - run-helm-tests
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
we should only ship the helm chart on a tag and after the helm tests have succeeded