### PR TITLE
 🐛 fix service account permissions to support wif scans

### DIFF
--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: mondooauditconfigs.k8s.mondoo.com
 spec:
   group: k8s.mondoo.com

--- a/config/crd/bases/k8s.mondoo.com_mondoooperatorconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondoooperatorconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: mondoooperatorconfigs.k8s.mondoo.com
 spec:
   group: k8s.mondoo.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,17 @@ rules:
   - delete
   - get
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -726,6 +726,8 @@ retry az aks get-credentials \
 			AllowPrivilegeEscalation: ptr.To(false),
 			ReadOnlyRootFilesystem:   ptr.To(true),
 			RunAsNonRoot:             ptr.To(true),
+			// needed to prevent errors for the google CLI container which runs as root by default
+			RunAsUser: ptr.To(int64(101)),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -71,6 +71,8 @@ var MondooClientBuilder = mondooclient.NewClient
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create;delete
 // Need to be able to check for the existence of Secrets with tokens, Mondoo service accounts, and private image pull secrets without asking for permission to read all Secrets
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get
+// Need to be able to manage ServiceAccounts for external cluster workload identity federation
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
- The operator should be able to do CRUD on service accounts, so we can manage the WIF bindings.
- The gcloud CLI container is running as root by default, which causes errors and the pod not starting up. We need to manually set a diff user ID for the container to avoid this error
