### PR TITLE
🐛 add ephemeral storage limits for GKE Autopilot compatibility

### DIFF
--- a/pkg/utils/k8s/resources_requirements.go
+++ b/pkg/utils/k8s/resources_requirements.go
@@ -22,15 +22,19 @@ var DefaultCnspecResources corev1.ResourceRequirements = corev1.ResourceRequirem
 }
 
 // DefaultContainerScanningResources for cnspec container
+// Container scanning downloads images to /tmp, requiring significant ephemeral storage
+// GKE Autopilot defaults to 1Gi but allows up to 10Gi per container
 var DefaultContainerScanningResources corev1.ResourceRequirements = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("1G"),
-		corev1.ResourceCPU:    resource.MustParse("1"),
+		corev1.ResourceMemory:           resource.MustParse("1G"),
+		corev1.ResourceCPU:              resource.MustParse("1"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 	},
 
 	Requests: corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("250M"),
-		corev1.ResourceCPU:    resource.MustParse("400m"),
+		corev1.ResourceMemory:           resource.MustParse("250M"),
+		corev1.ResourceCPU:              resource.MustParse("400m"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 	},
 }
 


### PR DESCRIPTION
## Summary
- Adds ephemeral storage requests (2Gi) and limits (5Gi) to `DefaultContainerScanningResources`
- Fixes container scanning pods failing on GKE Autopilot due to default 1Gi ephemeral storage limit

## Context
Container scanning downloads images to `/tmp`, requiring significant ephemeral storage. GKE Autopilot enforces a default 1Gi limit for pods without explicit resource requests, causing container scan pods to fail.

## Test plan
- [ ] Deploy to GKE Autopilot cluster
- [ ] Verify container scanning pods start successfully
- [ ] Verify scans complete without storage-related failures

---
*Extracted from #1337 - Original author: @jpaodev*