### PR TITLE
fix: skip version file updates on main for pre-release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ on:
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    # Only run for version tags
-    if: startsWith(github.event.release.tag_name, 'v')
+    # Only run for stable version tags (skip pre-releases like v1.0.0-alpha.1)
+    if: startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-')
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

- When a pre-release tag (e.g. `v12.1.0-alpha.1`) triggers the release workflow, the `prepare-release` job was updating version files (`Chart.yaml`, `kustomization.yaml`, etc.) on `main` with the pre-release version string. This left `main` referencing a pre-release version, which is undesirable.
- Added `!contains(github.event.release.tag_name, '-')` guard to the `prepare-release` job condition, matching the convention already used in `publish.yaml` and `release-manifests.yaml`.
- Stable release tags (e.g. `v12.1.0`) continue to work as before.

## Test plan

- [x] `make lint/actions` passes
- [ ] Verify a pre-release tag like `v12.1.0-alpha.1` would be skipped by the updated condition
- [ ] Verify a stable tag like `v12.1.0` still triggers the job normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)