### PR TITLE
docs: add WIF testing documentation for issue #1364

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -385,6 +385,8 @@ subjects:
 - **EKS**: Configure IRSA on management cluster, create IAM trust policy, grant role cluster access
 - **AKS**: Install Azure Workload Identity, create federated identity credential, grant managed identity RBAC on target cluster
 
+> **Terraform automation:** Terraform configurations for provisioning WIF test infrastructure (GKE, GKE Autopilot, EKS, AKS) are available in `tests/terraform/wif/`. See [Test Methods 4-6](#test-method-4-aks-azure-workload-identity) for cloud-specific instructions, or the [WIF Terraform README](../tests/terraform/wif/README.md) for the automated alternative.
+
 **Additional External Cluster Options:**
 
 Each external cluster also supports these optional fields:
@@ -1045,6 +1047,8 @@ This method tests Workload Identity Federation (WIF) with Azure AKS. The managem
 uses Azure AD Workload Identity to authenticate to a target AKS cluster without static credentials.
 
 > **Note:** This requires Azure resources and two AKS clusters. It cannot be tested locally with k3d.
+>
+> **Terraform alternative:** Instead of the manual steps below, you can use `tests/terraform/wif/aks/` to create both clusters and all IAM/RBAC plumbing automatically. See the [WIF Terraform README](../tests/terraform/wif/README.md).
 
 **Key AKS-specific details:**
 - ServiceAccount annotation: `azure.workload.identity/client-id`
@@ -1335,6 +1339,8 @@ This method tests Workload Identity using AWS EKS IRSA. The management cluster u
 for Service Accounts to authenticate to a target EKS cluster without static credentials.
 
 > **Note:** This requires AWS resources and two EKS clusters. It cannot be tested locally with k3d.
+>
+> **Terraform alternative:** Instead of the manual steps below, you can use `tests/terraform/wif/eks/` to create both clusters, the VPC, and all IAM plumbing automatically. See the [WIF Terraform README](../tests/terraform/wif/README.md).
 
 **Key EKS-specific details:**
 - ServiceAccount annotation: `eks.amazonaws.com/role-arn`
@@ -1687,6 +1693,8 @@ This method tests Workload Identity Federation with Google Kubernetes Engine. Th
 uses GCP Workload Identity to authenticate to a target GKE cluster without static credentials.
 
 > **Note:** This requires GCP resources and two GKE clusters. It cannot be tested locally with k3d.
+>
+> **Terraform alternative:** Instead of the manual steps below, you can use `tests/terraform/wif/gke/` (or `gke-autopilot/` for Autopilot clusters) to create both clusters and all IAM plumbing automatically. See the [WIF Terraform README](../tests/terraform/wif/README.md).
 
 **Key GKE-specific details:**
 - ServiceAccount annotation: `iam.gke.io/gcp-service-account`

--- a/tests/terraform/.gitignore
+++ b/tests/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+kubeconfig-*
+*.tfplan

--- a/tests/terraform/wif/README.md
+++ b/tests/terraform/wif/README.md
@@ -1,0 +1,75 @@
+# WIF Testing Terraform
+
+Terraform configurations for provisioning cloud infrastructure to test Workload Identity Federation (WIF) with the Mondoo Operator.
+
+Each subdirectory creates a **management cluster** (where the operator runs) and a **target cluster** (to be scanned), along with the IAM/RBAC plumbing needed for WIF authentication.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.3
+- Cloud provider CLI authenticated:
+  - **GKE**: `gcloud auth application-default login`
+  - **EKS**: `aws configure` or environment variables
+  - **AKS**: `az login`
+
+## Usage
+
+Each provider is independent. Navigate to the desired directory and run:
+
+```bash
+cd gke/   # or eks/ or aks/
+terraform init
+terraform plan
+terraform apply
+```
+
+After `apply` completes, check the outputs for the `mondoo_audit_config_snippet` which shows the exact YAML to use in your `MondooAuditConfig`.
+
+```bash
+terraform output mondoo_audit_config_snippet
+```
+
+## Providers
+
+### GKE (`gke/`)
+
+Creates two GKE Standard clusters with Workload Identity enabled. Sets up a Google Service Account with the necessary IAM bindings for the management cluster's KSA to authenticate to the target cluster.
+
+**Required variables:**
+- `project_id` - GCP project ID
+
+**Post-apply manual step:** Create a `ClusterRoleBinding` on the target cluster granting the GSA read access (shown in outputs).
+
+### GKE Autopilot (`gke-autopilot/`)
+
+Same as GKE but uses Autopilot clusters. Autopilot clusters have Workload Identity enabled by default and manage node pools automatically.
+
+**Required variables:**
+- `project_id` - GCP project ID
+
+**Post-apply manual step:** Create a `ClusterRoleBinding` on the target cluster granting the GSA read access (shown in outputs).
+
+### EKS (`eks/`)
+
+Creates two EKS clusters in a shared VPC with IRSA (IAM Roles for Service Accounts) configured. Sets up an IAM role with a trust policy for the management cluster's OIDC provider and maps it into the target cluster's `aws-auth` ConfigMap.
+
+**Required variables:** None (uses defaults)
+
+### AKS (`aks/`)
+
+Creates two AKS clusters with Azure Workload Identity configured. Sets up an Azure AD application with a federated identity credential and grants it RBAC on the target cluster.
+
+**Required variables:** None (uses defaults)
+
+## Cleanup
+
+```bash
+terraform destroy
+```
+
+## Design Notes
+
+- Spot/preemptible instances are used for cost savings
+- Random 4-character suffixes ensure unique resource names
+- Terraform state is stored locally (not in a remote backend)
+- These configs are for manual developer testing, not CI

--- a/tests/terraform/wif/aks/main.tf
+++ b/tests/terraform/wif/aks/main.tf
@@ -1,0 +1,124 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  name_prefix = "mondoo-wif-${random_string.suffix.result}"
+}
+
+data "azurerm_subscription" "current" {}
+data "azurerm_client_config" "current" {}
+
+################################################################################
+# Resource Group
+################################################################################
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.name_prefix}-rg"
+  location = var.location
+
+  tags = {
+    Environment = "Mondoo Operator WIF Tests"
+  }
+}
+
+################################################################################
+# Management Cluster (runs the operator, OIDC + Workload Identity enabled)
+################################################################################
+
+resource "azurerm_kubernetes_cluster" "management" {
+  name                = "${local.name_prefix}-mgmt"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "${local.name_prefix}-mgmt"
+  kubernetes_version  = var.k8s_version
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Mondoo Operator WIF Tests"
+  }
+}
+
+################################################################################
+# Target Cluster (to be scanned, Azure RBAC enabled)
+################################################################################
+
+resource "azurerm_kubernetes_cluster" "target" {
+  name                = "${local.name_prefix}-target"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "${local.name_prefix}-target"
+  kubernetes_version  = var.k8s_version
+
+  azure_active_directory_role_based_access_control {
+    managed            = true
+    azure_rbac_enabled = true
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Mondoo Operator WIF Tests"
+  }
+}
+
+################################################################################
+# Azure AD Application + Service Principal for the scanner
+################################################################################
+
+resource "azuread_application" "scanner" {
+  display_name = "${local.name_prefix}-scanner"
+}
+
+resource "azuread_service_principal" "scanner" {
+  client_id = azuread_application.scanner.client_id
+}
+
+# Federated identity credential: links the management cluster's KSA to the Azure AD app
+resource "azuread_application_federated_identity_credential" "scanner" {
+  application_id = azuread_application.scanner.id
+  display_name   = "mondoo-operator-wif"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = azurerm_kubernetes_cluster.management.oidc_issuer_url
+  subject        = "system:serviceaccount:${var.scanner_namespace}:${var.scanner_service_account}"
+}
+
+################################################################################
+# Role Assignments on the target cluster
+################################################################################
+
+# Allow the service principal to get cluster credentials
+resource "azurerm_role_assignment" "cluster_user" {
+  scope                = azurerm_kubernetes_cluster.target.id
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
+  principal_id         = azuread_service_principal.scanner.object_id
+}
+
+# Allow the service principal to read K8s resources via Azure RBAC
+resource "azurerm_role_assignment" "rbac_reader" {
+  scope                = azurerm_kubernetes_cluster.target.id
+  role_definition_name = "Azure Kubernetes Service RBAC Reader"
+  principal_id         = azuread_service_principal.scanner.object_id
+}

