### PR TITLE
fix: inherit namespace filters for external clusters

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -193,11 +193,10 @@ type ExternalCluster struct {
 	Schedule string `json:"schedule,omitempty"`
 
 	// Filtering allows namespace filtering specific to this external cluster.
-	// If not specified, uses the global filtering from MondooAuditConfigSpec.Filtering.
-	// Set at least one Include or Exclude namespace entry to override global filtering.
-	// Empty lists may be omitted by Kubernetes serialization and fall back to global filtering.
+	// If omitted, the external cluster inherits the global filtering from MondooAuditConfigSpec.Filtering.
+	// Set an empty filtering object to scan all namespaces for this external cluster even when global filtering is configured.
 	// +optional
-	Filtering Filtering `json:"filtering,omitempty"`
+	Filtering *Filtering `json:"filtering,omitempty"`
 
 	// ContainerImageScanning enables scanning of container images in this external cluster.
 	// +optional

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -194,6 +194,8 @@ type ExternalCluster struct {
 
 	// Filtering allows namespace filtering specific to this external cluster.
 	// If not specified, uses the global filtering from MondooAuditConfigSpec.Filtering.
+	// Set at least one Include or Exclude namespace entry to override global filtering.
+	// Empty lists may be omitted by Kubernetes serialization and fall back to global filtering.
 	// +optional
 	Filtering Filtering `json:"filtering,omitempty"`
 

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -158,7 +158,11 @@ func (in *ExternalCluster) DeepCopyInto(out *ExternalCluster) {
 		*out = new(VaultAuthConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Filtering.DeepCopyInto(&out.Filtering)
+	if in.Filtering != nil {
+		in, out := &in.Filtering, &out.Filtering
+		*out = new(Filtering)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PrivateRegistriesPullSecretRef != nil {
 		in, out := &in.PrivateRegistriesPullSecretRef, &out.PrivateRegistriesPullSecretRef
 		*out = new(v1.LocalObjectReference)

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -487,6 +487,8 @@ spec:
                           description: |-
                             Filtering allows namespace filtering specific to this external cluster.
                             If not specified, uses the global filtering from MondooAuditConfigSpec.Filtering.
+                            Set at least one Include or Exclude namespace entry to override global filtering.
+                            Empty lists may be omitted by Kubernetes serialization and fall back to global filtering.
                           properties:
                             namespaces:
                               properties:

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -486,9 +486,8 @@ spec:
                         filtering:
                           description: |-
                             Filtering allows namespace filtering specific to this external cluster.
-                            If not specified, uses the global filtering from MondooAuditConfigSpec.Filtering.
-                            Set at least one Include or Exclude namespace entry to override global filtering.
-                            Empty lists may be omitted by Kubernetes serialization and fall back to global filtering.
+                            If omitted, the external cluster inherits the global filtering from MondooAuditConfigSpec.Filtering.
+                            Set an empty filtering object to scan all namespaces for this external cluster even when global filtering is configured.
                           properties:
                             namespaces:
                               properties:

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -1149,8 +1149,8 @@ func ExternalClusterInventory(integrationMRN, operatorClusterUID string, cluster
 }
 
 func externalClusterFiltering(cluster v1alpha2.ExternalCluster, m v1alpha2.MondooAuditConfig) v1alpha2.Filtering {
-	if cluster.Filtering.Namespaces.Include != nil || cluster.Filtering.Namespaces.Exclude != nil {
-		return cluster.Filtering
+	if cluster.Filtering != nil {
+		return *cluster.Filtering
 	}
 	return m.Spec.Filtering
 }

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -1074,8 +1074,7 @@ func Inventory(integrationMRN, clusterUID string, m v1alpha2.MondooAuditConfig, 
 }
 
 func ExternalClusterInventory(integrationMRN, operatorClusterUID string, cluster v1alpha2.ExternalCluster, m v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOperatorConfig) (string, error) {
-	// Use cluster-specific filtering if provided, otherwise fall back to empty filtering
-	filtering := cluster.Filtering
+	filtering := externalClusterFiltering(cluster, m)
 
 	// Determine discovery targets based on whether container image scanning is enabled
 	// Make a copy to avoid mutating the shared slice
@@ -1147,6 +1146,13 @@ func ExternalClusterInventory(integrationMRN, operatorClusterUID string, cluster
 	}
 
 	return string(invBytes), nil
+}
+
+func externalClusterFiltering(cluster v1alpha2.ExternalCluster, m v1alpha2.MondooAuditConfig) v1alpha2.Filtering {
+	if cluster.Filtering.Namespaces.Include != nil || cluster.Filtering.Namespaces.Exclude != nil {
+		return cluster.Filtering
+	}
+	return m.Spec.Filtering
 }
 
 func buildEnvVars(cfg v1alpha2.MondooOperatorConfig) []corev1.EnvVar {

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -86,6 +86,78 @@ func TestExternalClusterInventory_WithAnnotations(t *testing.T) {
 	}
 }
 
+func TestExternalClusterInventory_InheritsGlobalNamespaceFiltering(t *testing.T) {
+	auditConfig := v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "mondoo-client"},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			Filtering: v1alpha2.Filtering{
+				Namespaces: v1alpha2.FilteringSpec{
+					Include: []string{"production", "shared"},
+					Exclude: []string{"kube-system"},
+				},
+			},
+		},
+	}
+	cluster := v1alpha2.ExternalCluster{Name: "remote-cluster"}
+
+	options := externalClusterInventoryOptions(t, auditConfig, cluster)
+
+	assert.Equal(t, "production,shared", options["namespaces"])
+	assert.Equal(t, "kube-system", options["namespaces-exclude"])
+}
+
+func TestExternalClusterInventory_UsesClusterNamespaceFiltering(t *testing.T) {
+	auditConfig := v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "mondoo-client"},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			Filtering: v1alpha2.Filtering{
+				Namespaces: v1alpha2.FilteringSpec{
+					Include: []string{"production"},
+				},
+			},
+		},
+	}
+	cluster := v1alpha2.ExternalCluster{
+		Name: "remote-cluster",
+		Filtering: v1alpha2.Filtering{
+			Namespaces: v1alpha2.FilteringSpec{
+				Exclude: []string{"kube-system", "monitoring"},
+			},
+		},
+	}
+
+	options := externalClusterInventoryOptions(t, auditConfig, cluster)
+
+	assert.Empty(t, options["namespaces"])
+	assert.Equal(t, "kube-system,monitoring", options["namespaces-exclude"])
+}
+
+func TestExternalClusterInventory_EmptyClusterNamespaceFilteringOverridesGlobal(t *testing.T) {
+	auditConfig := v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "mondoo-client"},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			Filtering: v1alpha2.Filtering{
+				Namespaces: v1alpha2.FilteringSpec{
+					Include: []string{"production"},
+				},
+			},
+		},
+	}
+	cluster := v1alpha2.ExternalCluster{
+		Name: "remote-cluster",
+		Filtering: v1alpha2.Filtering{
+			Namespaces: v1alpha2.FilteringSpec{
+				Include: []string{},
+			},
+		},
+	}
+
+	options := externalClusterInventoryOptions(t, auditConfig, cluster)
+
+	assert.Empty(t, options["namespaces"])
+	assert.Empty(t, options["namespaces-exclude"])
+}
+
 func TestCronJob_WithProxy(t *testing.T) {
 	m := testAuditConfig()
 	cfg := v1alpha2.MondooOperatorConfig{
@@ -310,6 +382,20 @@ func TestExternalClusterInventory_WithContainerProxy(t *testing.T) {
 	require.NotEmpty(t, inv.Spec.Assets)
 
 	assert.Equal(t, "http://container-proxy:3128", inv.Spec.Assets[0].Connections[0].Options["container-proxy"])
+}
+
+func externalClusterInventoryOptions(t *testing.T, auditConfig v1alpha2.MondooAuditConfig, cluster v1alpha2.ExternalCluster) map[string]string {
+	t.Helper()
+
+	invStr, err := ExternalClusterInventory("", testClusterUID, cluster, auditConfig, v1alpha2.MondooOperatorConfig{})
+	require.NoError(t, err)
+
+	var inv inventory.Inventory
+	require.NoError(t, yaml.Unmarshal([]byte(invStr), &inv))
+	require.NotEmpty(t, inv.Spec.Assets)
+	require.NotEmpty(t, inv.Spec.Assets[0].Connections)
+
+	return inv.Spec.Assets[0].Connections[0].Options
 }
 
 // envToMap converts a slice of EnvVar to a map for easy lookup.

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -119,7 +119,7 @@ func TestExternalClusterInventory_UsesClusterNamespaceFiltering(t *testing.T) {
 	}
 	cluster := v1alpha2.ExternalCluster{
 		Name: "remote-cluster",
-		Filtering: v1alpha2.Filtering{
+		Filtering: &v1alpha2.Filtering{
 			Namespaces: v1alpha2.FilteringSpec{
 				Exclude: []string{"kube-system", "monitoring"},
 			},
@@ -144,12 +144,8 @@ func TestExternalClusterInventory_EmptyClusterNamespaceFilteringOverridesGlobal(
 		},
 	}
 	cluster := v1alpha2.ExternalCluster{
-		Name: "remote-cluster",
-		Filtering: v1alpha2.Filtering{
-			Namespaces: v1alpha2.FilteringSpec{
-				Include: []string{},
-			},
-		},
+		Name:      "remote-cluster",
+		Filtering: &v1alpha2.Filtering{},
 	}
 
 	options := externalClusterInventoryOptions(t, auditConfig, cluster)


### PR DESCRIPTION
## Summary
- make external cluster inventory inherit global namespace filtering when cluster-specific filtering is omitted
- keep cluster-specific filters authoritative, including an explicit empty `filtering: {}` object to clear inherited global filters
- add regression coverage for inherited, overridden, and cleared external cluster namespace filters

Fixes #1479

## Behavior change
- External clusters that previously had no cluster-level `filtering` and were defined alongside global namespace filtering now inherit the global filters after upgrade.
- To scan all namespaces for one external cluster while global filters are configured, set `filtering: {}` on that external cluster.

## Tests
- make generate manifests
- go test ./controllers/k8s_scan -run 'TestExternalClusterInventory' -count=1
- git diff --check
