### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -71,7 +71,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@aba8d5ff1666d19b9549133e3b92e70d4fc52cb7 # master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           memory: 4000m
           kubernetes-version: ${{ matrix.k8s-version }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@aba8d5ff1666d19b9549133e3b92e70d4fc52cb7 # master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         if: matrix.k8s-distro == 'minikube'
         with:
           memory: 4000m

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@aba8d5ff1666d19b9549133e3b92e70d4fc52cb7 # master
         if: matrix.k8s-distro == 'minikube'
         with:
           memory: 4000m

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Scan Image
         if: matrix.arch == 'amd64'
-        uses: mondoohq/actions/docker-image@20caefcb2d1258d051149913cde321a698b1fdb9 # main
+        uses: mondoohq/actions/docker-image@20caefcb2d1258d051149913cde321a698b1fdb9 # v13.1.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
@@ -296,7 +296,7 @@ jobs:
       - name: Run chart-releaser
         # switch back to helm/chart-releaser-action when #60 is fixed
         # https://github.com/helm/chart-releaser-action/issues/60
-        uses: luisico/chart-releaser-action@7c1e965b4291eb09860486ddbed6cabe1dfca143 # on-tags
+        uses: luisico/chart-releaser-action@c25b74a986eb925b398320414b576227f375f946 # v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Scan Image
         if: matrix.arch == 'amd64'
-        uses: mondoohq/actions/docker-image@main
+        uses: mondoohq/actions/docker-image@20caefcb2d1258d051149913cde321a698b1fdb9 # main
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
@@ -296,7 +296,7 @@ jobs:
       - name: Run chart-releaser
         # switch back to helm/chart-releaser-action when #60 is fixed
         # https://github.com/helm/chart-releaser-action/issues/60
-        uses: luisico/chart-releaser-action@on-tags
+        uses: luisico/chart-releaser-action@7c1e965b4291eb09860486ddbed6cabe1dfca143 # on-tags
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/security-tests.yaml
+++ b/.github/workflows/security-tests.yaml
@@ -33,13 +33,13 @@ jobs:
           go-version-file: "go.mod"
           cache: false
       - name: Scan AWS terraform with Mondoo
-        uses: mondoohq/actions/terraform-hcl@main
+        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # main
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
           path: ".github/terraform/aws/main.tf"
       - name: Scan Azure terraform with Mondoo
-        uses: mondoohq/actions/terraform-hcl@main
+        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # main
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Generate manifests
         run: make generate-manifests IMG='${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}'
       - name: Scan Kubernetes Manifest with Mondoo
-        uses: mondoohq/actions/k8s-manifest@main
+        uses: mondoohq/actions/k8s-manifest@20caefcb2d1258d051149913cde321a698b1fdb9 # main
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:

--- a/.github/workflows/security-tests.yaml
+++ b/.github/workflows/security-tests.yaml
@@ -33,13 +33,13 @@ jobs:
           go-version-file: "go.mod"
           cache: false
       - name: Scan AWS terraform with Mondoo
-        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # main
+        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # v13.1.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
           path: ".github/terraform/aws/main.tf"
       - name: Scan Azure terraform with Mondoo
-        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # main
+        uses: mondoohq/actions/terraform-hcl@20caefcb2d1258d051149913cde321a698b1fdb9 # v13.1.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Generate manifests
         run: make generate-manifests IMG='${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}'
       - name: Scan Kubernetes Manifest with Mondoo
-        uses: mondoohq/actions/k8s-manifest@20caefcb2d1258d051149913cde321a698b1fdb9 # main
+        uses: mondoohq/actions/k8s-manifest@20caefcb2d1258d051149913cde321a698b1fdb9 # v13.1.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CLIENT }}
         with:


### PR DESCRIPTION
Pin all unpinned GitHub Actions to full commit SHAs for supply chain security. Pins: mondoohq/actions@main, medyagh/setup-minikube@master, luisico/chart-releaser-action@on-tags.