--- a/tests/terraform/wif/aks/outputs.tf
+++ b/tests/terraform/wif/aks/outputs.tf
@@ -1,0 +1,56 @@
+output "subscription_id" {
+  description = "Azure subscription ID."
+  value       = data.azurerm_subscription.current.subscription_id
+}
+
+output "tenant_id" {
+  description = "Azure AD tenant ID."
+  value       = data.azurerm_client_config.current.tenant_id
+}
+
+output "client_id" {
+  description = "Azure AD application (client) ID for the scanner."
+  value       = azuread_application.scanner.client_id
+}
+
+output "resource_group" {
+  description = "Resource group containing both clusters."
+  value       = azurerm_resource_group.rg.name
+}
+
+output "management_cluster_name" {
+  description = "Name of the management AKS cluster."
+  value       = azurerm_kubernetes_cluster.management.name
+}
+
+output "target_cluster_name" {
+  description = "Name of the target AKS cluster."
+  value       = azurerm_kubernetes_cluster.target.name
+}
+
+output "mondoo_audit_config_snippet" {
+  description = "MondooAuditConfig YAML snippet for the AKS WIF external cluster."
+  value       = <<-EOT
+    externalClusters:
+      - name: ${azurerm_kubernetes_cluster.target.name}
+        workloadIdentity:
+          provider: aks
+          aks:
+            subscriptionId: ${data.azurerm_subscription.current.subscription_id}
+            resourceGroup: ${azurerm_resource_group.rg.name}
+            clusterName: ${azurerm_kubernetes_cluster.target.name}
+            clientId: ${azuread_application.scanner.client_id}
+            tenantId: ${data.azurerm_client_config.current.tenant_id}
+  EOT
+}
+
+output "kubeconfig_commands" {
+  description = "Commands to configure kubectl for both clusters."
+  value       = <<-EOT
+    # Management cluster:
+    az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_cluster.management.name} --context mgmt
+
+    # Target cluster:
+    az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_cluster.target.name} --context target
+  EOT
+}

