### PR TITLE
fix: add nolint:gosec annotations for new gosec rules

### DIFF
--- a/pkg/client/common/http.go
+++ b/pkg/client/common/http.go
@@ -156,7 +156,7 @@ func Request(ctx context.Context, client http.Client, url, token string, reqBody
 	req.Header = header
 
 	// do http call
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to do request: %v", err)
 	}

--- a/pkg/client/mondooclient/types.go
+++ b/pkg/client/mondooclient/types.go
@@ -48,7 +48,7 @@ type IntegrationRegisterOutput struct {
 type ServiceAccountCredentials struct {
 	Mrn         string `protobuf:"bytes,1,opt,name=mrn,proto3" json:"mrn,omitempty"`
 	SpaceMrn    string `protobuf:"bytes,2,opt,name=space_mrn,json=spaceMrn,proto3" json:"space_mrn,omitempty"`
-	PrivateKey  string `protobuf:"bytes,3,opt,name=private_key,json=privateKey,proto3" json:"private_key,omitempty"`
+	PrivateKey  string `protobuf:"bytes,3,opt,name=private_key,json=privateKey,proto3" json:"private_key,omitempty"` //nolint:gosec
 	Certificate string `protobuf:"bytes,4,opt,name=certificate,proto3" json:"certificate,omitempty"`
 	ApiEndpoint string `protobuf:"bytes,5,opt,name=api_endpoint,json=apiEndpoint,proto3" json:"api_endpoint,omitempty"`
 }

--- a/pkg/imagecache/imagecache.go
+++ b/pkg/imagecache/imagecache.go
@@ -148,7 +148,7 @@ type DockerConfigJSON struct {
 // DockerConfigEntry represents a single registry entry in Docker config
 type DockerConfigEntry struct {
 	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty"` //nolint:gosec
 	Auth     string `json:"auth,omitempty"`
 }
 

--- a/pkg/utils/k8s/private_registries.go
+++ b/pkg/utils/k8s/private_registries.go
@@ -34,7 +34,7 @@ type DockerConfigJSON struct {
 type DockerAuthConfig struct {
 	Auth          string `json:"auth,omitempty"`
 	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
+	Password      string `json:"password,omitempty"` //nolint:gosec
 	Email         string `json:"email,omitempty"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 	IdentityToken string `json:"identitytoken,omitempty"`

--- a/tests/framework/utils/executor.go
+++ b/tests/framework/utils/executor.go
@@ -138,7 +138,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duratio
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// #nosec G204 Rook controls the input to the exec arguments
+	//nolint:gosec // Rook controls the input to the exec arguments
 	cmd := exec.CommandContext(ctx, command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 
@@ -179,7 +179,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 	arg = append(arg, outfileArg, outFile.Name())
 
 	logCommand(command, arg...)
-	// #nosec G204 Rook controls the input to the exec arguments
+	//nolint:gosec // Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- golangci-lint v2.10.1 introduced stricter gosec rules (G117, G702, G704) that flag existing code, causing CI lint failures on all PRs (e.g. #1395).
- Added `//nolint:gosec` annotations to 6 locations:
  - `pkg/client/common/http.go:159` — G704 (SSRF false positive on `client.Do`)
  - `pkg/client/mondooclient/types.go:51` — G117 (`PrivateKey` field name matches secret pattern)
  - `pkg/imagecache/imagecache.go:151` — G117 (`Password` field in Docker config struct)
  - `pkg/utils/k8s/private_registries.go:37` — G117 (`Password` field in Docker auth struct)
  - `tests/framework/utils/executor.go:142,183` — G702 (command injection in test executor)

## Test plan

- [x] `make lint` passes locally with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)