### PR TITLE
Support image digest in MondooAuditConfig

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -397,6 +397,10 @@ type DeprecatedCertificateProvisioning struct {
 type Image struct {
 	Name string `json:"name,omitempty"`
 	Tag  string `json:"tag,omitempty"`
+	// Digest specifies the image digest (e.g., sha256:abc123...).
+	// When specified, this takes precedence over Tag.
+	// +optional
+	Digest string `json:"digest,omitempty"`
 }
 
 // MondooAuditConfigStatus defines the observed state of MondooAuditConfig

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -59,6 +59,11 @@ spec:
                   image:
                     description: Image is DEPRECATED.
                     properties:
+                      digest:
+                        description: |-
+                          Digest specifies the image digest (e.g., sha256:abc123...).
+                          When specified, this takes precedence over Tag.
+                        type: string
                       name:
                         type: string
                       tag:
@@ -1092,6 +1097,11 @@ spec:
                     type: array
                   image:
                     properties:
+                      digest:
+                        description: |-
+                          Digest specifies the image digest (e.g., sha256:abc123...).
+                          When specified, this takes precedence over Tag.
+                        type: string
                       name:
                         type: string
                       tag:

--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -52,7 +52,7 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
-		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		logger.Error(err, "Failed to resolve mondoo-client container image")
 		return err

--- a/controllers/container_image/deployment_handler_test.go
+++ b/controllers/container_image/deployment_handler_test.go
@@ -60,7 +60,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -87,7 +88,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_CustomEnvVars() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -120,7 +122,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomImage() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("ubuntu", "22.04", false)
+	image, err := s.containerImageResolver.CnspecImage("ubuntu", "22.04", "", false)
 	s.NoError(err)
 
 	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -149,7 +151,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateWithCustomSchedule() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	expected := CronJob(image, "", test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -184,7 +187,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_PrivateRegistriesSecret() 
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	expected := CronJob(image, "", test.KubeSystemNamespaceUid, s.auditConfig.Spec.Scanner.PrivateRegistriesPullSecretRef.Name, &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -283,7 +287,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_ConsoleIntegration() {
 	s.NoError(err)
 	s.True(result.IsZero())
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	expected := CronJob(image, integrationMrn, test.KubeSystemNamespaceUid, "", &s.auditConfig, mondoov1alpha2.MondooOperatorConfig{})
@@ -305,7 +310,8 @@ func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
-	image, err := s.containerImageResolver.CnspecImage("", "", false)
+	image, err := s.containerImageResolver.CnspecImage(
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	// Make sure a cron job exists with different container command

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -137,7 +137,7 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	mondooOperatorImage, err := n.ContainerImageResolver.MondooOperatorImage(
-		ctx, n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+		ctx, n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		logger.Error(err, "Failed to resolve mondoo-operator container image")
 		return err
@@ -271,7 +271,7 @@ func (n *DeploymentHandler) syncConfigMap(ctx context.Context, integrationMrn, c
 // reconcileExternalClusters reconciles CronJobs for external clusters
 func (n *DeploymentHandler) reconcileExternalClusters(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
-		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		logger.Error(err, "Failed to resolve cnspec container image")
 		return err

--- a/controllers/k8s_scan/deployment_handler_test.go
+++ b/controllers/k8s_scan/deployment_handler_test.go
@@ -118,7 +118,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_Create_ConsoleIntegration() {
 func (s *DeploymentHandlerSuite) TestReconcile_Update() {
 	d := s.createDeploymentHandler()
 
-	image, err := s.containerImageResolver.MondooOperatorImage(s.ctx, "", "", false)
+	image, err := s.containerImageResolver.MondooOperatorImage(s.ctx, "", "", "", false)
 	s.NoError(err)
 
 	// Make sure a cron job exists with different container command

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -51,7 +51,7 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
-		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		logger.Error(err, "Failed to resolve mondoo-client container image")
 		return err
@@ -168,7 +168,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
-		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		logger.Error(err, "Failed to resolve mondoo-client container image")
 		return err

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -233,7 +233,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	for _, n := range nodes.Items {
@@ -268,7 +268,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_CustomEnvVars() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	for _, n := range nodes.Items {
@@ -302,7 +302,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_Switch() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	for _, n := range nodes.Items {
@@ -346,7 +346,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	// Make sure a cron job exists for one of the nodes
@@ -395,7 +395,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 	s.True(result.IsZero())
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	listOpts := &client.ListOptions{
@@ -433,7 +433,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
@@ -467,7 +467,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_Switch() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
@@ -508,7 +508,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateDaemonSets() {
 	s.NoError(d.KubeClient.List(s.ctx, nodes))
 
 	image, err := s.containerImageResolver.CnspecImage(
-		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, false)
+		s.auditConfig.Spec.Scanner.Image.Name, s.auditConfig.Spec.Scanner.Image.Tag, s.auditConfig.Spec.Scanner.Image.Digest, false)
 	s.NoError(err)
 
 	// Make sure a daemonset exists

--- a/controllers/resource_watcher/deployment_handler.go
+++ b/controllers/resource_watcher/deployment_handler.go
@@ -45,7 +45,7 @@ func (h *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 func (h *DeploymentHandler) syncDeployment(ctx context.Context) error {
 	mondooClientImage, err := h.ContainerImageResolver.CnspecImage(
-		h.Mondoo.Spec.Scanner.Image.Name, h.Mondoo.Spec.Scanner.Image.Tag, h.MondooOperatorConfig.Spec.SkipContainerResolution)
+		h.Mondoo.Spec.Scanner.Image.Name, h.Mondoo.Spec.Scanner.Image.Tag, h.Mondoo.Spec.Scanner.Image.Digest, h.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		deploymentHandlerLogger.Error(err, "Failed to resolve cnspec container image")
 		return err

--- a/pkg/utils/mondoo/fake/container_image_resolver.go
+++ b/pkg/utils/mondoo/fake/container_image_resolver.go
@@ -16,10 +16,32 @@ func NewNoOpContainerImageResolver() mondoo.ContainerImageResolver {
 	return &noOpContainerImageResolver{}
 }
 
-func (c *noOpContainerImageResolver) CnspecImage(userImage, userTag string, skipResolveImage bool) (string, error) {
-	return fmt.Sprintf("%s:%s", mondoo.CnspecImage, mondoo.CnspecTag), nil
+func (c *noOpContainerImageResolver) CnspecImage(userImage, userTag, userDigest string, skipResolveImage bool) (string, error) {
+	image := mondoo.CnspecImage
+	if userImage != "" {
+		image = userImage
+	}
+	if userDigest != "" {
+		return fmt.Sprintf("%s@%s", image, userDigest), nil
+	}
+	tag := mondoo.CnspecTag
+	if userTag != "" {
+		tag = userTag
+	}
+	return fmt.Sprintf("%s:%s", image, tag), nil
 }
 
-func (c *noOpContainerImageResolver) MondooOperatorImage(ctx context.Context, userImage, userTag string, skipResolveImage bool) (string, error) {
-	return fmt.Sprintf("%s:%s", mondoo.MondooOperatorImage, mondoo.MondooOperatorTag), nil
+func (c *noOpContainerImageResolver) MondooOperatorImage(ctx context.Context, userImage, userTag, userDigest string, skipResolveImage bool) (string, error) {
+	image := mondoo.MondooOperatorImage
+	if userImage != "" {
+		image = userImage
+	}
+	if userDigest != "" {
+		return fmt.Sprintf("%s@%s", image, userDigest), nil
+	}
+	tag := mondoo.MondooOperatorTag
+	if userTag != "" {
+		tag = userTag
+	}
+	return fmt.Sprintf("%s:%s", image, tag), nil
 }


### PR DESCRIPTION
## Summary

- Add `Digest` field to the `Image` struct in MondooAuditConfig API
- Update `ContainerImageResolver` interface to accept digest parameter
- When digest is specified, it takes precedence over tag and skips image resolution
- Update all controllers to pass digest from scanner image configuration

Closes #759

## Behavior

| `name` | `tag` | `digest` | Result |
|--------|-------|----------|--------|
| - | - | - | `ghcr.io/mondoohq/mondoo-operator/cnspec:12-rootless` |
| `custom/img` | - | - | `custom/img:12-rootless` |
| `custom/img` | `v2` | - | `custom/img:v2` |
| `custom/img` | - | `sha256:abc...` | `custom/img@sha256:abc...` |
| `custom/img` | `v2` | `sha256:abc...` | `custom/img@sha256:abc...` (digest wins) |

## Test plan

- [x] `make generate manifests` - CRD includes new `digest` field
- [x] `make test` - All tests pass including new digest tests
- [x] `make lint` - No linting errors
- [ ] Manual test: Apply a MondooAuditConfig with digest and verify the resulting pod uses the digest-based image reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)