### PR TITLE
Add Helm chart documentation and improve values.yaml annotations

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -16,6 +16,7 @@ psat
 rolearn
 selfsigned
 servicemonitors
+SResources
 spiffe
 SVIDs
 tekton

--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,23 @@ helm/lint: ## Lint the Helm chart using chart-testing (ct).
 helm/template: ## Render Helm chart templates for debugging.
 	helm template test charts/mondoo-operator
 
+README_GENERATOR_DIR = $(LOCALBIN)/readme-generator-for-helm
+README_GENERATOR = $(README_GENERATOR_DIR)/bin/index.js
+
+.PHONY: helm/docs
+helm/docs: $(README_GENERATOR) ## Generate Helm chart README from values.yaml annotations.
+	node $(README_GENERATOR) \
+		--values charts/mondoo-operator/values.yaml \
+		--readme charts/mondoo-operator/README.md
+
+$(README_GENERATOR): $(LOCALBIN)
+	@if [ ! -f $(README_GENERATOR) ]; then \
+		echo "Installing readme-generator-for-helm..."; \
+		rm -rf $(README_GENERATOR_DIR); \
+		git clone --depth 1 https://github.com/bitnami/readme-generator-for-helm.git $(README_GENERATOR_DIR); \
+		cd $(README_GENERATOR_DIR) && npm install --production; \
+	fi
+
 # Install prettier gloablly via
 # yarn global add prettier --prefix /usr/local
 .PHONY: fmt/docs

