### PR TITLE
🧹 improved testing and release

### DIFF
--- a/.github/workflows/release-manifests.yaml
+++ b/.github/workflows/release-manifests.yaml
@@ -28,4 +28,5 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: mondoo-operator-manifests.yaml
-          generate_release_notes: true
+          generate_release_notes: false
+          make_latest: true

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test/integration: manifests generate generate-manifests load-k3d
 else
 test/integration: manifests generate generate-manifests load-minikube
 endif
-	go test -ldflags $(LDFLAGS) -v -timeout 45m -p 1 ./tests/integration/...
+	go test -ldflags $(LDFLAGS) -v -timeout 20m -p 1 ./tests/integration/...
 
 ifeq ($(K8S_DISTRO),gke)
 test/integration/ci: gotestsum
@@ -157,7 +157,7 @@ test/integration/ci: gotestsum load-k3d/ci
 else
 test/integration/ci: gotestsum load-minikube/ci
 endif
-	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -ldflags $(LDFLAGS) -v -timeout 45m -p 1
+	$(GOTESTSUM) --junitfile integration-tests.xml -- ./tests/integration/... -ldflags $(LDFLAGS) -v -timeout 20m -p 1
 
 ##@ Build
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -43,7 +43,7 @@ import (
 const (
 	cmd                    = "kubectl"
 	RetryInterval          = 2
-	RetryLoop              = 100
+	RetryLoop              = 50
 	SkipVersionCheckEnvVar = "SKIP_VERSION_CHECK"
 )
 


### PR DESCRIPTION
- Lower the retry loop for integration tests. This should allow us to see failures quicker instead of retrying for a very long times
- Make sure no release notes are generated, we generate them when we create the release
- Make sure the release is marked as latest. This is important to make sure the latest release is always our operator release, not the helm chart release