### PR TITLE
⭐️ fix logging severity for GKE/cloud log explorers

### DIFF
--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -9,9 +9,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// gcpLevelEncoder encodes log levels to Google Cloud Logging severity names.
-// GCP expects "WARNING" instead of zap's "WARN", and maps DPANIC/PANIC/FATAL to CRITICAL.
-func gcpLevelEncoder(level zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+// severityLevelEncoder encodes log levels to cloud-compatible severity names.
+// Uses "WARNING" instead of zap's "WARN", and maps DPANIC/PANIC/FATAL to CRITICAL.
+func severityLevelEncoder(level zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 	switch level {
 	case zapcore.WarnLevel:
 		enc.AppendString("WARNING")
@@ -24,18 +24,18 @@ func gcpLevelEncoder(level zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 
 func NewLogger() logr.Logger {
 	opts := zap.Options{
-		// Use production mode by default for JSON output (required for GKE log parsing).
+		// Use production mode for JSON output (enables structured logging in cloud environments).
 		// Can be overridden with --zap-devel flag for local development.
 		Development:     false,
 		StacktraceLevel: zapcore.DPanicLevel,
 		TimeEncoder:     zapcore.RFC3339TimeEncoder,
-		// Configure encoder for GCP/GKE compatibility:
-		// - Use "severity" instead of "level" for log level field
-		// - Use GCP-compatible level names (WARNING instead of WARN)
+		// Configure encoder for cloud logging compatibility:
+		// - Use "severity" field name (recognized by GKE, AKS, EKS log explorers)
+		// - Use standard severity names (WARNING instead of WARN, CRITICAL for fatal errors)
 		EncoderConfigOptions: []zap.EncoderConfigOption{
 			func(ec *zapcore.EncoderConfig) {
 				ec.LevelKey = "severity"
-				ec.EncodeLevel = gcpLevelEncoder
+				ec.EncodeLevel = severityLevelEncoder
 			},
 		},
 	}

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -37,14 +37,14 @@ func (t *testEncoder) AppendUint16(uint16)         {}
 func (t *testEncoder) AppendUint8(uint8)           {}
 func (t *testEncoder) AppendUintptr(uintptr)       {}
 
-func TestGcpLevelEncoder(t *testing.T) {
+func TestSeverityLevelEncoder(t *testing.T) {
 	tests := []struct {
 		level    zapcore.Level
 		expected string
 	}{
 		{zapcore.DebugLevel, "DEBUG"},
 		{zapcore.InfoLevel, "INFO"},
-		{zapcore.WarnLevel, "WARNING"}, // GCP expects WARNING, not WARN
+		{zapcore.WarnLevel, "WARNING"}, // Cloud log explorers expect WARNING, not WARN
 		{zapcore.ErrorLevel, "ERROR"},
 		{zapcore.DPanicLevel, "CRITICAL"},
 		{zapcore.PanicLevel, "CRITICAL"},
@@ -54,7 +54,7 @@ func TestGcpLevelEncoder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.level.String(), func(t *testing.T) {
 			enc := &testEncoder{}
-			gcpLevelEncoder(tt.level, enc)
+			severityLevelEncoder(tt.level, enc)
 			assert.Equal(t, tt.expected, enc.result)
 		})
 	}


### PR DESCRIPTION
## Summary
- Configure logger to output structured JSON with GCP-compatible severity levels
- Use `severity` field instead of `level` for log level (GCP requirement)
- Map `WARN` to `WARNING` and `DPANIC/PANIC/FATAL` to `CRITICAL`
- Also compatible with AKS (Azure) and EKS (AWS) log aggregation

## Problem
Both INFO and ERROR messages were incorrectly recognized as errors in Google Log Explorer, making it hard to filter logs by severity.

**Before:**
```
2026-02-05T16:18:23+01:00    INFO    test message    {"key": "value"}
```

**After:**
```json
{"severity":"INFO","ts":"2026-02-05T16:19:23+01:00","msg":"test message","key":"value"}
```

## Test plan
- [x] Unit tests for GCP level encoder added
- [ ] Deploy to GKE and verify logs appear with correct severity in Log Explorer
- [ ] Verify logs work correctly in AKS/EKS environments

Fixes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)