### PR TITLE
⭐️ publish helm charts to OCI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -340,6 +340,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write  # Required for GHCR OCI push
 
     steps:
       - name: Checkout
@@ -358,9 +359,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
         id: install
 
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run chart-releaser
         # switch back to helm/chart-releaser-action when #60 is fixed
         # https://github.com/helm/chart-releaser-action/issues/60
         uses: luisico/chart-releaser-action@on-tags
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push Helm chart to OCI registry
+        run: |
+          helm package charts/mondoo-operator
+          helm push mondoo-operator-*.tgz oci://ghcr.io/${{ github.repository }}/charts


### PR DESCRIPTION
**Summary**

- Add OCI registry publishing for the Helm chart to GHCR alongside the existing GitHub Pages publication
- Users can now install the chart via oci://ghcr.io/mondoohq/mondoo-operator/charts/mondoo-operator  

Closes #1359

**Changes**

- Added packages: write permission to the release-helm job
- Added GHCR login step using docker/login-action
- Added step to package and push the Helm chart to the OCI registry  


**Usage**

OCI method (new)

```
helm install mondoo-operator oci://ghcr.io/mondoohq/mondoo-operator/charts/mondoo-operator --version <version>
```

GitHub Pages method (still works)

```
helm repo add mondoo https://mondoohq.github.io/mondoo-operator  
helm install mondoo-operator mondoo/mondoo-operator
```

**Test plan**

- Push a version tag and verify the chart appears at ghcr.io/mondoohq/mondoo-operator/charts/mondoo-operator
- Test pulling the chart: helm pull oci://ghcr.io/mondoohq/mondoo-operator/charts/mondoo-operator
- Verify existing GitHub Pages installation method still works
