### PR TITLE
🐛 fix docker/build-push-action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -134,6 +134,9 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          # Disable provenance attestations to produce single-platform images
+          # instead of manifest lists. Required for docker manifest create to work.
+          provenance: false
 
       - name: Scan Image
         if: matrix.arch == 'amd64'


### PR DESCRIPTION
Docker BuildKit v0.11+ adds provenance attestations by default, which converts images into manifest lists with attestation layers.

Added provenance: false to the docker/build-push-action step in .github/workflows/publish.yaml. This produces true single-platform images that work with docker manifest create.