### PR TITLE
🧹 update test matrix

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.31.9, v1.32.9, v1.33.5, v1.34.1]
+        k8s-version: [v1.32.0, v1.35.0]
         k8s-distro: [minikube, k3d]
 
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -233,7 +233,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.31.9, v1.32.9, v1.33.5, v1.34.1]
+        k8s-version: [v1.32.0, v1.35.0]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- remove 1.31 as it is end of life
- switch to boundary tests where we test with lowest supported version and latest version