### PR TITLE
✨ add optional endpoint override for WIF configurations

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -277,6 +277,13 @@ type GKEWorkloadIdentity struct {
 	// Format: <name>@<project>.iam.gserviceaccount.com
 	// +kubebuilder:validation:Required
 	GoogleServiceAccount string `json:"googleServiceAccount"`
+
+	// Endpoint optionally overrides the Kubernetes API server endpoint URL.
+	// When set, the init container uses this URL instead of the auto-discovered endpoint.
+	// Must start with "https://".
+	// +optional
+	// +kubebuilder:validation:Pattern=`^https://`
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // EKSWorkloadIdentity configures AWS EKS IRSA (IAM Roles for Service Accounts)
@@ -293,6 +300,13 @@ type EKSWorkloadIdentity struct {
 	// Format: arn:aws:iam::<account>:role/<name>
 	// +kubebuilder:validation:Required
 	RoleARN string `json:"roleArn"`
+
+	// Endpoint optionally overrides the Kubernetes API server endpoint URL.
+	// When set, the init container uses this URL instead of the auto-discovered endpoint.
+	// Must start with "https://".
+	// +optional
+	// +kubebuilder:validation:Pattern=`^https://`
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // AKSWorkloadIdentity configures Azure Workload Identity
@@ -316,6 +330,13 @@ type AKSWorkloadIdentity struct {
 	// TenantID is the Azure AD tenant ID.
 	// +kubebuilder:validation:Required
 	TenantID string `json:"tenantId"`
+
+	// Endpoint optionally overrides the Kubernetes API server endpoint URL.
+	// When set, the init container uses this URL instead of the auto-discovered endpoint.
+	// Must start with "https://".
+	// +optional
+	// +kubebuilder:validation:Pattern=`^https://`
+	Endpoint string `json:"endpoint,omitempty"`
 
 	// LoginServer is the ACR login server URL (e.g., "myregistry.azurecr.io").
 	// Only used for container registry WIF authentication (containers.workloadIdentity).

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -341,6 +341,13 @@ spec:
                           clusterName:
                             description: ClusterName is the AKS cluster name.
                             type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
+                            type: string
                           loginServer:
                             description: |-
                               LoginServer is the ACR login server URL (e.g., "myregistry.azurecr.io").
@@ -370,6 +377,13 @@ spec:
                           clusterName:
                             description: ClusterName is the EKS cluster name.
                             type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
+                            type: string
                           region:
                             description: Region is the AWS region.
                             type: string
@@ -394,6 +408,13 @@ spec:
                             type: string
                           clusterName:
                             description: ClusterName is the GKE cluster name.
+                            type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
                             type: string
                           googleServiceAccount:
                             description: |-
@@ -708,6 +729,13 @@ spec:
                                 clusterName:
                                   description: ClusterName is the AKS cluster name.
                                   type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
+                                  type: string
                                 loginServer:
                                   description: |-
                                     LoginServer is the ACR login server URL (e.g., "myregistry.azurecr.io").
@@ -737,6 +765,13 @@ spec:
                                 clusterName:
                                   description: ClusterName is the EKS cluster name.
                                   type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
+                                  type: string
                                 region:
                                   description: Region is the AWS region.
                                   type: string
@@ -761,6 +796,13 @@ spec:
                                   type: string
                                 clusterName:
                                   description: ClusterName is the GKE cluster name.
+                                  type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
                                   type: string
                                 googleServiceAccount:
                                   description: |-

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -341,6 +341,13 @@ spec:
                           clusterName:
                             description: ClusterName is the AKS cluster name.
                             type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
+                            type: string
                           loginServer:
                             description: |-
                               LoginServer is the ACR login server URL (e.g., "myregistry.azurecr.io").
@@ -370,6 +377,13 @@ spec:
                           clusterName:
                             description: ClusterName is the EKS cluster name.
                             type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
+                            type: string
                           region:
                             description: Region is the AWS region.
                             type: string
@@ -394,6 +408,13 @@ spec:
                             type: string
                           clusterName:
                             description: ClusterName is the GKE cluster name.
+                            type: string
+                          endpoint:
+                            description: |-
+                              Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                              When set, the init container uses this URL instead of the auto-discovered endpoint.
+                              Must start with "https://".
+                            pattern: ^https://
                             type: string
                           googleServiceAccount:
                             description: |-
@@ -708,6 +729,13 @@ spec:
                                 clusterName:
                                   description: ClusterName is the AKS cluster name.
                                   type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
+                                  type: string
                                 loginServer:
                                   description: |-
                                     LoginServer is the ACR login server URL (e.g., "myregistry.azurecr.io").
@@ -737,6 +765,13 @@ spec:
                                 clusterName:
                                   description: ClusterName is the EKS cluster name.
                                   type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
+                                  type: string
                                 region:
                                   description: Region is the AWS region.
                                   type: string
@@ -761,6 +796,13 @@ spec:
                                   type: string
                                 clusterName:
                                   description: ClusterName is the GKE cluster name.
+                                  type: string
+                                endpoint:
+                                  description: |-
+                                    Endpoint optionally overrides the Kubernetes API server endpoint URL.
+                                    When set, the init container uses this URL instead of the auto-discovered endpoint.
+                                    Must start with "https://".
+                                  pattern: ^https://
                                   type: string
                                 googleServiceAccount:
                                   description: |-

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -403,7 +403,7 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 	// List all CronJobs with our labels
 	cronJobs := &batchv1.CronJobList{}
 	listOpts := &client.ListOptions{
-		Namespace: n.Mondoo.Namespace,
+		Namespace:     n.Mondoo.Namespace,
 		LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
 	}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
@@ -569,7 +569,7 @@ func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterU
 	// List all k8s-scan CronJobs (local + external) for this audit config
 	cronJobs := &batchv1.CronJobList{}
 	listOpts := &client.ListOptions{
-		Namespace: n.Mondoo.Namespace,
+		Namespace:     n.Mondoo.Namespace,
 		LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
 	}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
@@ -724,7 +724,7 @@ func (n *DeploymentHandler) syncWIFServiceAccount(ctx context.Context, cluster v
 func (n *DeploymentHandler) cleanupStaleCronJobs(ctx context.Context) error {
 	cronJobs := &batchv1.CronJobList{}
 	listOpts := &client.ListOptions{
-		Namespace: n.Mondoo.Namespace,
+		Namespace:     n.Mondoo.Namespace,
 		LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
 	}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {

--- a/controllers/k8s_scan/deployment_handler_test.go
+++ b/controllers/k8s_scan/deployment_handler_test.go
@@ -1341,6 +1341,60 @@ func TestWIFInitContainer(t *testing.T) {
 			expectImage:   "mcr.microsoft.com/azure-cli",
 			expectEnvVars: []string{"CLUSTER_NAME", "RESOURCE_GROUP", "SUBSCRIPTION_ID"},
 		},
+		{
+			name: "GKE init container with endpoint override",
+			cluster: mondoov1alpha2.ExternalCluster{
+				Name: "gke-cluster",
+				WorkloadIdentity: &mondoov1alpha2.WorkloadIdentityConfig{
+					Provider: mondoov1alpha2.CloudProviderGKE,
+					GKE: &mondoov1alpha2.GKEWorkloadIdentity{
+						ProjectID:            "my-project",
+						ClusterName:          "prod-cluster",
+						ClusterLocation:      "us-central1-a",
+						GoogleServiceAccount: "scanner@my-project.iam.gserviceaccount.com",
+						Endpoint:             "https://34.123.45.67",
+					},
+				},
+			},
+			expectImage:   "gcr.io/google.com/cloudsdktool/google-cloud-cli",
+			expectEnvVars: []string{"CLUSTER_NAME", "PROJECT_ID", "CLUSTER_LOCATION", "ENDPOINT_OVERRIDE"},
+		},
+		{
+			name: "EKS init container with endpoint override",
+			cluster: mondoov1alpha2.ExternalCluster{
+				Name: "eks-cluster",
+				WorkloadIdentity: &mondoov1alpha2.WorkloadIdentityConfig{
+					Provider: mondoov1alpha2.CloudProviderEKS,
+					EKS: &mondoov1alpha2.EKSWorkloadIdentity{
+						Region:      "us-west-2",
+						ClusterName: "prod-cluster",
+						RoleARN:     "arn:aws:iam::123456789012:role/Scanner",
+						Endpoint:    "https://ABCDEF.gr7.us-west-2.eks.amazonaws.com",
+					},
+				},
+			},
+			expectImage:   "amazon/aws-cli",
+			expectEnvVars: []string{"CLUSTER_NAME", "AWS_REGION", "ENDPOINT"},
+		},
+		{
+			name: "AKS init container with endpoint override",
+			cluster: mondoov1alpha2.ExternalCluster{
+				Name: "aks-cluster",
+				WorkloadIdentity: &mondoov1alpha2.WorkloadIdentityConfig{
+					Provider: mondoov1alpha2.CloudProviderAKS,
+					AKS: &mondoov1alpha2.AKSWorkloadIdentity{
+						SubscriptionID: "sub-123",
+						ResourceGroup:  "my-rg",
+						ClusterName:    "prod-cluster",
+						ClientID:       "client-123",
+						TenantID:       "tenant-456",
+						Endpoint:       "https://my-cluster.hcp.westus2.azmk8s.io:443",
+					},
+				},
+			},
+			expectImage:   "mcr.microsoft.com/azure-cli",
+			expectEnvVars: []string{"CLUSTER_NAME", "RESOURCE_GROUP", "SUBSCRIPTION_ID", "ENDPOINT_OVERRIDE"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -721,10 +721,15 @@ CLUSTER_CA=$(retry gcloud container clusters describe "$CLUSTER_NAME" \
   --project "$PROJECT_ID" \
   --location "$CLUSTER_LOCATION" \
   --format='value(masterAuth.clusterCaCertificate)')
-CLUSTER_ENDPOINT=$(retry gcloud container clusters describe "$CLUSTER_NAME" \
-  --project "$PROJECT_ID" \
-  --location "$CLUSTER_LOCATION" \
-  --format='value(endpoint)')
+if [ -n "$ENDPOINT_OVERRIDE" ]; then
+  CLUSTER_SERVER="$ENDPOINT_OVERRIDE"
+else
+  CLUSTER_ENDPOINT=$(retry gcloud container clusters describe "$CLUSTER_NAME" \
+    --project "$PROJECT_ID" \
+    --location "$CLUSTER_LOCATION" \
+    --format='value(endpoint)')
+  CLUSTER_SERVER="https://${CLUSTER_ENDPOINT}"
+fi
 TOKEN=$(retry gcloud auth print-access-token)
 
 cat > /etc/opt/mondoo/kubeconfig/kubeconfig <<EOF
@@ -733,7 +738,7 @@ kind: Config
 clusters:
 - cluster:
     certificate-authority-data: ${CLUSTER_CA}
-    server: https://${CLUSTER_ENDPOINT}
+    server: ${CLUSTER_SERVER}
   name: external
 contexts:
 - context:
@@ -754,6 +759,9 @@ echo "Kubeconfig generated for GKE cluster ${CLUSTER_NAME}"
 			{Name: "PROJECT_ID", Value: cluster.WorkloadIdentity.GKE.ProjectID},
 			{Name: "CLUSTER_LOCATION", Value: cluster.WorkloadIdentity.GKE.ClusterLocation},
 		}
+		if cluster.WorkloadIdentity.GKE.Endpoint != "" {
+			env = append(env, corev1.EnvVar{Name: "ENDPOINT_OVERRIDE", Value: cluster.WorkloadIdentity.GKE.Endpoint})
+		}
 
 	case v1alpha2.CloudProviderEKS:
 		image = constants.AWSCLIImage
@@ -762,12 +770,16 @@ echo "Kubeconfig generated for GKE cluster ${CLUSTER_NAME}"
 retry aws eks update-kubeconfig \
   --name "$CLUSTER_NAME" \
   --region "$AWS_REGION" \
+  ${ENDPOINT:+--endpoint "$ENDPOINT"} \
   --kubeconfig /etc/opt/mondoo/kubeconfig/kubeconfig
 `
 		env = []corev1.EnvVar{
 			{Name: "HOME", Value: "/tmp"},
 			{Name: "CLUSTER_NAME", Value: cluster.WorkloadIdentity.EKS.ClusterName},
 			{Name: "AWS_REGION", Value: cluster.WorkloadIdentity.EKS.Region},
+		}
+		if cluster.WorkloadIdentity.EKS.Endpoint != "" {
+			env = append(env, corev1.EnvVar{Name: "ENDPOINT", Value: cluster.WorkloadIdentity.EKS.Endpoint})
 		}
 
 	case v1alpha2.CloudProviderAKS:
@@ -786,12 +798,18 @@ retry az aks get-credentials \
   --name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
   --file /etc/opt/mondoo/kubeconfig/kubeconfig
+if [ -n "$ENDPOINT_OVERRIDE" ]; then
+  sed -i "s|server:.*|server: $ENDPOINT_OVERRIDE|" /etc/opt/mondoo/kubeconfig/kubeconfig
+fi
 `
 		env = []corev1.EnvVar{
 			{Name: "HOME", Value: "/tmp"},
 			{Name: "CLUSTER_NAME", Value: cluster.WorkloadIdentity.AKS.ClusterName},
 			{Name: "RESOURCE_GROUP", Value: cluster.WorkloadIdentity.AKS.ResourceGroup},
 			{Name: "SUBSCRIPTION_ID", Value: cluster.WorkloadIdentity.AKS.SubscriptionID},
+		}
+		if cluster.WorkloadIdentity.AKS.Endpoint != "" {
+			env = append(env, corev1.EnvVar{Name: "ENDPOINT_OVERRIDE", Value: cluster.WorkloadIdentity.AKS.Endpoint})
 		}
 
 	default:

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -360,6 +360,8 @@ WIF requires setup in three places:
 2. **Target cluster RBAC**: grant the cloud identity read access to the target cluster's Kubernetes API
 3. **MondooAuditConfig**: configure the external cluster with WIF auth
 
+**Networking note:** Cloud providers with both public and private endpoints enabled (e.g., EKS with split-horizon DNS) may resolve the API server hostname to a private IP that is unreachable from the scanner cluster. If you see `i/o timeout` errors connecting to a private IP, you can either configure network access (security group rules, VPC peering) or use the optional `endpoint` field on the provider config to override the API server URL with a reachable address.
+
 **GKE example:**
 
 ```yaml
@@ -372,6 +374,9 @@ externalClusters:
         clusterName: production-cluster
         clusterLocation: us-central1-a
         googleServiceAccount: scanner@my-gcp-project.iam.gserviceaccount.com
+        # Optional: override the API server endpoint when the default is not
+        # reachable (e.g., private clusters or restricted network access)
+        # endpoint: "https://34.123.45.67"
 ```
 
 GKE prerequisites:
@@ -429,6 +434,9 @@ externalClusters:
         region: us-west-2
         clusterName: production-cluster
         roleArn: arn:aws:iam::123456789012:role/MondooScannerRole
+        # Optional: override the API server endpoint when the default is not
+        # reachable (e.g., split-horizon DNS resolving to an unreachable private IP)
+        # endpoint: "https://ABCDEF1234567890.gr7.us-west-2.eks.amazonaws.com"
 ```
 
 EKS prerequisites:
@@ -467,6 +475,9 @@ externalClusters:
         clusterName: production-cluster
         clientId: abcdef12-3456-7890-abcd-ef1234567890
         tenantId: fedcba98-7654-3210-fedc-ba9876543210
+        # Optional: override the API server endpoint when the default is not
+        # reachable (e.g., private clusters or restricted network access)
+        # endpoint: "https://my-cluster-abc123.hcp.westus2.azmk8s.io:443"
 ```
 
 AKS prerequisites:

--- a/tests/e2e/aks/manifests/mondoo-audit-config-wif-endpoint-override.yaml.tpl
+++ b/tests/e2e/aks/manifests/mondoo-audit-config-wif-endpoint-override.yaml.tpl
@@ -1,0 +1,46 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-client
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+    externalClusters:
+      - name: target-cluster
+        containerImageScanning: true
+        workloadIdentity:
+          provider: aks
+          aks:
+            subscriptionId: ${AZURE_SUBSCRIPTION_ID}
+            resourceGroup: ${AZURE_RESOURCE_GROUP}
+            clusterName: ${TARGET_CLUSTER_NAME}
+            clientId: ${WIF_CLIENT_ID}
+            tenantId: ${WIF_TENANT_ID}
+            endpoint: ${TARGET_CLUSTER_ENDPOINT}
+  containers:
+    enable: true
+    schedule: "*/5 * * * *"
+    workloadIdentity:
+      provider: aks
+      aks:
+        subscriptionId: ${AZURE_SUBSCRIPTION_ID}
+        resourceGroup: ${AZURE_RESOURCE_GROUP}
+        clusterName: ${CLUSTER_NAME}
+        clientId: ${WIF_CLIENT_ID}
+        tenantId: ${WIF_TENANT_ID}
+        loginServer: ${ACR_LOGIN_SERVER}
+  nodes:
+    enable: true
+    style: cronjob
+    schedule: "*/5 * * * *"

--- a/tests/e2e/aks/terraform/main.tf
+++ b/tests/e2e/aks/terraform/main.tf
@@ -156,8 +156,10 @@ resource "azurerm_kubernetes_cluster" "target" {
 # Allow scanner cluster to reach target cluster API server.
 # Both clusters are in the same VNet but on different subnets.
 # NSG rule ensures scanner subnet can reach target subnet on port 443.
+# Disabled when enable_private_endpoint_access=false to test the endpoint override
+# feature, where the scanner must use the public endpoint instead.
 resource "azurerm_network_security_group" "scanner_to_target" {
-  count               = var.enable_target_cluster ? 1 : 0
+  count               = var.enable_target_cluster && var.enable_private_endpoint_access ? 1 : 0
   name                = "${local.name_prefix}-scanner-to-target-nsg"
   location            = azurerm_resource_group.e2e.location
   resource_group_name = azurerm_resource_group.e2e.name
@@ -165,7 +167,7 @@ resource "azurerm_network_security_group" "scanner_to_target" {
 }
 
 resource "azurerm_network_security_rule" "scanner_to_target_api" {
-  count                       = var.enable_target_cluster ? 1 : 0
+  count                       = var.enable_target_cluster && var.enable_private_endpoint_access ? 1 : 0
   name                        = "scanner-to-target-api"
   priority                    = 100
   direction                   = "Inbound"
@@ -180,7 +182,7 @@ resource "azurerm_network_security_rule" "scanner_to_target_api" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "target" {
-  count                     = var.enable_target_cluster ? 1 : 0
+  count                     = var.enable_target_cluster && var.enable_private_endpoint_access ? 1 : 0
   subnet_id                 = azurerm_subnet.target[0].id
   network_security_group_id = azurerm_network_security_group.scanner_to_target[0].id
 }

--- a/tests/e2e/aks/terraform/outputs.tf
+++ b/tests/e2e/aks/terraform/outputs.tf
@@ -71,3 +71,14 @@ output "wif_client_id" {
 output "wif_tenant_id" {
   value = var.enable_wif_test && var.enable_target_cluster ? azurerm_user_assigned_identity.scanner[0].tenant_id : ""
 }
+
+output "target_cluster_endpoint" {
+  description = "API server endpoint of the target AKS cluster (for endpoint override tests)."
+  value       = var.enable_target_cluster ? azurerm_kubernetes_cluster.target[0].kube_config[0].host : ""
+  sensitive   = true
+}
+
+output "enable_private_endpoint_access" {
+  description = "Whether the scanner-to-target private endpoint NSG rule is enabled."
+  value       = var.enable_private_endpoint_access
+}

--- a/tests/e2e/aks/terraform/variables.tf
+++ b/tests/e2e/aks/terraform/variables.tf
@@ -34,3 +34,9 @@ variable "enable_wif_test" {
   type        = bool
   default     = false
 }
+
+variable "enable_private_endpoint_access" {
+  description = "Allow scanner cluster subnet to reach target cluster API server via private endpoint (NSG rule). Set to false for endpoint override tests where scanner must use the public endpoint."
+  type        = bool
+  default     = true
+}

--- a/tests/e2e/eks/manifests/mondoo-audit-config-wif-endpoint-override.yaml.tpl
+++ b/tests/e2e/eks/manifests/mondoo-audit-config-wif-endpoint-override.yaml.tpl
@@ -1,0 +1,41 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-client
+  namespace: ${NAMESPACE}
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  filtering:
+    namespaces:
+      exclude:
+        - kube-system
+  kubernetesResources:
+    enable: true
+    schedule: "*/5 * * * *"
+    externalClusters:
+      - name: target-cluster
+        containerImageScanning: true
+        workloadIdentity:
+          provider: eks
+          eks:
+            region: ${AWS_REGION}
+            clusterName: ${TARGET_CLUSTER_NAME}
+            roleArn: ${SCANNER_ROLE_ARN}
+            endpoint: ${TARGET_CLUSTER_ENDPOINT}
+  containers:
+    enable: true
+    schedule: "*/5 * * * *"
+    workloadIdentity:
+      provider: eks
+      eks:
+        region: ${AWS_REGION}
+        clusterName: ${CLUSTER_NAME}
+        roleArn: ${SCANNER_ROLE_ARN}
+  nodes:
+    enable: true
+    style: cronjob
+    schedule: "*/5 * * * *"

--- a/tests/e2e/eks/terraform/main.tf
+++ b/tests/e2e/eks/terraform/main.tf
@@ -131,8 +131,10 @@ module "eks_target" {
 # Allow scanner cluster nodes to reach target cluster API server (port 443).
 # Both clusters share the same VPC, so DNS resolves to the private endpoint.
 # Without this rule, the scanner pods get "i/o timeout" connecting to the target.
+# Disabled when enable_private_endpoint_access=false to test the endpoint override
+# feature, where the scanner must use the public endpoint instead.
 resource "aws_security_group_rule" "scanner_to_target_api" {
-  count                    = var.enable_target_cluster ? 1 : 0
+  count                    = var.enable_target_cluster && var.enable_private_endpoint_access ? 1 : 0
   type                     = "ingress"
   from_port                = 443
   to_port                  = 443

--- a/tests/e2e/eks/terraform/outputs.tf
+++ b/tests/e2e/eks/terraform/outputs.tf
@@ -53,3 +53,13 @@ output "profile" {
 output "private_test_ecr_repo" {
   value = var.enable_wif_test ? aws_ecr_repository.private_test[0].repository_url : ""
 }
+
+output "target_cluster_endpoint" {
+  description = "API server endpoint of the target EKS cluster (for endpoint override tests)."
+  value       = var.enable_target_cluster ? module.eks_target[0].cluster_endpoint : ""
+}
+
+output "enable_private_endpoint_access" {
+  description = "Whether the scanner-to-target private endpoint SG rule is enabled."
+  value       = var.enable_private_endpoint_access
+}

--- a/tests/e2e/eks/terraform/variables.tf
+++ b/tests/e2e/eks/terraform/variables.tf
@@ -35,3 +35,9 @@ variable "enable_wif_test" {
   type        = bool
   default     = false
 }
+
+variable "enable_private_endpoint_access" {
+  description = "Allow scanner cluster nodes to reach target cluster API server via private endpoint (SG rule). Set to false for endpoint override tests where scanner must use the public endpoint."
+  type        = bool
+  default     = true
+}

--- a/tests/e2e/run-wif-endpoint-override.sh
+++ b/tests/e2e/run-wif-endpoint-override.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test: WIF External Cluster Scanning with Endpoint Override
+# Validates that the optional `endpoint` field on WIF provider configs correctly
+# overrides the API server URL in the generated kubeconfig. This tests the fix
+# for split-horizon DNS issues (GitHub #1442).
+#
+# The infrastructure MUST be provisioned with enable_private_endpoint_access=false
+# so that the scanner cluster cannot reach the target cluster's private endpoint.
+# The scanner is forced to use the public endpoint via the `endpoint` field —
+# if the override doesn't work, the scan fails with "i/o timeout".
+#
+# Prerequisites:
+#   - Terraform provisioned with:
+#       enable_target_cluster=true
+#       enable_wif_test=true
+#       enable_private_endpoint_access=false
+#   - Cloud CLI authenticated, docker, helm, kubectl available
+#
+# Usage:
+#   ./run-wif-endpoint-override.sh <cloud>    (eks|aks)
+
+set -euo pipefail
+
+CLOUD="${1:?Usage: $0 <cloud> (eks|aks)}"
+export CLOUD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/${CLOUD}" && pwd)"
+source "${CLOUD_DIR}/../scripts/common.sh"
+
+info "=========================================="
+info "  Test: WIF Endpoint Override (${CLOUD})"
+info "=========================================="
+
+# Step 1: Load Terraform outputs
+load_tf_outputs
+
+if [[ "${ENABLE_TARGET_CLUSTER}" != "true" ]]; then
+  die "Target cluster is not enabled. Run: terraform apply -var='enable_target_cluster=true' -var='enable_wif_test=true' -var='enable_private_endpoint_access=false'"
+fi
+
+if [[ "${ENABLE_WIF_TEST}" != "true" ]]; then
+  die "WIF test is not enabled. Run: terraform apply -var='enable_wif_test=true' -var='enable_private_endpoint_access=false'"
+fi
+
+if [[ "${PRIVATE_ENDPOINT_ACCESS:-true}" == "true" ]]; then
+  die "Private endpoint access is enabled. This test requires enable_private_endpoint_access=false so the scanner cannot reach the target via the private endpoint. Re-run: terraform apply -var='enable_private_endpoint_access=false'"
+fi
+
+if [[ -z "${TARGET_CLUSTER_ENDPOINT:-}" ]]; then
+  die "TARGET_CLUSTER_ENDPOINT is not set. Ensure your Terraform outputs include target_cluster_endpoint."
+fi
+
+info "Target cluster endpoint: ${TARGET_CLUSTER_ENDPOINT}"
+
+# Step 2: Build and push operator image
+info "--- Step: Build and Push ---"
+source "${E2E_DIR}/scripts/build-and-push.sh"
+
+# Step 3: Deploy test workloads to scanner cluster (public + private-registry)
+info "--- Step: Deploy Test Workloads (scanner cluster) ---"
+source "${E2E_DIR}/scripts/deploy-test-workload.sh"
+source "${E2E_DIR}/scripts/deploy-private-test-workload.sh"
+
+# Step 4: Deploy operator from local chart
+info "--- Step: Deploy Operator ---"
+source "${E2E_DIR}/scripts/deploy-operator.sh"
+
+# Step 5: Deploy workload to target cluster (no kubeconfig Secret — WIF handles auth)
+info "--- Step: Deploy Target Workload ---"
+source "${E2E_DIR}/scripts/deploy-target-workload-only.sh"
+
+# Step 6: Setup WIF (cloud-specific RBAC)
+info "--- Step: Setup WIF ---"
+source "${E2E_DIR}/scripts/setup-wif.sh"
+
+# Step 7: Apply MondooAuditConfig with endpoint override
+info "--- Step: Apply Mondoo Config (with WIF + endpoint override) ---"
+export ENABLE_WIF_TEST="true"
+export ENABLE_ENDPOINT_OVERRIDE_TEST="true"
+source "${E2E_DIR}/scripts/apply-mondoo-config.sh"
+
+# Step 8: Wait for operator to reconcile (longer wait — init container needs cloud auth)
+info "Waiting 120s for operator to reconcile and WIF init container..."
+sleep 120
+
+# Step 9: Verify local scanning
+info "--- Step: Verify (local) ---"
+source "${E2E_DIR}/scripts/verify.sh"
+
+# Step 10: Verify WIF external cluster scanning with endpoint override
+info "--- Step: Verify (WIF endpoint override) ---"
+source "${E2E_DIR}/scripts/verify-wif-endpoint-override.sh"
+
+# Step 11: Verify WIF container registry scanning
+info "--- Step: Verify (WIF container registry) ---"
+source "${E2E_DIR}/scripts/verify-wif-container-registry.sh"
+
+info ""
+info "=========================================="
+info "  Test: WIF Endpoint Override (${CLOUD}) - COMPLETE"
+info "=========================================="

--- a/tests/e2e/scripts/apply-mondoo-config.sh
+++ b/tests/e2e/scripts/apply-mondoo-config.sh
@@ -26,7 +26,9 @@ export NAMESPACE
 
 # Select manifest based on test type and cluster mode.
 # Autopilot variants are GKE-specific; other clouds just use the base manifest.
-if [[ "${ENABLE_WIF_TEST:-false}" == "true" ]]; then
+if [[ "${ENABLE_ENDPOINT_OVERRIDE_TEST:-false}" == "true" ]]; then
+  MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config-wif-endpoint-override.yaml.tpl"
+elif [[ "${ENABLE_WIF_TEST:-false}" == "true" ]]; then
   if [[ "${AUTOPILOT:-false}" == "true" ]]; then
     MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config-wif-external-autopilot.yaml.tpl"
   else

--- a/tests/e2e/scripts/common-aks.sh
+++ b/tests/e2e/scripts/common-aks.sh
@@ -22,6 +22,8 @@ _load_cloud_outputs() {
   if [[ "${ENABLE_WIF_TEST}" == "true" ]]; then
     export WIF_CLIENT_ID="$(terraform output -raw wif_client_id)"
     export WIF_TENANT_ID="$(terraform output -raw wif_tenant_id)"
+    export TARGET_CLUSTER_ENDPOINT="$(terraform output -raw target_cluster_endpoint 2>/dev/null || echo "")"
+    export PRIVATE_ENDPOINT_ACCESS="$(terraform output -raw enable_private_endpoint_access 2>/dev/null || echo "true")"
   fi
 
   cd ->/dev/null

--- a/tests/e2e/scripts/common-eks.sh
+++ b/tests/e2e/scripts/common-eks.sh
@@ -36,6 +36,8 @@ _load_cloud_outputs() {
   if [[ "${ENABLE_WIF_TEST}" == "true" ]]; then
     export SCANNER_ROLE_ARN="$(terraform output -raw scanner_role_arn)"
     export PRIVATE_TEST_ECR_REPO="$(terraform output -raw private_test_ecr_repo)"
+    export TARGET_CLUSTER_ENDPOINT="$(terraform output -raw target_cluster_endpoint 2>/dev/null || echo "")"
+    export PRIVATE_ENDPOINT_ACCESS="$(terraform output -raw enable_private_endpoint_access 2>/dev/null || echo "true")"
   fi
 
   cd ->/dev/null

--- a/tests/e2e/scripts/verify-wif-endpoint-override.sh
+++ b/tests/e2e/scripts/verify-wif-endpoint-override.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Verify WIF external cluster scanning with endpoint override.
+# Extends verify-wif-external.sh with additional checks that the endpoint
+# override env var is set on the init container.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+: "${NAMESPACE:?NAMESPACE must be set}"
+: "${TARGET_CLUSTER_ENDPOINT:?TARGET_CLUSTER_ENDPOINT must be set}"
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    info "PASS: ${desc}"
+    PASS=$((PASS + 1))
+  else
+    err "FAIL: ${desc}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+info "=== WIF Endpoint Override Verification ==="
+
+EXPECTED_WIF_VALUE="$(wif_annotation_value)"
+
+# --- Standard WIF checks (same as verify-wif-external.sh) ---
+
+check "WIF ServiceAccount exists" \
+  kubectl get serviceaccount mondoo-client-wif-target-cluster -n "${NAMESPACE}"
+
+check "WIF SA has ${WIF_ANNOTATION_KEY} annotation" \
+  bash -c "
+    ANNOTATION=\$(kubectl get serviceaccount mondoo-client-wif-target-cluster -n '${NAMESPACE}' \
+      -o jsonpath='{.metadata.annotations.${WIF_ANNOTATION_KEY//./\\.}}')
+    [[ \"\${ANNOTATION}\" == '${EXPECTED_WIF_VALUE}' ]]
+  "
+
+check "CronJob for WIF external cluster exists" \
+  bash -c "kubectl get cronjobs -n '${NAMESPACE}' -l mondoo_cr=mondoo-client -o name | grep -q target-cluster"
+
+check "CronJob has generate-kubeconfig init container" \
+  bash -c "
+    kubectl get cronjobs -n '${NAMESPACE}' -l cluster_name=target-cluster \
+      -o jsonpath='{.items[0].spec.jobTemplate.spec.template.spec.initContainers[0].name}' \
+      | grep -q generate-kubeconfig
+  "
+
+check "Init container uses ${WIF_INIT_IMAGE_PATTERN} image" \
+  bash -c "
+    kubectl get cronjobs -n '${NAMESPACE}' -l cluster_name=target-cluster \
+      -o jsonpath='{.items[0].spec.jobTemplate.spec.template.spec.initContainers[0].image}' \
+      | grep -q '${WIF_INIT_IMAGE_PATTERN}'
+  "
+
+# --- Endpoint override specific checks ---
+
+# Determine the expected env var name based on cloud provider.
+# EKS uses ENDPOINT (native --endpoint flag), GKE/AKS use ENDPOINT_OVERRIDE.
+CLOUD_PROVIDER="$(basename "${CLOUD_DIR}")"
+case "${CLOUD_PROVIDER}" in
+  eks) ENDPOINT_ENV_NAME="ENDPOINT" ;;
+  *)   ENDPOINT_ENV_NAME="ENDPOINT_OVERRIDE" ;;
+esac
+
+check "Init container has ${ENDPOINT_ENV_NAME} env var" \
+  bash -c "
+    kubectl get cronjobs -n '${NAMESPACE}' -l cluster_name=target-cluster \
+      -o jsonpath='{.items[0].spec.jobTemplate.spec.template.spec.initContainers[0].env[*].name}' \
+      | tr ' ' '\n' | grep -q '${ENDPOINT_ENV_NAME}'
+  "
+
+check "Init container ${ENDPOINT_ENV_NAME} value matches target endpoint" \
+  bash -c "
+    ENV_JSON=\$(kubectl get cronjobs -n '${NAMESPACE}' -l cluster_name=target-cluster \
+      -o jsonpath='{.items[0].spec.jobTemplate.spec.template.spec.initContainers[0].env}')
+    ACTUAL=\$(echo \"\${ENV_JSON}\" | python3 -c \"
+import json, sys
+envs = json.loads(sys.stdin.read())
+for e in envs:
+    if e['name'] == '${ENDPOINT_ENV_NAME}':
+        print(e['value'])
+        break
+\")
+    [[ \"\${ACTUAL}\" == '${TARGET_CLUSTER_ENDPOINT}' ]]
+  "
+
+check "No static target-kubeconfig Secret (WIF manages auth)" \
+  bash -c "! kubectl get secret target-kubeconfig -n '${NAMESPACE}' 2>/dev/null"
+
+check "Inventory ConfigMap for external cluster exists" \
+  bash -c "kubectl get configmaps -n '${NAMESPACE}' -l cluster_name=target-cluster -o name | grep -q inventory"
+
+# --- Wait for at least one Job to be created and check its init container ---
+
+info ""
+info "Waiting for a scan Job to be created (up to 360s)..."
+JOB_FOUND="false"
+for i in $(seq 1 72); do
+  JOB_NAME=$(kubectl get jobs -n "${NAMESPACE}" -l cluster_name=target-cluster \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [[ -n "${JOB_NAME}" ]]; then
+    JOB_FOUND="true"
+    break
+  fi
+  sleep 5
+done
+
+if [[ "${JOB_FOUND}" == "true" ]]; then
+  check "Scan Job was created from CronJob" test -n "${JOB_NAME}"
+
+  # Check that the Job's pod init container completed successfully
+  info "Waiting for Job pod to start (up to 120s)..."
+  POD_NAME=""
+  for i in $(seq 1 24); do
+    POD_NAME=$(kubectl get pods -n "${NAMESPACE}" -l job-name="${JOB_NAME}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "${POD_NAME}" ]]; then
+      break
+    fi
+    sleep 5
+  done
+
+  if [[ -n "${POD_NAME}" ]]; then
+    info "Found pod: ${POD_NAME}"
+
+    # Wait for init container to complete
+    info "Waiting for init container to finish (up to 120s)..."
+    for i in $(seq 1 24); do
+      INIT_STATUS=$(kubectl get pod "${POD_NAME}" -n "${NAMESPACE}" \
+        -o jsonpath='{.status.initContainerStatuses[0].state}' 2>/dev/null || true)
+      if echo "${INIT_STATUS}" | grep -q "terminated"; then
+        break
+      fi
+      sleep 5
+    done
+
+    INIT_EXIT=$(kubectl get pod "${POD_NAME}" -n "${NAMESPACE}" \
+      -o jsonpath='{.status.initContainerStatuses[0].state.terminated.exitCode}' 2>/dev/null || echo "unknown")
+
+    check "Init container (generate-kubeconfig) exited successfully" \
+      test "${INIT_EXIT}" = "0"
+
+    if [[ "${INIT_EXIT}" != "0" ]]; then
+      err "Init container logs:"
+      kubectl logs "${POD_NAME}" -n "${NAMESPACE}" -c generate-kubeconfig 2>/dev/null || true
+    fi
+  else
+    err "FAIL: No pod found for Job ${JOB_NAME}"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  err "FAIL: No scan Job was created within timeout"
+  FAIL=$((FAIL + 1))
+fi
+
+info ""
+info "=== WIF Endpoint Override Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ ${FAIL} -gt 0 ]]; then
+  err "Some endpoint override checks failed. Review the output above."
+  exit 1
+fi
+
+info ""
+info "=== Manual Verification ==="
+info "Check the Mondoo console for WIF-authenticated external cluster assets"
+info "  Space MRN: ${MONDOO_SPACE_MRN:-unknown}"
+info "  - Target cluster K8s resources should appear as assets"
+info "  - Auth was via ${WIF_AUTH_DESCRIPTION} with endpoint override: ${TARGET_CLUSTER_ENDPOINT}"
+read -rp "Press Enter once verified (or Ctrl+C to abort)... "


### PR DESCRIPTION
- Introduced an `endpoint` field in GKE, EKS, and AKS workload identity configurations to allow users to specify a custom Kubernetes API server endpoint.
- Updated CRDs and YAML manifests to include the new `endpoint` field with appropriate descriptions and validation patterns.
- Enhanced deployment scripts and tests to support the new endpoint override functionality, ensuring compatibility with existing infrastructure.
- Added documentation to clarify the use of the endpoint override feature, particularly for scenarios involving split-horizon DNS and private cluster access.
- Implemented new end-to-end tests to validate the functionality of the endpoint override in WIF configurations for both EKS and AKS.

Fixes #1442