### PR TITLE
🔒 Harden pull_request_target workflow chain

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,10 +18,14 @@ on:
 env:
   CNSPEC_IMAGE_TAG: ${{ github.event.inputs.cnspecImageTag }}
 
+# SECURITY: This workflow checks out and executes PR head code with access to secrets
+# (MONDOO_CLIENT, MONDOO_CLIENT_EDGE, MONDOO_TEST_ORG_TOKEN, SLACK_BOT_TOKEN).
+# When called via pull_request_target (tests-forks.yaml), this code is untrusted.
+# Access controls are enforced by the calling workflow's label gate.
+#
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
   contents: read
-# Attention: These jobs still have access to all the secrets.
 
 jobs:
   build-operator:

--- a/.github/workflows/security-tests.yaml
+++ b/.github/workflows/security-tests.yaml
@@ -5,10 +5,13 @@ on:
       MONDOO_CLIENT:
         required: true
 
+# SECURITY: This workflow checks out and executes PR head code with access to secrets.
+# When called via pull_request_target (tests-forks.yaml), this code is untrusted.
+# Access controls are enforced by the calling workflow's label gate.
+#
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
   contents: read
-# Attention: These jobs still have access to all the secrets.
 
 jobs:
   security-tests:

--- a/.github/workflows/tests-forks.yaml
+++ b/.github/workflows/tests-forks.yaml
@@ -1,4 +1,14 @@
 name: Run Test (forks & dependabot)
+# SECURITY: This workflow uses pull_request_target, which runs with write-scoped
+# GITHUB_TOKEN and access to repository secrets even for fork PRs.
+# The "ok to test" label gate is the primary security control.
+# Maintainers MUST review fork PR code before applying the label.
+# Downstream workflows (unit-tests, security-tests, integration-tests) checkout
+# and execute PR head code with access to secrets.
+# DO NOT:
+#   - Remove or weaken the label check
+#   - Add checkout of PR head code in this file
+#   - Pass secrets to new downstream workflows without security review
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
@@ -49,7 +59,8 @@ jobs:
     needs: [unit-tests]
     if: needs.unit-tests.result == 'success'
     uses: ./.github/workflows/security-tests.yaml
-    secrets: inherit
+    secrets:
+      MONDOO_CLIENT: ${{ secrets.MONDOO_CLIENT }}
   integration-tests:
     name: Integration tests
     needs: [unit-tests]
@@ -57,4 +68,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yaml
     with:
       cnspecImageTag: ""
-    secrets: inherit
+    secrets:
+      MONDOO_CLIENT: ${{ secrets.MONDOO_CLIENT }}
+      MONDOO_CLIENT_EDGE: ${{ secrets.MONDOO_CLIENT_EDGE }}
+      MONDOO_TEST_ORG_TOKEN: ${{ secrets.MONDOO_TEST_ORG_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,10 +2,13 @@ name: Unit Tests
 on:
   workflow_call:
 
+# SECURITY: This workflow checks out and executes PR head code. When called via
+# pull_request_target (tests-forks.yaml), this code is untrusted.
+# Access controls are enforced by the calling workflow's label gate.
+#
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
   contents: read
-# Attention: These jobs still have access to all the secrets.
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary

- Replace `secrets: inherit` with explicit secret passing in `tests-forks.yaml` so only the secrets each downstream workflow declares are forwarded — limits blast radius if new secrets are added to the repo
- Add security comments to all workflows in the chain (`tests-forks.yaml`, `unit-tests.yaml`, `security-tests.yaml`, `integration-tests.yaml`) documenting the trust boundary
- Remove incorrect "These jobs still have access to all the secrets" comments (secrets are now explicitly scoped or not passed at all)

## Test plan

- [ ] Verify fork PRs with "ok to test" label still trigger the full test suite
- [ ] Verify dependabot PRs with "ok to test" label still trigger correctly
- [ ] Confirm `security-tests` receives `MONDOO_CLIENT`
- [ ] Confirm `integration-tests` receives `MONDOO_CLIENT`, `MONDOO_CLIENT_EDGE`, `MONDOO_TEST_ORG_TOKEN`, `SLACK_BOT_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)