--- a/tests/terraform/wif/aks/variables.tf
+++ b/tests/terraform/wif/aks/variables.tf
@@ -1,0 +1,23 @@
+variable "location" {
+  description = "Azure region for all resources."
+  type        = string
+  default     = "eastus"
+}
+
+variable "k8s_version" {
+  description = "Kubernetes version for the AKS clusters."
+  type        = string
+  default     = "1.30"
+}
+
+variable "scanner_namespace" {
+  description = "Namespace where the Mondoo operator scanner runs."
+  type        = string
+  default     = "mondoo-operator"
+}
+
+variable "scanner_service_account" {
+  description = "Kubernetes ServiceAccount name used by the scanner."
+  type        = string
+  default     = "mondoo-client-wif-target"
+}

--- a/tests/terraform/wif/aks/versions.tf
+++ b/tests/terraform/wif/aks/versions.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {}

--- a/tests/terraform/wif/eks/main.tf
+++ b/tests/terraform/wif/eks/main.tf
@@ -1,0 +1,162 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  name_prefix = "mondoo-wif-${random_string.suffix.result}"
+  default_tags = {
+    Name       = local.name_prefix
+    GitHubRepo = "mondoo-operator"
+    GitHubOrg  = "mondoohq"
+    Terraform  = "true"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+data "aws_caller_identity" "current" {}
+
+################################################################################
+# VPC (shared by both clusters)
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${local.name_prefix}-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 2)
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.3.0/24", "10.0.4.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  tags = local.default_tags
+}
+
+################################################################################
+# Management Cluster (runs the operator, IRSA enabled)
+################################################################################
+
+module "management" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = "${local.name_prefix}-mgmt"
+  cluster_version = var.k8s_version
+
+  cluster_endpoint_public_access = true
+  enable_irsa                    = true
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = ["m5.large"]
+      capacity_type  = "SPOT"
+      min_size       = 1
+      max_size       = 2
+      desired_size   = 1
+    }
+  }
+
+  tags = local.default_tags
+}
+
+################################################################################
+# Target Cluster (to be scanned)
+################################################################################
+
+module "target" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = "${local.name_prefix}-target"
+  cluster_version = var.k8s_version
+
+  cluster_endpoint_public_access = true
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = ["m5.large"]
+      capacity_type  = "SPOT"
+      min_size       = 1
+      max_size       = 2
+      desired_size   = 1
+    }
+  }
+
+  # Map the scanner IAM role so it can access this cluster
+  access_entries = {
+    mondoo-scanner = {
+      principal_arn = aws_iam_role.scanner.arn
+      policy_associations = {
+        cluster_view = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
+  tags = local.default_tags
+}
+
+################################################################################
+# IAM Role for the scanner (IRSA)
+################################################################################
+
+resource "aws_iam_role" "scanner" {
+  name = "${local.name_prefix}-scanner"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = module.management.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${module.management.oidc_provider}:aud" = "sts.amazonaws.com"
+            "${module.management.oidc_provider}:sub" = "system:serviceaccount:${var.scanner_namespace}:${var.scanner_service_account}"
+          }
+        }
+      },
+    ]
+  })
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_role_policy" "eks_access" {
+  name = "eks-access"
+  role = aws_iam_role.scanner.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster",
+          "eks:ListClusters",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/tests/terraform/wif/eks/outputs.tf
+++ b/tests/terraform/wif/eks/outputs.tf
@@ -1,0 +1,44 @@
+output "region" {
+  description = "AWS region."
+  value       = var.region
+}
+
+output "management_cluster_name" {
+  description = "Name of the management EKS cluster."
+  value       = module.management.cluster_name
+}
+
+output "target_cluster_name" {
+  description = "Name of the target EKS cluster."
+  value       = module.target.cluster_name
+}
+
+output "scanner_role_arn" {
+  description = "ARN of the IAM role for the scanner."
+  value       = aws_iam_role.scanner.arn
+}
+
+output "mondoo_audit_config_snippet" {
+  description = "MondooAuditConfig YAML snippet for the EKS IRSA external cluster."
+  value       = <<-EOT
+    externalClusters:
+      - name: ${module.target.cluster_name}
+        workloadIdentity:
+          provider: eks
+          eks:
+            region: ${var.region}
+            clusterName: ${module.target.cluster_name}
+            roleArn: ${aws_iam_role.scanner.arn}
+  EOT
+}
+
+output "kubeconfig_update_commands" {
+  description = "Commands to configure kubectl for both clusters."
+  value       = <<-EOT
+    # Management cluster:
+    aws eks update-kubeconfig --name ${module.management.cluster_name} --region ${var.region} --alias mgmt
+
+    # Target cluster:
+    aws eks update-kubeconfig --name ${module.target.cluster_name} --region ${var.region} --alias target
+  EOT
+}