--- a/charts/mondoo-operator/README.md
+++ b/charts/mondoo-operator/README.md
@@ -1,0 +1,88 @@
+# Mondoo Operator Helm Chart
+
+The Mondoo Operator provides a Kubernetes-native way to deploy and manage [Mondoo](https://mondoo.com) security scanning in your clusters.
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.x
+
+## Installation
+
+### Add the Helm repository
+
+```bash
+helm repo add mondoo https://mondoohq.github.io/mondoo-operator
+helm repo update
+```
+
+### Install the chart
+
+```bash
+helm install mondoo-operator mondoo/mondoo-operator --namespace mondoo-operator --create-namespace
+```
+
+### Uninstall the chart
+
+```bash
+helm uninstall mondoo-operator --namespace mondoo-operator
+```
+
+## Parameters
+
+### Controller Manager Configuration
+
+| Name                                                 | Description                                                     | Value                                                                                              |
+| ---------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `controllerManager.manager.args`                     | Command-line arguments passed to the operator manager container | `["operator","--health-probe-bind-address=:8081","--metrics-bind-address=:8080","--leader-elect"]` |
+| `controllerManager.manager.containerSecurityContext` | Security context for the manager container                      | `{}`                                                                                               |
+| `controllerManager.manager.image.repository`         | Container image repository for the operator                     | `ghcr.io/mondoohq/mondoo-operator`                                                                 |
+| `controllerManager.manager.image.tag`                | Container image tag for the operator                            | `v12.0.1`                                                                                          |
+| `controllerManager.manager.imagePullPolicy`          | Image pull policy for the operator container                    | `IfNotPresent`                                                                                     |
+| `controllerManager.manager.resources`                | Resource requests and limits for the manager container          | `{}`                                                                                               |
+| `controllerManager.podSecurityContext`               | Pod-level security context for the controller manager           | `{}`                                                                                               |
+| `controllerManager.replicas`                         | Number of controller manager replicas                           | `1`                                                                                                |
+| `controllerManager.serviceAccount.annotations`       | Annotations to add to the controller manager service account    | `{}`                                                                                               |
+
+### Kubernetes Resources Scanning Configuration
+
+| Name                                              | Description                                                             | Value |
+| ------------------------------------------------- | ----------------------------------------------------------------------- | ----- |
+| `k8SResourcesScanning.serviceAccount.annotations` | Annotations to add to the Kubernetes resources scanning service account | `{}`  |
+
+### General Configuration
+
+| Name                      | Description                            | Value           |
+| ------------------------- | -------------------------------------- | --------------- |
+| `kubernetesClusterDomain` | Kubernetes cluster domain used for DNS | `cluster.local` |
+
+### Manager Config
+
+| Name                                        | Description                                            | Value                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `managerConfig.controllerManagerConfigYaml` | Embedded YAML configuration for the controller manager | `# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+kind: ControllerManagerConfig
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: 127.0.0.1:8080
+leaderElection:
+  leaderElect: true
+  resourceName: 60679458.mondoo.com` |
+
+### Metrics Service Configuration
+
+| Name                   | Description                                     | Value       |
+| ---------------------- | ----------------------------------------------- | ----------- |
+| `metricsService.ports` | Ports configuration for the metrics service     | `[]`        |
+| `metricsService.type`  | Kubernetes service type for the metrics service | `ClusterIP` |
+
+### Pre-delete Cleanup Hook Configuration
+
+| Name              | Description                                                       | Value  |
+| ----------------- | ----------------------------------------------------------------- | ------ |
+| `cleanup.enabled` | Enable or disable the pre-delete cleanup hook                     | `true` |
+| `cleanup.timeout` | Timeout for waiting for MondooAuditConfig resources to be deleted | `2m`   |
+

--- a/charts/mondoo-operator/values.yaml
+++ b/charts/mondoo-operator/values.yaml
@@ -1,10 +1,15 @@
+## @section Controller Manager Configuration
+## Configuration for the mondoo-operator controller manager deployment
+
 controllerManager:
   manager:
+    ## @param controllerManager.manager.args Command-line arguments passed to the operator manager container
     args:
     - operator
     - --health-probe-bind-address=:8081
     - --metrics-bind-address=:8080
     - --leader-elect
+    ## @param controllerManager.manager.containerSecurityContext [object] Security context for the manager container
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -13,9 +18,13 @@ controllerManager:
       privileged: false
       readOnlyRootFilesystem: true
     image:
+      ## @param controllerManager.manager.image.repository Container image repository for the operator
       repository: ghcr.io/mondoohq/mondoo-operator
+      ## @param controllerManager.manager.image.tag Container image tag for the operator
       tag: v12.0.1
+    ## @param controllerManager.manager.imagePullPolicy Image pull policy for the operator container
     imagePullPolicy: IfNotPresent
+    ## @param controllerManager.manager.resources [object] Resource requests and limits for the manager container
     resources:
       limits:
         cpu: 200m
@@ -23,16 +32,32 @@ controllerManager:
       requests:
         cpu: 100m
         memory: 70Mi
+  ## @param controllerManager.podSecurityContext [object] Pod-level security context for the controller manager
   podSecurityContext:
     runAsNonRoot: true
+  ## @param controllerManager.replicas Number of controller manager replicas
   replicas: 1
   serviceAccount:
+    ## @param controllerManager.serviceAccount.annotations [object] Annotations to add to the controller manager service account
     annotations: {}
+
+## @section Kubernetes Resources Scanning Configuration
+
 k8SResourcesScanning:
   serviceAccount:
+    ## @param k8SResourcesScanning.serviceAccount.annotations [object] Annotations to add to the Kubernetes resources scanning service account
     annotations: {}
+
+## @section General Configuration
+
+## @param kubernetesClusterDomain Kubernetes cluster domain used for DNS
 kubernetesClusterDomain: cluster.local
+
+## @section Manager Config
+## Configuration for the controller manager runtime settings
+
 managerConfig:
+  ## @param managerConfig.controllerManagerConfigYaml Embedded YAML configuration for the controller manager
   controllerManagerConfigYaml: |-
     # Copyright (c) Mondoo, Inc.
     # SPDX-License-Identifier: BUSL-1.1
@@ -45,18 +70,26 @@ managerConfig:
     leaderElection:
       leaderElect: true
       resourceName: 60679458.mondoo.com
+
+## @section Metrics Service Configuration
+
 metricsService:
+  ## @param metricsService.ports [array] Ports configuration for the metrics service
   ports:
   - name: metrics
     port: 8080
     protocol: TCP
     targetPort: metrics
+  ## @param metricsService.type Kubernetes service type for the metrics service
   type: ClusterIP
-# Pre-delete cleanup hook configuration
-# This hook runs before uninstall to delete MondooAuditConfig resources,
-# allowing finalizers to clean up operator-created resources properly.
-# The cleanup job uses the same image as the operator.
+
+## @section Pre-delete Cleanup Hook Configuration
+## This hook runs before uninstall to delete MondooAuditConfig resources,
+## allowing finalizers to clean up operator-created resources properly.
+## The cleanup job uses the same image as the operator.
+
 cleanup:
+  ## @param cleanup.enabled Enable or disable the pre-delete cleanup hook
   enabled: true
-  # Timeout for waiting for MondooAuditConfig resources to be deleted
+  ## @param cleanup.timeout Timeout for waiting for MondooAuditConfig resources to be deleted
   timeout: 2m


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Mondoo Operator Helm chart and improves the values.yaml file with structured annotations for automatic documentation generation.

## Key Changes
- **Added README.md**: Created a comprehensive Helm chart README with installation instructions, prerequisites, and a complete parameters table documenting all configurable values
- **Enhanced values.yaml**: Added Helm documentation annotations (`@section` and `@param`) to all configuration parameters for better organization and automated documentation generation
- **Added documentation generation tooling**: Implemented a new `helm/docs` Makefile target that uses the Bitnami readme-generator-for-helm tool to automatically generate the README from values.yaml annotations

## Implementation Details
- The README includes sections for Controller Manager Configuration, Kubernetes Resources Scanning, General Configuration, Manager Config, Metrics Service, and Pre-delete Cleanup Hook Configuration
- All parameters are documented with descriptions and default values in a structured table format
- The Makefile target automatically clones and installs the readme-generator-for-helm tool on first use
- Documentation annotations follow Helm best practices with `@section` headers for logical grouping and `@param` tags for individual parameters
- The cleanup hook configuration section includes helpful comments explaining its purpose in the uninstall process

https://claude.ai/code/session_01HTHQYrFGw5L4Wn3BxCU5hk