### PR TITLE
🐛 add missing delete verb to batch jobs RBAC

### DIFF
--- a/charts/mondoo-operator/templates/manager-rbac.yaml
+++ b/charts/mondoo-operator/templates/manager-rbac.yaml
@@ -75,6 +75,7 @@ rules:
   resources:
   - jobs
   verbs:
+  - delete
   - deletecollection
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,7 @@ rules:
   resources:
   - jobs
   verbs:
+  - delete
   - deletecollection
   - get
   - list


### PR DESCRIPTION
## Summary
- Adds `delete` verb to batch/jobs RBAC permissions in both kustomize and helm chart

## Context
The operator needs permission to delete individual batch Jobs when cleaning up completed scan jobs. Previously only `deletecollection` was granted, which doesn't allow deleting single jobs.

## Test plan
- [ ] Verify operator can delete individual completed jobs
- [ ] Verify no RBAC errors in operator logs when jobs are cleaned up

---
*Extracted from #1337 - Original author: @jpaodev*