--- a/tests/terraform/wif/eks/variables.tf
+++ b/tests/terraform/wif/eks/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  description = "AWS region for the clusters."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "k8s_version" {
+  description = "Kubernetes version for the EKS clusters."
+  type        = string
+  default     = "1.30"
+}
+
+variable "scanner_namespace" {
+  description = "Namespace where the Mondoo operator scanner runs."
+  type        = string
+  default     = "mondoo-operator"
+}
+
+variable "scanner_service_account" {
+  description = "Kubernetes ServiceAccount name used by the scanner."
+  type        = string
+  default     = "mondoo-client-wif-target"
+}

--- a/tests/terraform/wif/eks/versions.tf
+++ b/tests/terraform/wif/eks/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/tests/terraform/wif/gke-autopilot/main.tf
+++ b/tests/terraform/wif/gke-autopilot/main.tf
@@ -1,0 +1,82 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  name_prefix = "mondoo-wif-ap-${random_string.suffix.result}"
+}
+
+################################################################################
+# Management Cluster (Autopilot - Workload Identity enabled by default)
+################################################################################
+
+resource "google_container_cluster" "management" {
+  name     = "${local.name_prefix}-mgmt"
+  project  = var.project_id
+  location = var.region
+
+  # Autopilot mode - manages node pools automatically
+  enable_autopilot    = true
+  deletion_protection = false
+}
+
+################################################################################
+# Target Cluster (Autopilot)
+################################################################################
+
+resource "google_container_cluster" "target" {
+  name     = "${local.name_prefix}-target"
+  project  = var.project_id
+  location = var.region
+
+  enable_autopilot    = true
+  deletion_protection = false
+}
+
+################################################################################
+# Google Service Account for the scanner
+################################################################################
+
+resource "google_service_account" "scanner" {
+  account_id   = "${local.name_prefix}-scan"
+  display_name = "Mondoo WIF Autopilot Scanner (${random_string.suffix.result})"
+  project      = var.project_id
+}
+
+# Allow the management cluster KSA to impersonate this GSA
+resource "google_service_account_iam_binding" "workload_identity" {
+  service_account_id = google_service_account.scanner.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[${var.scanner_namespace}/${var.scanner_service_account}]",
+  ]
+}
+
+# Grant the GSA permission to view/access the target cluster
+resource "google_project_iam_member" "cluster_viewer" {
+  project = var.project_id
+  role    = "roles/container.clusterViewer"
+  member  = "serviceAccount:${google_service_account.scanner.email}"
+}
+
+################################################################################
+# Kubeconfig for management cluster
+################################################################################
+
+data "google_client_config" "default" {}
+
+module "gke_auth" {
+  source = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+
+  project_id   = var.project_id
+  cluster_name = google_container_cluster.management.name
+  location     = var.region
+}
+
+resource "local_file" "kubeconfig" {
+  content  = module.gke_auth.kubeconfig_raw
+  filename = "${path.module}/kubeconfig-mgmt"
+}

