### PR TITLE
Fix spell check workflow permissions

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -5,13 +5,18 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   spelling:
     name: Run spell check
     permissions:
+      actions: read
       contents: read
       pull-requests: read
-      actions: read
+      security-events: write
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
@@ -43,8 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: spelling
     permissions:
-      contents: write
+      actions: read
+      contents: read
       pull-requests: write
+      security-events: write
     if: (success() || failure()) && needs.spelling.outputs.followup
     steps:
       - name: comment


### PR DESCRIPTION
## Summary
- Add `actions: read` to the Report job so it can download artifacts from the spell check job
- Add `security-events: write` to the Report job for SARIF upload
- Add top-level `permissions` block for least-privilege defaults
- Align all job permissions with the reference pattern

## Test plan
- [ ] Verify spell check workflow runs and the Report job can post comments on a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)