### PR TITLE
Explicitly set permissions on all GitHub Actions workflows

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -6,6 +6,12 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud-tests.yaml
+++ b/.github/workflows/cloud-tests.yaml
@@ -16,6 +16,10 @@ on:
         default: main
         description: The image tag to use for the mondoo operator image
 
+permissions:
+  contents: read
+  checks: write
+
 env:
   MONDOO_OPERATOR_IMAGE_TAG: ${{ github.event.inputs.mondooOperatorImageTag || 'main' }}
   CNSPEC_IMAGE_TAG: ${{ github.event.inputs.cnspecImageTag || 'latest-rootless' }}

--- a/.github/workflows/edge-integration-tests.yaml
+++ b/.github/workflows/edge-integration-tests.yaml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     uses: ./.github/workflows/integration-tests.yaml

--- a/.github/workflows/leftover-spaces-cleaner.yaml
+++ b/.github/workflows/leftover-spaces-cleaner.yaml
@@ -5,6 +5,9 @@ on:
     # Every Sunday at 11PM
     - cron: '0 23 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   md-links:
     name: Run markdown link check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,14 +8,14 @@ on:
       - "main"
     tags: ["v*.*.*"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@37c927c24552caa0ef6040ab0876db729cc12754 # v1.0.2-beta7
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,10 @@ on:
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
+# Restrictive top-level default; individual jobs escalate as needed.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   GHCR_IMAGE: ghcr.io/${{ github.repository }}

--- a/.github/workflows/release-manifests.yaml
+++ b/.github/workflows/release-manifests.yaml
@@ -3,6 +3,9 @@ name: Release Manifests
 on:
   workflow_call:
 
+permissions:
+  contents: write
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` blocks to all workflows that were missing them, following the principle of least privilege
- Removes the `GitHubSecurityLab/actions-permissions/monitor` step from `lint.yaml` since it has served its purpose
- Workflows that already had job-level permissions (e.g. `publish.yaml`) now also have a restrictive top-level default

### Workflows updated
| Workflow | Permissions | 
|---|---|
| `lint.yaml` | `contents: read` |
| `link-check.yaml` | `contents: read` |
| `leftover-spaces-cleaner.yaml` | `contents: read` |
| `cla.yaml` | `contents: read`, `pull-requests: write`, `issues: write`, `actions: read` |
| `publish-images.yaml` | `contents: read` |
| `edge-integration-tests.yaml` | `contents: read` |
| `cloud-tests.yaml` | `contents: read`, `checks: write` |
| `release-manifests.yaml` | `contents: write` |
| `publish.yaml` | `contents: read` (top-level default; jobs escalate individually) |

Closes #843

## Test plan
- [ ] Verify lint workflow passes (only needs checkout + linter)
- [ ] Verify CLA bot can still comment on PRs
- [ ] Verify publish workflow can still push images and create releases
- [ ] Verify cloud-tests can still publish test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)