--- a/tests/terraform/wif/gke-autopilot/outputs.tf
+++ b/tests/terraform/wif/gke-autopilot/outputs.tf
@@ -1,0 +1,61 @@
+output "project_id" {
+  description = "GCP project ID."
+  value       = var.project_id
+}
+
+output "management_cluster_name" {
+  description = "Name of the management GKE Autopilot cluster."
+  value       = google_container_cluster.management.name
+}
+
+output "target_cluster_name" {
+  description = "Name of the target GKE Autopilot cluster."
+  value       = google_container_cluster.target.name
+}
+
+output "cluster_location" {
+  description = "Region of both clusters."
+  value       = var.region
+}
+
+output "google_service_account" {
+  description = "Email of the Google Service Account for the scanner."
+  value       = google_service_account.scanner.email
+}
+
+output "mondoo_audit_config_snippet" {
+  description = "MondooAuditConfig YAML snippet for the GKE WIF external cluster."
+  value       = <<-EOT
+    externalClusters:
+      - name: ${google_container_cluster.target.name}
+        workloadIdentity:
+          provider: gke
+          gke:
+            projectId: ${var.project_id}
+            clusterName: ${google_container_cluster.target.name}
+            clusterLocation: ${var.region}
+            googleServiceAccount: ${google_service_account.scanner.email}
+  EOT
+}
+
+output "target_cluster_rbac" {
+  description = "Manual step: apply this ClusterRoleBinding on the target cluster."
+  value       = <<-EOT
+    # Get credentials for the target cluster:
+    #   gcloud container clusters get-credentials ${google_container_cluster.target.name} --region ${var.region} --project ${var.project_id}
+    #
+    # Then apply:
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: mondoo-wif-scanner
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: view
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: User
+      name: ${google_service_account.scanner.email}
+  EOT
+}

--- a/tests/terraform/wif/gke-autopilot/variables.tf
+++ b/tests/terraform/wif/gke-autopilot/variables.tf
@@ -1,0 +1,22 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Autopilot clusters."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "scanner_namespace" {
+  description = "Namespace where the Mondoo operator scanner runs."
+  type        = string
+  default     = "mondoo-operator"
+}
+
+variable "scanner_service_account" {
+  description = "Kubernetes ServiceAccount name used by the scanner."
+  type        = string
+  default     = "mondoo-client-wif-target"
+}

