### PR TITLE
Replace deprecated --score-threshold 

### DIFF
--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -36,7 +36,6 @@ func CronJob(image, integrationMrn, clusterUid, privateImageScanningSecretName s
 		"cnspec", "scan", "k8s",
 		"--config", "/etc/opt/mondoo/config/mondoo.yml",
 		"--inventory-file", "/etc/opt/mondoo/config/inventory.yml",
-		"--score-threshold", "0",
 	}
 
 	if cfg.Spec.HttpProxy != nil {

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -47,7 +47,6 @@ func UpdateCronJob(cj *batchv1.CronJob, image string, node corev1.Node, m *v1alp
 		"cnspec", "scan", "local",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
 		"--inventory-template", "/etc/opt/mondoo/inventory_template.yml",
-		"--score-threshold", "0",
 	}
 
 	if cfg.Spec.HttpProxy != nil {


### PR DESCRIPTION
The --score-threshold flag is deprecated and has been removed.

Fixes #1331