### PR TITLE
✨ Remove deprecated score-threshold parameter from cnspec scan commands

### DIFF
--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -57,7 +57,6 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 		"cnspec", "scan", "k8s",
 		"--config", "/etc/opt/mondoo/config/mondoo.yml",
 		"--inventory-file", "/etc/opt/mondoo/config/inventory.yml",
-		"--score-threshold", "0",
 	}
 
 	// Only add proxy if configured and not skipped for cnspec
@@ -191,7 +190,6 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 		"cnspec", "scan", "k8s",
 		"--config", "/etc/opt/mondoo/config/mondoo.yml",
 		"--inventory-file", "/etc/opt/mondoo/config/inventory.yml",
-		"--score-threshold", "0",
 	}
 
 	// Only add proxy if configured and not skipped for cnspec

--- a/controllers/resource_watcher/scanner.go
+++ b/controllers/resource_watcher/scanner.go
@@ -97,7 +97,6 @@ func (s *Scanner) ScanResources(ctx context.Context, resources []K8sResourceIden
 		"scan", "k8s",
 		"--config", s.config.ConfigPath,
 		"--inventory-file", tempPath,
-		"--score-threshold", "0",
 	}
 	if s.config.APIProxy != "" {
 		cnspecArgs = append(cnspecArgs, "--api-proxy", s.config.APIProxy)

--- a/docs/admission-migration-guide.md
+++ b/docs/admission-migration-guide.md
@@ -125,7 +125,7 @@ jobs:
 
       - name: Scan Kubernetes manifests
         run: |
-          cnspec scan k8s --path ./manifests --score-threshold 80
+          cnspec scan k8s --path ./manifests --risk-threshold 20
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
 ```
@@ -137,7 +137,7 @@ scan-manifests:
   image: mondoo/cnspec:latest
   stage: test
   script:
-    - cnspec scan k8s --path ./manifests --score-threshold 80
+    - cnspec scan k8s --path ./manifests --risk-threshold 20
   variables:
     MONDOO_CONFIG_BASE64: $MONDOO_SERVICE_ACCOUNT
 ```
@@ -167,7 +167,7 @@ jobs:
         run: curl -sSL https://install.mondoo.com/sh | bash
 
       - name: Scan Kubernetes manifests
-        run: cnspec scan k8s --path . --score-threshold 80
+        run: cnspec scan k8s --path . --risk-threshold 20
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
 ```
@@ -190,7 +190,7 @@ spec:
     - name: scan
       image: mondoo/cnspec:latest
       script: |
-        cnspec scan k8s --path $(workspaces.source.path)/$(params.manifest-path) --score-threshold 80
+        cnspec scan k8s --path $(workspaces.source.path)/$(params.manifest-path) --risk-threshold 20
       env:
         - name: MONDOO_CONFIG_BASE64
           valueFrom:


### PR DESCRIPTION
Reasons to remove:
1. `--score-threshold` is superseded by `--risk-threshold`
2. `--risk-threshold` already has a default value `cnspec`-side that never fails the scans, changing threshold is intended for CI scans