--- a/tests/terraform/wif/gke-autopilot/versions.tf
+++ b/tests/terraform/wif/gke-autopilot/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/tests/terraform/wif/gke/main.tf
+++ b/tests/terraform/wif/gke/main.tf
@@ -1,0 +1,133 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  name_prefix = "mondoo-wif-${random_string.suffix.result}"
+}
+
+################################################################################
+# Management Cluster (runs the operator)
+################################################################################
+
+resource "google_container_cluster" "management" {
+  name               = "${local.name_prefix}-mgmt"
+  project            = var.project_id
+  location           = var.zone
+  min_master_version = var.k8s_version
+  deletion_protection = false
+
+  # Workload Identity is required for WIF
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_node_pool" "management" {
+  name     = "${local.name_prefix}-mgmt-pool"
+  location = var.zone
+  project  = var.project_id
+  cluster  = google_container_cluster.management.id
+
+  node_count = 1
+
+  node_config {
+    spot         = true
+    machine_type = "e2-standard-2"
+
+    # Required for Workload Identity on nodes
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+}
+
+################################################################################
+# Target Cluster (to be scanned)
+################################################################################
+
+resource "google_container_cluster" "target" {
+  name               = "${local.name_prefix}-target"
+  project            = var.project_id
+  location           = var.zone
+  min_master_version = var.k8s_version
+  deletion_protection = false
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_node_pool" "target" {
+  name     = "${local.name_prefix}-target-pool"
+  location = var.zone
+  project  = var.project_id
+  cluster  = google_container_cluster.target.id
+
+  node_count = 1
+
+  node_config {
+    spot         = true
+    machine_type = "e2-standard-2"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+}
+
+################################################################################
+# Google Service Account for the scanner
+################################################################################
+
+resource "google_service_account" "scanner" {
+  account_id   = "${local.name_prefix}-scanner"
+  display_name = "Mondoo WIF Scanner (${random_string.suffix.result})"
+  project      = var.project_id
+}
+
+# Allow the management cluster KSA to impersonate this GSA
+resource "google_service_account_iam_binding" "workload_identity" {
+  service_account_id = google_service_account.scanner.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[${var.scanner_namespace}/${var.scanner_service_account}]",
+  ]
+}
+
+# Grant the GSA permission to view/access the target cluster
+resource "google_project_iam_member" "cluster_viewer" {
+  project = var.project_id
+  role    = "roles/container.clusterViewer"
+  member  = "serviceAccount:${google_service_account.scanner.email}"
+}
+
+################################################################################
+# Kubeconfig for management cluster
+################################################################################
+
+data "google_client_config" "default" {}
+
+module "gke_auth" {
+  source = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+
+  project_id   = var.project_id
+  cluster_name = google_container_cluster.management.name
+  location     = var.zone
+
+  depends_on = [google_container_node_pool.management]
+}
+
+resource "local_file" "kubeconfig" {
+  content  = module.gke_auth.kubeconfig_raw
+  filename = "${path.module}/kubeconfig-mgmt"
+}

--- a/tests/terraform/wif/gke/outputs.tf
+++ b/tests/terraform/wif/gke/outputs.tf
@@ -1,0 +1,61 @@
+output "project_id" {
+  description = "GCP project ID."
+  value       = var.project_id
+}
+
+output "management_cluster_name" {
+  description = "Name of the management GKE cluster."
+  value       = google_container_cluster.management.name
+}
+
+output "target_cluster_name" {
+  description = "Name of the target GKE cluster."
+  value       = google_container_cluster.target.name
+}
+
+output "cluster_location" {
+  description = "Zone of both clusters."
+  value       = var.zone
+}
+
+output "google_service_account" {
+  description = "Email of the Google Service Account for the scanner."
+  value       = google_service_account.scanner.email
+}
+
+output "mondoo_audit_config_snippet" {
+  description = "MondooAuditConfig YAML snippet for the GKE WIF external cluster."
+  value       = <<-EOT
+    externalClusters:
+      - name: ${google_container_cluster.target.name}
+        workloadIdentity:
+          provider: gke
+          gke:
+            projectId: ${var.project_id}
+            clusterName: ${google_container_cluster.target.name}
+            clusterLocation: ${var.zone}
+            googleServiceAccount: ${google_service_account.scanner.email}
+  EOT
+}
+
+output "target_cluster_rbac" {
+  description = "Manual step: apply this ClusterRoleBinding on the target cluster."
+  value       = <<-EOT
+    # Get credentials for the target cluster:
+    #   gcloud container clusters get-credentials ${google_container_cluster.target.name} --zone ${var.zone} --project ${var.project_id}
+    #
+    # Then apply:
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: mondoo-wif-scanner
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: view
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: User
+      name: ${google_service_account.scanner.email}
+  EOT
+}

--- a/tests/terraform/wif/gke/variables.tf
+++ b/tests/terraform/wif/gke/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the clusters."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone for zonal clusters."
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "k8s_version" {
+  description = "Kubernetes version for the clusters."
+  type        = string
+  default     = "1.30"
+}
+
+variable "scanner_namespace" {
+  description = "Namespace where the Mondoo operator scanner runs."
+  type        = string
+  default     = "mondoo-operator"
+}
+
+variable "scanner_service_account" {
+  description = "Kubernetes ServiceAccount name used by the scanner."
+  type        = string
+  default     = "mondoo-client-wif-target"
+}

--- a/tests/terraform/wif/gke/versions.tf
+++ b/tests/terraform/wif/gke/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
Add comprehensive documentation for testing Workload Identity Federation:

- Local testing without cloud infrastructure section
  - Unit test commands for WIF functionality
  - Resource verification testing using k3d
  - Tests for GKE, EKS, and AKS WIF resource creation
  - Validation testing for invalid configurations
- WIF testing checklist (local vs cloud required)
- Test Method 6: GKE Workload Identity guide
  - Step-by-step setup with gcloud commands
  - GSA creation and IAM binding
  - Troubleshooting guide and cleanup instructions
  
  
fixes #1364