### PR TITLE
✨ add spaceId support for MondooAuditConfig to route assets to specific spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ tests/e2e/**/kubeconfig
 tests/e2e/**/kubeconfig-target
 tests/e2e/**/gke_gcloud_auth_plugin_cache
 tests/e2e/**/mondoo.json
+
+# macOS
+.DS_Store

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -29,6 +29,13 @@ type MondooAuditConfigSpec struct {
 	Filtering           Filtering           `json:"filtering,omitempty"`
 	Containers          Containers          `json:"containers,omitempty"`
 
+	// SpaceID optionally specifies the target Mondoo space for asset routing.
+	// When set, scanned assets are sent to this space instead of the space
+	// associated with the service account credentials. This allows using an
+	// org-level service account across multiple spaces.
+	// +optional
+	SpaceID string `json:"spaceId,omitempty"`
+
 	// Annotations allows adding custom annotations to all scanned assets. These key-value pairs
 	// will be attached to every asset discovered by the operator, making them searchable
 	// and filterable in the Mondoo Console.

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1312,6 +1312,13 @@ spec:
                     default: mondoo-operator-k8s-resources-scanning
                     type: string
                 type: object
+              spaceId:
+                description: |-
+                  SpaceID optionally specifies the target Mondoo space for asset routing.
+                  When set, scanned assets are sent to this space instead of the space
+                  associated with the service account credentials. This allows using an
+                  org-level service account across multiple spaces.
+                type: string
             required:
             - mondooCredsSecretRef
             type: object

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondoooperatorconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondoooperatorconfigs.yaml
@@ -93,6 +93,13 @@ spec:
                       ResourceLabels allows providing a list of extra labels to apply to the metrics-related
                       resources (eg. ServiceMonitor)
                     type: object
+                  secureMetrics:
+                    description: |-
+                      SecureMetrics enables authentication and authorization on the metrics endpoint
+                      using controller-runtime's built-in TLS and RBAC-based auth.
+                      When enabled, metrics are served over HTTPS on port 8443 with token-based auth.
+                      When disabled, metrics are served over HTTP on port 8080 without auth.
+                    type: boolean
                 type: object
               noProxy:
                 description: NoProxy specifies a comma-separated list of hosts that

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1312,6 +1312,13 @@ spec:
                     default: mondoo-operator-k8s-resources-scanning
                     type: string
                 type: object
+              spaceId:
+                description: |-
+                  SpaceID optionally specifies the target Mondoo space for asset routing.
+                  When set, scanned assets are sent to this space instead of the space
+                  associated with the service account credentials. This allows using an
+                  org-level service account across multiple spaces.
+                type: string
             required:
             - mondooCredsSecretRef
             type: object

--- a/charts/mondoo-operator/templates/manager-rbac.yaml
+++ b/charts/mondoo-operator/templates/manager-rbac.yaml
@@ -36,6 +36,7 @@ rules:
   - create
   - delete
   - get
+  - update
 - apiGroups:
   - ""
   resources:

--- a/cmd/mondoo-operator/garbage_collect/cmd.go
+++ b/cmd/mondoo-operator/garbage_collect/cmd.go
@@ -30,6 +30,7 @@ func init() {
 	filterPlatformRuntime := Cmd.Flags().String("filter-platform-runtime", "", "Cleanup assets by an asset's PlatformRuntime (k8s-cluster or docker-image).")
 	filterManagedBy := Cmd.Flags().String("filter-managed-by", "", "Cleanup assets with matching ManagedBy field.")
 	filterOlderThan := Cmd.Flags().String("filter-older-than", "", "Cleanup assets which have not been updated in over the time provided (eg 12m or 48h or anything time.ParseDuration() accepts).")
+	spaceMrnOverride := Cmd.Flags().String("space-mrn", "", "Override the space MRN for garbage collection (used when spaceId is set in MondooAuditConfig).")
 	Cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		log.SetLogger(logger.NewLogger())
 		logger := log.Log.WithName("garbage-collect")
@@ -77,9 +78,12 @@ func init() {
 			return fmt.Errorf("no filters provided to garbage collect by")
 		}
 
-		spaceMrn := serviceAccount.SpaceMrn
+		spaceMrn := *spaceMrnOverride
 		if spaceMrn == "" {
-			spaceMrn = mondoo.SpaceMrnFromServiceAccountMrn(serviceAccount.Mrn)
+			spaceMrn = serviceAccount.SpaceMrn
+			if spaceMrn == "" {
+				spaceMrn = mondoo.SpaceMrnFromServiceAccountMrn(serviceAccount.Mrn)
+			}
 		}
 		return GarbageCollectCmd(ctx, client, spaceMrn, *filterPlatformRuntime, *filterOlderThan, *filterManagedBy, logger)
 	}

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1312,6 +1312,13 @@ spec:
                     default: mondoo-operator-k8s-resources-scanning
                     type: string
                 type: object
+              spaceId:
+                description: |-
+                  SpaceID optionally specifies the target Mondoo space for asset routing.
+                  When set, scanned assets are sent to this space instead of the space
+                  associated with the service account credentials. This allows using an
+                  org-level service account across multiple spaces.
+                type: string
             required:
             - mondooCredsSecretRef
             type: object

--- a/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
@@ -8,9 +8,17 @@ metadata:
   name: mondoo-client
   namespace: mondoo-operator
 spec:
-  # Required: Reference to secret containing Mondoo service account credentials
+  # Required: Reference to secret containing Mondoo service account credentials.
+  # Can be a space-level or org-level service account.
   mondooCredsSecretRef:
     name: mondoo-client
+
+  # Optional: Route scanned assets to a specific Mondoo space.
+  # When set, the operator injects the target space into the scanner config,
+  # overriding the space derived from the service account credentials.
+  # This enables using a single org-level service account across multiple
+  # MondooAuditConfigs, each targeting a different space.
+  # spaceId: "your-space-1234"
 
   # Optional: Reference to secret containing a Mondoo registration token
   # If provided and mondooCredsSecretRef secret doesn't exist, the operator

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -140,7 +140,7 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 												},
 												{
 													Secret: &corev1.SecretProjection{
-														LocalObjectReference: m.Spec.MondooCredsSecretRef,
+														LocalObjectReference: k8s.ConfigSecretRef(*m),
 														Items: []corev1.KeyToPath{{
 															Key:  "config",
 															Path: "mondoo.yml",

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -152,7 +152,7 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 												},
 												{
 													Secret: &corev1.SecretProjection{
-														LocalObjectReference: m.Spec.MondooCredsSecretRef,
+														LocalObjectReference: k8s.ConfigSecretRef(*m),
 														Items: []corev1.KeyToPath{{
 															Key:  "config",
 															Path: "mondoo.yml",
@@ -237,7 +237,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 						},
 						{
 							Secret: &corev1.SecretProjection{
-								LocalObjectReference: m.Spec.MondooCredsSecretRef,
+								LocalObjectReference: k8s.ConfigSecretRef(*m),
 								Items: []corev1.KeyToPath{{
 									Key:  "config",
 									Path: "mondoo.yml",

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -272,6 +272,13 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, reconcileError
 	}
 
+	// When spaceId is set, create a derived Secret with scope_mrn injected so cnspec
+	// routes assets to the specified space instead of the SA's default space.
+	if reconcileError = k8s.SyncConfigOverrideSecret(ctx, r.Client, mondooAuditConfig); reconcileError != nil {
+		log.Error(reconcileError, "failed to sync config override secret for space routing")
+		return ctrl.Result{}, reconcileError
+	}
+
 	nodes := nodes.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
 		KubeClient:             r.Client,

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -156,7 +156,7 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 												},
 												{
 													Secret: &corev1.SecretProjection{
-														LocalObjectReference: m.Spec.MondooCredsSecretRef,
+														LocalObjectReference: k8s.ConfigSecretRef(*m),
 														Items:                []corev1.KeyToPath{{Key: "config", Path: "mondoo/mondoo.yml"}},
 													},
 												},
@@ -290,7 +290,7 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 										},
 										{
 											Secret: &corev1.SecretProjection{
-												LocalObjectReference: m.Spec.MondooCredsSecretRef,
+												LocalObjectReference: k8s.ConfigSecretRef(m),
 												Items:                []corev1.KeyToPath{{Key: "config", Path: "mondoo/mondoo.yml"}},
 											},
 										},

--- a/controllers/resource_watcher/resources.go
+++ b/controllers/resource_watcher/resources.go
@@ -178,7 +178,7 @@ func Deployment(image, integrationMRN, clusterUID string, m *v1alpha2.MondooAudi
 									Sources: []corev1.VolumeProjection{
 										{
 											Secret: &corev1.SecretProjection{
-												LocalObjectReference: m.Spec.MondooCredsSecretRef,
+												LocalObjectReference: k8s.ConfigSecretRef(*m),
 												Items: []corev1.KeyToPath{{
 													Key:  constants.MondooCredsSecretServiceAccountKey,
 													Path: "mondoo.yml",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,6 +137,9 @@ spec:
   mondooCredsSecretRef:
     name: mondoo-client
 
+  # Optional: route assets to a specific space (for org-level Service Accounts)
+  # spaceId: "your-space-1234"
+
   # Scan Kubernetes resources
   kubernetesResources:
     enable: true

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -180,6 +180,8 @@ Once the Secret is configured, configure the operator to define the scan targets
    spec:
      mondooCredsSecretRef:
        name: mondoo-client
+     # Optional: route assets to a specific space (useful with org-level Service Accounts)
+     # spaceId: "your-space-1234"
      kubernetesResources:
        enable: true
      nodes:
@@ -543,6 +545,60 @@ If no secret reference is specified, the operator looks for a secret named `mond
 The operator's default RBAC only allows reading secrets with specific names. If you use a custom secret name, extend RBAC so that the `ServiceAccount` `mondoo-operator-k8s-resources-scanning` has permission to read the secret.
 
 You can find examples of creating Docker registry secrets [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
+## Routing assets to a specific space with `spaceId`
+
+By default, scanned assets are sent to the space associated with the service account credentials. The `spaceId` field lets you override this, routing assets to any space the service account has access to. This is especially useful with **org-level service accounts**, which have access to all spaces in the organization.
+
+### Use cases
+
+- **Multi-space scanning**: A single operator with multiple `MondooAuditConfig` resources, each routing to a different space.
+- **External cluster scanning**: Scan remote clusters and route each cluster's assets to its own space.
+- **Simplified credential management**: Use one org-level service account instead of managing per-space service accounts.
+
+### Example: Two MondooAuditConfigs routing to different spaces
+
+Create an org-level service account in the [Mondoo Console](https://mondoo.com/docs/platform/maintain/access/service_accounts/) and store it as a Secret:
+
+```bash
+kubectl create secret generic mondoo-client --namespace mondoo-operator --from-file=config=org-creds.json
+```
+
+Then create two `MondooAuditConfig` resources, each targeting a different space:
+
+```yaml
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-scanner
+  namespace: mondoo-operator
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "space-for-local-cluster"
+  kubernetesResources:
+    enable: true
+  nodes:
+    enable: true
+---
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-target
+  namespace: mondoo-operator
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "space-for-remote-cluster"
+  kubernetesResources:
+    enable: true
+    externalClusters:
+      - name: remote-cluster
+        kubeconfigSecretRef:
+          name: remote-kubeconfig
+```
+
+Both configs share the same org-level service account but route assets to different spaces. The operator creates a derived config Secret for each `MondooAuditConfig` that has `spaceId` set, injecting the target space into the scanner configuration.
 
 ## Installing Mondoo into multiple namespaces
 

--- a/pkg/utils/k8s/space_config.go
+++ b/pkg/utils/k8s/space_config.go
@@ -1,0 +1,123 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/constants"
+)
+
+const (
+	// ConfigOverrideSecretSuffix is appended to the MondooAuditConfig name to form the
+	// derived config Secret name when spaceId is set.
+	ConfigOverrideSecretSuffix = "-config-override"
+
+	// SpaceMrnPrefix is the MRN prefix for Mondoo spaces.
+	SpaceMrnPrefix = "//captain.api.mondoo.app/spaces/"
+)
+
+// ConfigSecretRef returns the Secret reference to use for mounting the mondoo config.
+// When spaceId is set, it returns the derived config override Secret; otherwise it
+// returns the original MondooCredsSecretRef.
+func ConfigSecretRef(m v1alpha2.MondooAuditConfig) corev1.LocalObjectReference {
+	if m.Spec.SpaceID != "" {
+		return corev1.LocalObjectReference{Name: m.Name + ConfigOverrideSecretSuffix}
+	}
+	return m.Spec.MondooCredsSecretRef
+}
+
+// SyncConfigOverrideSecret creates or updates a derived Secret that injects scope_mrn
+// into the service account config when spaceId is set. Returns nil if spaceId is empty.
+func SyncConfigOverrideSecret(
+	ctx context.Context,
+	kubeClient client.Client,
+	m *v1alpha2.MondooAuditConfig,
+) error {
+	if m.Spec.SpaceID == "" {
+		// Clean up any leftover override secret from when spaceId was previously set
+		derivedSecret := &corev1.Secret{}
+		key := client.ObjectKey{Name: m.Name + ConfigOverrideSecretSuffix, Namespace: m.Namespace}
+		if err := kubeClient.Get(ctx, key, derivedSecret); err == nil {
+			if err := kubeClient.Delete(ctx, derivedSecret); err != nil {
+				return fmt.Errorf("failed to clean up override secret: %w", err)
+			}
+		}
+		return nil
+	}
+
+	// Read the original credentials secret
+	origSecret, err := GetIntegrationSecretForAuditConfig(ctx, kubeClient, *m)
+	if err != nil {
+		return fmt.Errorf("failed to get credentials secret: %w", err)
+	}
+
+	saData, ok := origSecret.Data[constants.MondooCredsSecretServiceAccountKey]
+	if !ok {
+		return fmt.Errorf("credentials secret missing key %q", constants.MondooCredsSecretServiceAccountKey)
+	}
+
+	// Unmarshal as generic map to preserve all original fields (including any future
+	// additions) and inject scope_mrn. Go's encoding/json round-trips map[string]any
+	// faithfully for JSON-compatible types.
+	var config map[string]any
+	if err := json.Unmarshal(saData, &config); err != nil {
+		return fmt.Errorf("failed to unmarshal service account config: %w", err)
+	}
+
+	config["scope_mrn"] = SpaceMrnPrefix + m.Spec.SpaceID
+
+	modifiedData, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal modified config: %w", err)
+	}
+
+	derivedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.Name + ConfigOverrideSecretSuffix,
+			Namespace: m.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, kubeClient, derivedSecret, func() error {
+		// Set owner reference for automatic cleanup
+		if err := controllerutil.SetControllerReference(m, derivedSecret, kubeClient.Scheme()); err != nil {
+			return err
+		}
+
+		if derivedSecret.Data == nil {
+			derivedSecret.Data = make(map[string][]byte)
+		}
+		derivedSecret.Data[constants.MondooCredsSecretServiceAccountKey] = modifiedData
+
+		// Copy integration MRN if present
+		if integrationMrn, ok := origSecret.Data[constants.MondooCredsSecretIntegrationMRNKey]; ok {
+			derivedSecret.Data[constants.MondooCredsSecretIntegrationMRNKey] = integrationMrn
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create/update config override secret: %w", err)
+	}
+
+	return nil
+}
+
+// SpaceMrnForAuditConfig returns the space MRN for the given MondooAuditConfig.
+// If spaceId is set, it constructs the MRN from that. Otherwise returns empty string.
+func SpaceMrnForAuditConfig(m v1alpha2.MondooAuditConfig) string {
+	if m.Spec.SpaceID != "" {
+		return SpaceMrnPrefix + m.Spec.SpaceID
+	}
+	return ""
+}

--- a/pkg/utils/k8s/space_config_test.go
+++ b/pkg/utils/k8s/space_config_test.go
@@ -1,0 +1,192 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/constants"
+)
+
+func TestConfigSecretRef_NoSpaceID(t *testing.T) {
+	m := v1alpha2.MondooAuditConfig{
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			MondooCredsSecretRef: corev1.LocalObjectReference{Name: "my-creds"},
+		},
+	}
+	ref := ConfigSecretRef(m)
+	assert.Equal(t, "my-creds", ref.Name)
+}
+
+func TestConfigSecretRef_WithSpaceID(t *testing.T) {
+	m := v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-audit"},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			MondooCredsSecretRef: corev1.LocalObjectReference{Name: "my-creds"},
+			SpaceID:              "abc123",
+		},
+	}
+	ref := ConfigSecretRef(m)
+	assert.Equal(t, "test-audit"+ConfigOverrideSecretSuffix, ref.Name)
+}
+
+func TestSpaceMrnForAuditConfig(t *testing.T) {
+	t.Run("empty when no spaceId", func(t *testing.T) {
+		m := v1alpha2.MondooAuditConfig{}
+		assert.Equal(t, "", SpaceMrnForAuditConfig(m))
+	})
+
+	t.Run("constructs MRN when spaceId set", func(t *testing.T) {
+		m := v1alpha2.MondooAuditConfig{
+			Spec: v1alpha2.MondooAuditConfigSpec{SpaceID: "abc123"},
+		}
+		assert.Equal(t, "//captain.api.mondoo.app/spaces/abc123", SpaceMrnForAuditConfig(m))
+	})
+}
+
+func TestSyncConfigOverrideSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	origConfig := map[string]any{
+		"mrn":          "//agents.api.mondoo.app/organizations/org1/serviceaccounts/sa1",
+		"private_key":  "test-key",
+		"certificate":  "test-cert",
+		"api_endpoint": "https://api.mondoo.app",
+	}
+	origConfigBytes, _ := json.Marshal(origConfig)
+
+	t.Run("no-op when spaceId is empty", func(t *testing.T) {
+		m := &v1alpha2.MondooAuditConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       v1alpha2.MondooAuditConfigSpec{},
+		}
+		kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		err := SyncConfigOverrideSecret(context.Background(), kubeClient, m)
+		assert.NoError(t, err)
+	})
+
+	t.Run("cleans up override secret when spaceId is removed", func(t *testing.T) {
+		leftoverSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test" + ConfigOverrideSecretSuffix,
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				constants.MondooCredsSecretServiceAccountKey: []byte(`{"scope_mrn":"old"}`),
+			},
+		}
+
+		m := &v1alpha2.MondooAuditConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       v1alpha2.MondooAuditConfigSpec{},
+		}
+
+		kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leftoverSecret).Build()
+		err := SyncConfigOverrideSecret(context.Background(), kubeClient, m)
+		require.NoError(t, err)
+
+		// Verify the override secret was deleted
+		deletedSecret := &corev1.Secret{}
+		err = kubeClient.Get(context.Background(), client.ObjectKey{
+			Name:      "test" + ConfigOverrideSecretSuffix,
+			Namespace: "default",
+		}, deletedSecret)
+		assert.Error(t, err, "override secret should have been deleted")
+	})
+
+	t.Run("creates derived secret with scope_mrn", func(t *testing.T) {
+		origSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "org-creds", Namespace: "default"},
+			Data: map[string][]byte{
+				constants.MondooCredsSecretServiceAccountKey: origConfigBytes,
+				constants.MondooCredsSecretIntegrationMRNKey: []byte("integration-mrn-value"),
+			},
+		}
+
+		m := &v1alpha2.MondooAuditConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-123"},
+			Spec: v1alpha2.MondooAuditConfigSpec{
+				MondooCredsSecretRef: corev1.LocalObjectReference{Name: "org-creds"},
+				SpaceID:              "target-space",
+			},
+		}
+
+		kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(origSecret).Build()
+		err := SyncConfigOverrideSecret(context.Background(), kubeClient, m)
+		require.NoError(t, err)
+
+		// Verify derived secret was created
+		derivedSecret := &corev1.Secret{}
+		err = kubeClient.Get(context.Background(), client.ObjectKey{
+			Name:      "test" + ConfigOverrideSecretSuffix,
+			Namespace: "default",
+		}, derivedSecret)
+		require.NoError(t, err)
+
+		// Verify scope_mrn was injected
+		var derivedConfig map[string]any
+		err = json.Unmarshal(derivedSecret.Data[constants.MondooCredsSecretServiceAccountKey], &derivedConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "//captain.api.mondoo.app/spaces/target-space", derivedConfig["scope_mrn"])
+		assert.Equal(t, "test-key", derivedConfig["private_key"])
+		assert.Equal(t, "https://api.mondoo.app", derivedConfig["api_endpoint"])
+
+		// Verify integration MRN was copied
+		assert.Equal(t, []byte("integration-mrn-value"),
+			derivedSecret.Data[constants.MondooCredsSecretIntegrationMRNKey])
+	})
+
+	t.Run("updates existing derived secret", func(t *testing.T) {
+		origSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "org-creds", Namespace: "default"},
+			Data: map[string][]byte{
+				constants.MondooCredsSecretServiceAccountKey: origConfigBytes,
+			},
+		}
+
+		existingDerived := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "test" + ConfigOverrideSecretSuffix, Namespace: "default"},
+			Data: map[string][]byte{
+				constants.MondooCredsSecretServiceAccountKey: []byte(`{"scope_mrn":"old-value"}`),
+			},
+		}
+
+		m := &v1alpha2.MondooAuditConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-123"},
+			Spec: v1alpha2.MondooAuditConfigSpec{
+				MondooCredsSecretRef: corev1.LocalObjectReference{Name: "org-creds"},
+				SpaceID:              "new-space",
+			},
+		}
+
+		kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(origSecret, existingDerived).Build()
+		err := SyncConfigOverrideSecret(context.Background(), kubeClient, m)
+		require.NoError(t, err)
+
+		derivedSecret := &corev1.Secret{}
+		err = kubeClient.Get(context.Background(), client.ObjectKey{
+			Name:      "test" + ConfigOverrideSecretSuffix,
+			Namespace: "default",
+		}, derivedSecret)
+		require.NoError(t, err)
+
+		var derivedConfig map[string]any
+		err = json.Unmarshal(derivedSecret.Data[constants.MondooCredsSecretServiceAccountKey], &derivedConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "//captain.api.mondoo.app/spaces/new-space", derivedConfig["scope_mrn"])
+	})
+}

--- a/pkg/utils/mondoo/gc.go
+++ b/pkg/utils/mondoo/gc.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/constants"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 )
 
 const (
@@ -112,12 +113,21 @@ func DeleteStaleAssets(
 		return fmt.Errorf("failed to generate token: %w", err)
 	}
 
-	// Set the SpaceMrn from the service account credentials.
+	// Use spaceId override from MondooAuditConfig if set, otherwise derive from SA credentials.
 	// Some SA credentials (e.g. terraform-created) omit space_mrn, so derive it from the SA MRN.
 	// SA MRN format: //agents.api.mondoo.app/spaces/<id>/serviceaccounts/<id>
-	req.SpaceMrn = sa.SpaceMrn
-	if req.SpaceMrn == "" {
-		req.SpaceMrn = SpaceMrnFromServiceAccountMrn(sa.Mrn)
+	if spaceMrn := k8s.SpaceMrnForAuditConfig(*mondoo); spaceMrn != "" {
+		req.SpaceMrn = spaceMrn
+		// Warn if SA appears to be space-scoped (not org-level) and targets a different space
+		if saSpaceMrn := sa.SpaceMrn; saSpaceMrn != "" && saSpaceMrn != spaceMrn {
+			logger.Info("WARNING: spaceId targets a different space than the service account; ensure the SA has org-level access",
+				"saSpaceMrn", saSpaceMrn, "targetSpaceMrn", spaceMrn)
+		}
+	} else {
+		req.SpaceMrn = sa.SpaceMrn
+		if req.SpaceMrn == "" {
+			req.SpaceMrn = SpaceMrnFromServiceAccountMrn(sa.Mrn)
+		}
 	}
 	logger.Info("Preparing DeleteAssets request", "spaceMrn", req.SpaceMrn, "managedBy", req.ManagedBy)
 

--- a/tests/e2e/gke/manifests/mondoo-audit-config-space-splitting-autopilot.yaml.tpl
+++ b/tests/e2e/gke/manifests/mondoo-audit-config-space-splitting-autopilot.yaml.tpl
@@ -1,0 +1,58 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# MondooAuditConfig for scanning the LOCAL (scanner) cluster.
+# Routes assets to the scanner space using spaceId.
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-scanner
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "${SCANNER_SPACE_ID}"
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+        - gke-managed-system
+        - gke-managed-cim
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+  containers:
+    enable: true
+    schedule: "*/5 * * * *"
+  nodes:
+    # Disabled: GKE Autopilot does not allow hostPath volumes on /
+    enable: false
+---
+# MondooAuditConfig for scanning the REMOTE (target) cluster.
+# Routes assets to the target space using spaceId.
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-target
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "${TARGET_SPACE_ID}"
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+        - gke-managed-system
+        - gke-managed-cim
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+    externalClusters:
+      - name: target-cluster
+        kubeconfigSecretRef:
+          name: target-kubeconfig
+  containers:
+    enable: false
+  nodes:
+    enable: false

--- a/tests/e2e/gke/manifests/mondoo-audit-config-space-splitting.yaml.tpl
+++ b/tests/e2e/gke/manifests/mondoo-audit-config-space-splitting.yaml.tpl
@@ -1,0 +1,59 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# MondooAuditConfig for scanning the LOCAL (scanner) cluster.
+# Routes assets to the scanner space using spaceId.
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-scanner
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "${SCANNER_SPACE_ID}"
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+        - gke-managed-system
+        - gke-managed-cim
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+  containers:
+    enable: true
+    schedule: "*/5 * * * *"
+  nodes:
+    enable: true
+    style: cronjob
+    schedule: "*/5 * * * *"
+---
+# MondooAuditConfig for scanning the REMOTE (target) cluster.
+# Routes assets to the target space using spaceId.
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-target
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  spaceId: "${TARGET_SPACE_ID}"
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+        - gke-managed-system
+        - gke-managed-cim
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+    externalClusters:
+      - name: target-cluster
+        kubeconfigSecretRef:
+          name: target-kubeconfig
+  containers:
+    enable: false
+  nodes:
+    enable: false

--- a/tests/e2e/gke/terraform/mondoo.tf
+++ b/tests/e2e/gke/terraform/mondoo.tf
@@ -14,3 +14,21 @@ resource "mondoo_service_account" "e2e" {
 
   depends_on = [mondoo_space.e2e]
 }
+
+################################################################################
+# Space Splitting Test: second space + org-level service account
+################################################################################
+
+resource "mondoo_space" "target" {
+  count  = var.enable_space_splitting_test ? 1 : 0
+  name   = "e2e-target-${local.name_prefix}"
+  org_id = var.mondoo_org_id
+}
+
+resource "mondoo_service_account" "org" {
+  count       = var.enable_space_splitting_test ? 1 : 0
+  name        = "e2e-org-sa"
+  description = "Org-level service account for space splitting e2e test"
+  roles       = ["//iam.api.mondoo.app/roles/editor", "//iam.api.mondoo.app/roles/agent"]
+  org_id      = var.mondoo_org_id
+}

--- a/tests/e2e/gke/terraform/outputs.tf
+++ b/tests/e2e/gke/terraform/outputs.tf
@@ -78,3 +78,24 @@ output "enable_wif_test" {
 output "wif_gsa_email" {
   value = var.enable_wif_test ? google_service_account.wif_scanner[0].email : ""
 }
+
+output "enable_space_splitting_test" {
+  value = var.enable_space_splitting_test
+}
+
+output "scanner_space_id" {
+  value = var.enable_space_splitting_test ? mondoo_space.e2e.id : ""
+}
+
+output "target_space_id" {
+  value = var.enable_space_splitting_test ? mondoo_space.target[0].id : ""
+}
+
+output "target_space_mrn" {
+  value = var.enable_space_splitting_test ? mondoo_space.target[0].mrn : ""
+}
+
+output "org_credentials_b64" {
+  value     = var.enable_space_splitting_test ? mondoo_service_account.org[0].credential : ""
+  sensitive = true
+}

--- a/tests/e2e/gke/terraform/variables.tf
+++ b/tests/e2e/gke/terraform/variables.tf
@@ -46,3 +46,9 @@ variable "enable_wif_test" {
   type        = bool
   default     = false
 }
+
+variable "enable_space_splitting_test" {
+  description = "Create a second Mondoo space to test org-level SA with spaceId routing"
+  type        = bool
+  default     = false
+}

--- a/tests/e2e/run-space-splitting.sh
+++ b/tests/e2e/run-space-splitting.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test: Space Splitting
+# Deploys a SINGLE operator on the scanner cluster with TWO MondooAuditConfigs,
+# each routing assets to a different Mondoo space using the same org-level SA:
+#   - mondoo-scanner: scans the local (scanner) cluster → scanner space
+#   - mondoo-target:  scans the remote (target) cluster → target space
+#
+# Prerequisites:
+#   - Terraform provisioned with enable_target_cluster=true AND
+#     enable_space_splitting_test=true
+#   - Cloud CLI authenticated, docker, helm, kubectl available
+#
+# Usage:
+#   ./run-space-splitting.sh <cloud>    (gke|eks|aks)
+
+set -euo pipefail
+
+CLOUD="${1:?Usage: $0 <cloud> (gke|eks|aks)}"
+export CLOUD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/${CLOUD}" && pwd)"
+source "${CLOUD_DIR}/../scripts/common.sh"
+
+info "=========================================="
+info "  Test: Space Splitting (${CLOUD})"
+info "=========================================="
+
+# Step 1: Load Terraform outputs
+load_tf_outputs
+
+if [[ "${ENABLE_SPACE_SPLITTING_TEST}" != "true" ]]; then
+  die "Space splitting test not enabled. Run terraform with enable_space_splitting_test=true"
+fi
+if [[ "${ENABLE_TARGET_CLUSTER}" != "true" ]]; then
+  die "Target cluster not enabled. Run terraform with enable_target_cluster=true"
+fi
+
+# Step 2: Build and push operator image
+info "--- Step: Build and Push ---"
+source "${E2E_DIR}/scripts/build-and-push.sh"
+
+# Step 3: Deploy test workload on scanner cluster
+info "--- Step: Deploy Test Workload (scanner cluster) ---"
+source "${E2E_DIR}/scripts/deploy-test-workload.sh"
+
+# Step 4: Deploy operator on scanner cluster (single instance)
+info "--- Step: Deploy Operator ---"
+source "${E2E_DIR}/scripts/deploy-operator.sh"
+
+# Step 5: Deploy workload on target cluster and create kubeconfig Secret
+info "--- Step: Deploy Target Workload + Kubeconfig Secret ---"
+source "${E2E_DIR}/scripts/deploy-target-workload.sh"
+
+# Step 6: Apply both MondooAuditConfigs with org-level SA and space routing
+info "--- Step: Apply Mondoo Configs (space splitting) ---"
+source "${E2E_DIR}/scripts/apply-mondoo-config-space-splitting.sh"
+
+# Step 7: Wait for operator to reconcile both configs
+info "Waiting 90s for operator to reconcile both MondooAuditConfigs..."
+sleep 90
+
+# Step 8: Verify space splitting
+info "--- Step: Verify Space Splitting ---"
+source "${E2E_DIR}/scripts/verify-space-splitting.sh"
+
+info ""
+info "=========================================="
+info "  Test: Space Splitting (${CLOUD}) - COMPLETE"
+info "=========================================="
+info ""
+info "Scanner cluster scan → Space: ${SCANNER_SPACE_ID}"
+info "Target cluster scan  → Space: ${TARGET_SPACE_ID}"
+info "Both MondooAuditConfigs use the same org-level service account."

--- a/tests/e2e/scripts/apply-mondoo-config-space-splitting.sh
+++ b/tests/e2e/scripts/apply-mondoo-config-space-splitting.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Create the Mondoo credentials secret from an org-level SA and apply
+# TWO MondooAuditConfigs with spaceId routing:
+#   - mondoo-scanner: local cluster → scanner space
+#   - mondoo-target:  external cluster → target space
+#
+# Credentials can come from:
+#   - ORG_CREDS_B64 env var (base64-encoded, from Terraform)
+#   - MONDOO_CONFIG_PATH env var (path to a mondoo.json file)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+: "${SCANNER_SPACE_ID:?SCANNER_SPACE_ID must be set}"
+: "${TARGET_SPACE_ID:?TARGET_SPACE_ID must be set}"
+: "${NAMESPACE:?NAMESPACE must be set}"
+
+info "Creating mondoo-client secret from org-level service account..."
+
+if [[ -n "${MONDOO_CONFIG_PATH:-}" ]]; then
+  info "Using credentials from MONDOO_CONFIG_PATH=${MONDOO_CONFIG_PATH}"
+  [[ -f "${MONDOO_CONFIG_PATH}" ]] || die "MONDOO_CONFIG_PATH file not found: ${MONDOO_CONFIG_PATH}"
+  kubectl create secret generic mondoo-client \
+    --from-file=config="${MONDOO_CONFIG_PATH}" \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+elif [[ -n "${ORG_CREDS_B64:-}" ]]; then
+  info "Using credentials from ORG_CREDS_B64"
+  trap 'rm -f /tmp/mondoo-creds.json' EXIT
+  echo "${ORG_CREDS_B64}" | base64 -d > /tmp/mondoo-creds.json
+  kubectl create secret generic mondoo-client \
+    --from-file=config=/tmp/mondoo-creds.json \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  rm -f /tmp/mondoo-creds.json
+else
+  die "Either MONDOO_CONFIG_PATH or ORG_CREDS_B64 must be set"
+fi
+
+info "Applying MondooAuditConfigs with space splitting..."
+info "  mondoo-scanner → spaceId=${SCANNER_SPACE_ID}"
+info "  mondoo-target  → spaceId=${TARGET_SPACE_ID}"
+export NAMESPACE SCANNER_SPACE_ID TARGET_SPACE_ID
+
+if [[ "${AUTOPILOT:-false}" == "true" ]]; then
+  MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config-space-splitting-autopilot.yaml.tpl"
+else
+  MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config-space-splitting.yaml.tpl"
+fi
+info "Using manifest: $(basename "${MANIFEST}")"
+envsubst < "${MANIFEST}" | kubectl apply -f -
+
+info "Both MondooAuditConfigs with space splitting applied."

--- a/tests/e2e/scripts/common.sh
+++ b/tests/e2e/scripts/common.sh
@@ -49,6 +49,14 @@ load_tf_outputs() {
 
   export ENABLE_WIF_TEST="$(terraform output -raw enable_wif_test 2>/dev/null || echo "false")"
 
+  export ENABLE_SPACE_SPLITTING_TEST="$(terraform output -raw enable_space_splitting_test 2>/dev/null || echo "false")"
+  if [[ "${ENABLE_SPACE_SPLITTING_TEST}" == "true" ]]; then
+    export SCANNER_SPACE_ID="$(terraform output -raw scanner_space_id)"
+    export TARGET_SPACE_ID="$(terraform output -raw target_space_id)"
+    export TARGET_SPACE_MRN="$(terraform output -raw target_space_mrn)"
+    export ORG_CREDS_B64="$(terraform output -raw org_credentials_b64)"
+  fi
+
   cd ->/dev/null
 
   # Delegate to cloud-specific loader for remaining outputs and credential setup

--- a/tests/e2e/scripts/verify-space-splitting.sh
+++ b/tests/e2e/scripts/verify-space-splitting.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Verify space splitting: single operator, two MondooAuditConfigs,
+# each routing to a different space via org-level SA + spaceId.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+: "${NAMESPACE:?NAMESPACE must be set}"
+: "${SCANNER_SPACE_ID:?SCANNER_SPACE_ID must be set}"
+: "${TARGET_SPACE_ID:?TARGET_SPACE_ID must be set}"
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    info "PASS: ${desc}"
+    PASS=$((PASS + 1))
+  else
+    err "FAIL: ${desc}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+info "=== Space Splitting Verification ==="
+
+# ---- Operator ----
+check "Operator pod is Running" \
+  kubectl get pods -n "${NAMESPACE}" -l control-plane=controller-manager \
+    --field-selector=status.phase=Running -o name
+
+# ---- Scanner MondooAuditConfig (local cluster → scanner space) ----
+info ""
+info "--- mondoo-scanner (local → ${SCANNER_SPACE_ID}) ---"
+
+check "MondooAuditConfig 'mondoo-scanner' exists" \
+  kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-scanner -n "${NAMESPACE}"
+
+check "mondoo-scanner has spaceId=${SCANNER_SPACE_ID}" \
+  bash -c "kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-scanner -n '${NAMESPACE}' \
+    -o jsonpath='{.spec.spaceId}' | grep -q '${SCANNER_SPACE_ID}'"
+
+SCANNER_OVERRIDE="mondoo-scanner-config-override"
+check "Config override secret '${SCANNER_OVERRIDE}' exists" \
+  kubectl get secret "${SCANNER_OVERRIDE}" -n "${NAMESPACE}"
+
+check "Scanner override has correct scope_mrn" \
+  bash -c "kubectl get secret '${SCANNER_OVERRIDE}' -n '${NAMESPACE}' \
+    -o jsonpath='{.data.config}' | base64 -d | grep -q '${SCANNER_SPACE_ID}'"
+
+check "Scanner override owned by MondooAuditConfig" \
+  bash -c "kubectl get secret '${SCANNER_OVERRIDE}' -n '${NAMESPACE}' \
+    -o jsonpath='{.metadata.ownerReferences[0].kind}' | grep -q 'MondooAuditConfig'"
+
+check "Scanner CronJobs created" \
+  kubectl get cronjobs -n "${NAMESPACE}" -l mondoo_cr=mondoo-scanner -o name
+
+check "Scanner CronJobs use override secret" \
+  bash -c "kubectl get cronjobs -n '${NAMESPACE}' -l mondoo_cr=mondoo-scanner \
+    -o yaml | grep -q '${SCANNER_OVERRIDE}'"
+
+# ---- Target MondooAuditConfig (external cluster → target space) ----
+info ""
+info "--- mondoo-target (external → ${TARGET_SPACE_ID}) ---"
+
+check "MondooAuditConfig 'mondoo-target' exists" \
+  kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-target -n "${NAMESPACE}"
+
+check "mondoo-target has spaceId=${TARGET_SPACE_ID}" \
+  bash -c "kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-target -n '${NAMESPACE}' \
+    -o jsonpath='{.spec.spaceId}' | grep -q '${TARGET_SPACE_ID}'"
+
+TARGET_OVERRIDE="mondoo-target-config-override"
+check "Config override secret '${TARGET_OVERRIDE}' exists" \
+  kubectl get secret "${TARGET_OVERRIDE}" -n "${NAMESPACE}"
+
+check "Target override has correct scope_mrn" \
+  bash -c "kubectl get secret '${TARGET_OVERRIDE}' -n '${NAMESPACE}' \
+    -o jsonpath='{.data.config}' | base64 -d | grep -q '${TARGET_SPACE_ID}'"
+
+check "Target override owned by MondooAuditConfig" \
+  bash -c "kubectl get secret '${TARGET_OVERRIDE}' -n '${NAMESPACE}' \
+    -o jsonpath='{.metadata.ownerReferences[0].kind}' | grep -q 'MondooAuditConfig'"
+
+check "Target CronJobs created" \
+  kubectl get cronjobs -n "${NAMESPACE}" -l mondoo_cr=mondoo-target -o name
+
+check "Target CronJobs use override secret" \
+  bash -c "kubectl get cronjobs -n '${NAMESPACE}' -l mondoo_cr=mondoo-target \
+    -o yaml | grep -q '${TARGET_OVERRIDE}'"
+
+check "External cluster CronJob references target-cluster" \
+  bash -c "kubectl get cronjobs -n '${NAMESPACE}' -l mondoo_cr=mondoo-target \
+    -o yaml | grep -q 'target-cluster'"
+
+# ---- Both share the same org SA secret ----
+info ""
+info "--- Shared credentials ---"
+
+check "Both configs reference the same mondoo-client secret" \
+  bash -c "
+    s1=\$(kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-scanner -n '${NAMESPACE}' -o jsonpath='{.spec.mondooCredsSecretRef.name}')
+    s2=\$(kubectl get mondooauditconfigs.k8s.mondoo.com mondoo-target -n '${NAMESPACE}' -o jsonpath='{.spec.mondooCredsSecretRef.name}')
+    [[ \"\$s1\" == \"mondoo-client\" && \"\$s2\" == \"mondoo-client\" ]]
+  "
+
+check "Override secrets have DIFFERENT scope_mrn values" \
+  bash -c "
+    s1=\$(kubectl get secret '${SCANNER_OVERRIDE}' -n '${NAMESPACE}' -o jsonpath='{.data.config}' | base64 -d)
+    s2=\$(kubectl get secret '${TARGET_OVERRIDE}' -n '${NAMESPACE}' -o jsonpath='{.data.config}' | base64 -d)
+    echo \"\$s1\" | grep -q '${SCANNER_SPACE_ID}' && echo \"\$s2\" | grep -q '${TARGET_SPACE_ID}'
+  "
+
+# ---- Summary ----
+info ""
+info "--- Resource Overview ---"
+info "Pods:"
+kubectl get pods -n "${NAMESPACE}" -o wide 2>/dev/null || true
+info "CronJobs:"
+kubectl get cronjobs -n "${NAMESPACE}" -o wide 2>/dev/null || true
+info "Secrets (override):"
+for s in "${SCANNER_OVERRIDE}" "${TARGET_OVERRIDE}"; do
+  info "  ${s}:"
+  kubectl get secret "${s}" -n "${NAMESPACE}" \
+    -o jsonpath='{.data.config}' 2>/dev/null | base64 -d | python3 -c "import json,sys; d=json.load(sys.stdin); print('    scope_mrn:', d.get('scope_mrn','NOT SET'))" 2>/dev/null || true
+done
+
+info ""
+info "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ ${FAIL} -gt 0 ]]; then
+  err "Some checks failed. Review the output above."
+  exit 1
+fi


### PR DESCRIPTION


- Introduced `spaceId` field in `MondooAuditConfig` CRD to allow routing of scanned assets to a specified Mondoo space, enabling the use of org-level service accounts across multiple spaces.
- Updated sample configurations and documentation to reflect the new `spaceId` functionality.
- Modified controller logic to create derived Secrets with injected `scope_mrn` when `spaceId` is set.
- Enhanced tests to cover new functionality, including the creation and verification of derived Secrets.
- Added end-to-end tests for space splitting scenarios, ensuring correct routing of assets to designated spaces.