### PR TITLE
🐛 use DeleteCompletedJobs to preserve active scans during CronJob updates

### DIFF
--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -113,11 +113,9 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 		existing.SetOwnerReferences(desired.GetOwnerReferences())
 
-		// Remove any old jobs because they won't be updated when the cronjob changes
-		if err := n.KubeClient.DeleteAllOf(ctx, &batchv1.Job{},
-			client.InNamespace(n.Mondoo.Namespace),
-			client.MatchingLabels(CronJobLabels(*n.Mondoo)),
-			client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+		// Remove completed/failed jobs because they won't be updated when the cronjob changes.
+		// Active jobs are preserved to avoid killing in-progress scans.
+		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), logger); err != nil {
 			return err
 		}
 

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -117,11 +117,9 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			}
 			continue
 		case controllerutil.OperationResultUpdated:
-			// Remove any old jobs because they won't be updated when the cronjob changes
-			if err := n.KubeClient.DeleteAllOf(ctx, &batchv1.Job{},
-				client.InNamespace(n.Mondoo.Namespace),
-				client.MatchingLabels(NodeScanningLabels(*n.Mondoo)),
-				client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			// Remove completed/failed jobs because they won't be updated when the cronjob changes.
+			// Active jobs are preserved to avoid killing in-progress scans.
+			if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, NodeScanningLabels(*n.Mondoo), logger); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- Replaces `DeleteAllOf` with `DeleteCompletedJobs` in all 4 CronJob update paths (k8s_scan local, k8s_scan external, container_image, nodes)
- Running scan jobs are no longer killed when a CronJob spec changes; only completed/failed jobs are cleaned up
- This wires up the `DeleteCompletedJobs` utility added in #1377, which was previously unused in production code

## Context
When the operator reconciles a CronJob spec change (e.g. new image, new config), it needs to clean up old Jobs since they won't pick up the new spec. Previously this used `DeleteAllOf` which killed **all** Jobs including actively running scans. This was disruptive for long-running scans.

The `DeleteCompletedJobs` function from #1377 already handles this correctly — it skips Jobs with `Status.Active > 0` and only deletes completed/failed ones. Active scans finish naturally with the old config, and the next scheduled run picks up the new spec.

## Test plan
- [x] All unit tests pass (`make test`)
- [x] Go linting passes (`make lint`)
- [x] Actions linting passes (`make lint/actions`)
- [ ] Verify running scans are not interrupted when CronJob spec changes
- [ ] Verify completed jobs are still cleaned up on spec change

🤖 Generated with [Claude Code](https://claude.com/claude-code)