### PR TITLE
🧹 set the correct operator version in helm charts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,6 @@ on:
       - 'docs/**'
     branches:
       - "main"
-    tags: ["v*.*.*"]
   schedule:
     - cron: '0 4 * * 3' # Every Wednesday at 4:00 AM
 

--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -14,7 +14,7 @@ controllerManager:
       readOnlyRootFilesystem: true
     image:
       repository: ghcr.io/mondoohq/mondoo-operator
-      tag: v11.4.2
+      tag: v12.0.0
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,19 +2,17 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 resources:
-- manager.yaml
-- metrics-service.yaml
-
+  - manager.yaml
+  - metrics-service.yaml
 generatorOptions:
   disableNameSuffixHash: true
-
 configMapGenerator:
-- files:
-  - controller_manager_config.yaml
-  name: manager-config
+  - files:
+      - controller_manager_config.yaml
+    name: manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: ghcr.io/mondoohq/mondoo-operator
-  newTag: v11.4.2
+  - name: controller
+    newName: ghcr.io/mondoohq/mondoo-operator
+    newTag: v12.0.0

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -6,11 +6,10 @@ kind: Kustomization
 namespace: mondoo-operator
 namePrefix: mondoo-operator-
 resources:
-- manifests.yaml
+  - manifests.yaml
 images:
-- name: controller
-  newName: ghcr.io/mondoohq/mondoo-operator
-  newTag: v11.4.2
-
+  - name: controller
+    newName: ghcr.io/mondoohq/mondoo-operator
+    newTag: v12.0.0
 patchesStrategicMerge:
-- webhook_patch.yaml
+  - webhook_patch.yaml

--- a/release.sh
+++ b/release.sh
@@ -21,6 +21,9 @@ fi
 
 make manifests
 
+yq -i ".images[0].newTag=\"v${VERSION}\"" config/manager/kustomization.yaml
+yq -i ".images[0].newTag=\"v${VERSION}\"" config/webhook/kustomization.yaml
+
 yq -i ".appVersion = \"${VERSION}\"" charts/mondoo-operator/Chart.yaml
 yq -i ".version = \"${VERSION}\"" charts/mondoo-operator/Chart.yaml
 CHART_NAME=charts/mondoo-operator make helm


### PR DESCRIPTION
Make sure we set the right version of the operator containers in the helm chart. This got broken when deleting the operatorhub logic. This PR fixes it. It also makes sure we don't run all tests on tags. That's not required since we run them on each commit anyways