### PR TITLE
fix(logging): add context to scan controller logs

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [429, 200, 406]
+  "aliveStatusCodes": [200, 406, 429]
 }

--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	logutils "go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +38,10 @@ type DeploymentHandler struct {
 	RefreshDigests         RefreshDigestsFunc
 }
 
+func (n *DeploymentHandler) log() logr.Logger {
+	return logutils.WithMondooAuditConfig(logger, n.Mondoo, "container-image-scanning")
+}
+
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
 	// Clean up CronJobs with stale names (from old naming schemes)
 	if err := n.cleanupStaleCronJobs(ctx); err != nil {
@@ -49,7 +55,7 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 	// Validate container registry WIF configuration
 	if err := validateContainerRegistryWIF(n.Mondoo.Spec.Containers.WorkloadIdentity); err != nil {
-		logger.Error(err, "invalid container registry WIF configuration")
+		n.log().Error(err, "invalid container registry WIF configuration")
 		return ctrl.Result{}, err
 	}
 
@@ -65,9 +71,9 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 		}
 	}
 
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID")
+		n.log().Error(err, "Failed to get cluster's UID")
 		return ctrl.Result{}, err
 	}
 
@@ -84,13 +90,13 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		logger.Error(err, "Failed to resolve mondoo-client container image")
+		n.log().Error(err, "Failed to resolve mondoo-client container image")
 		return err
 	}
 
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
-		logger.Error(err,
+		n.log().Error(err,
 			"failed to retrieve integration-mrn for MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
 		return err
 	}
@@ -102,13 +108,13 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 	// Reconcile private registry secrets (merges multiple secrets if needed)
 	privateRegistrySecretName, err := k8s.ReconcilePrivateRegistriesSecret(ctx, n.KubeClient, n.Mondoo)
 	if err != nil {
-		logger.Error(err, "Failed to reconcile private registry secrets")
+		n.log().Error(err, "Failed to reconcile private registry secrets")
 		return err
 	}
 
 	desired := CronJob(mondooClientImage, integrationMrn, clusterUid, privateRegistrySecretName, n.Mondoo, *n.MondooOperatorConfig)
 	obj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		k8s.UpdateCronJobFields(obj, desired)
 		return nil
 	})
@@ -118,8 +124,8 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 
 	// When a CronJob is updated, remove completed Jobs so they don't linger with stale config
 	if op == controllerutil.OperationResultUpdated {
-		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), logger); err != nil {
-			logger.Error(err, "Failed to clean up completed Jobs after CronJob update")
+		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), n.log()); err != nil {
+			n.log().Error(err, "Failed to clean up completed Jobs after CronJob update")
 			return err
 		}
 	}
@@ -135,7 +141,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 		lSelector := metav1.SetAsLabelSelector(CronJobLabels(*n.Mondoo))
 		selector, err := metav1.LabelSelectorAsSelector(lSelector)
 		if err != nil {
-			logger.Error(err, "Failed to create label selector for Kubernetes Container Image Scanning")
+			n.log().Error(err, "Failed to create label selector for Kubernetes Container Image Scanning")
 			return err
 		}
 		opts := []client.ListOption{
@@ -144,7 +150,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 		}
 		err = n.KubeClient.List(ctx, pods, opts...)
 		if err != nil {
-			logger.Error(err, "Failed to list Pods for Kubernetes Container Image Scanning")
+			n.log().Error(err, "Failed to list Pods for Kubernetes Container Image Scanning")
 			return err
 		}
 	}
@@ -156,7 +162,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 func (n *DeploymentHandler) syncConfigMap(ctx context.Context, clusterUid string) error {
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
-		logger.Error(err, "failed to retrieve IntegrationMRN")
+		n.log().Error(err, "failed to retrieve IntegrationMRN")
 		return err
 	}
 
@@ -176,12 +182,12 @@ func (n *DeploymentHandler) syncConfigMap(ctx context.Context, clusterUid string
 
 	desired, err := ConfigMap(integrationMrn, clusterUid, *n.Mondoo, *n.MondooOperatorConfig, platformIdsExclude, scanTime)
 	if err != nil {
-		logger.Error(err, "failed to generate desired ConfigMap with inventory")
+		n.log().Error(err, "failed to generate desired ConfigMap with inventory")
 		return err
 	}
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -199,7 +205,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 	// Lists only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
-		logger.Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
+		n.log().Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
 		return nil, err
 	}
 	return cronJobs.Items, nil
@@ -263,7 +269,7 @@ func (n *DeploymentHandler) performGarbageCollection(ctx context.Context, manage
 func (n *DeploymentHandler) down(ctx context.Context) error {
 	cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace}}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, cronJob); err != nil {
-		logger.Error(
+		n.log().Error(
 			err, "failed to clean up Kubernetes resource scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
 		return err
 	}
@@ -284,7 +290,7 @@ func (n *DeploymentHandler) syncWIFServiceAccount(ctx context.Context) error {
 	desired := WIFServiceAccount(n.Mondoo)
 
 	obj := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		obj.Labels = desired.Labels
 		obj.Annotations = desired.Annotations
 		return nil
@@ -304,7 +310,7 @@ func (n *DeploymentHandler) cleanupWIFServiceAccount(ctx context.Context) error 
 		},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, sa); err != nil {
-		logger.Error(err, "failed to clean up WIF ServiceAccount for container registry")
+		n.log().Error(err, "failed to clean up WIF ServiceAccount for container registry")
 		return err
 	}
 	return nil
@@ -324,7 +330,7 @@ func (n *DeploymentHandler) cleanupStaleCronJobs(ctx context.Context) error {
 	expectedName := CronJobName(n.Mondoo.Name)
 	for i := range cronJobs.Items {
 		if cronJobs.Items[i].Name != expectedName {
-			logger.Info("Deleting stale container scan CronJob", "name", cronJobs.Items[i].Name)
+			n.log().Info("Deleting stale container scan CronJob", "name", cronJobs.Items[i].Name)
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, &cronJobs.Items[i]); err != nil {
 				return err
 			}

--- a/controllers/k8s_scan/deployment_handler.go
+++ b/controllers/k8s_scan/deployment_handler.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +22,7 @@ import (
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	logutils "go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 )
 
@@ -140,6 +142,14 @@ type DeploymentHandler struct {
 	SATokenPath string
 }
 
+func (n *DeploymentHandler) log() logr.Logger {
+	return logutils.WithMondooAuditConfig(logger, n.Mondoo, "k8s-resources-scanning")
+}
+
+func (n *DeploymentHandler) externalClusterLog(clusterName string) logr.Logger {
+	return logutils.WithExternalCluster(n.log(), clusterName)
+}
+
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
 	// Clean up CronJobs with stale names (from old naming schemes)
 	if err := n.cleanupStaleCronJobs(ctx); err != nil {
@@ -174,9 +184,9 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 	// Perform garbage collection of stale K8s resource scan assets if a new successful scan has completed
 	if n.Mondoo.Spec.KubernetesResources.Enable || hasExternalClusters {
-		clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+		clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 		if err != nil {
-			logger.Error(err, "Failed to get cluster's UID for garbage collection")
+			n.log().Error(err, "Failed to get cluster's UID for garbage collection")
 		} else {
 			n.garbageCollectIfNeeded(ctx, clusterUid)
 		}
@@ -203,20 +213,20 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	cnspecImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		logger.Error(err, "Failed to resolve cnspec container image")
+		n.log().Error(err, "Failed to resolve cnspec container image")
 		return err
 	}
 
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
-		logger.Error(err,
+		n.log().Error(err,
 			"failed to retrieve integration-mrn for MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
 		return err
 	}
 
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID")
+		n.log().Error(err, "Failed to get cluster's UID")
 		return err
 	}
 
@@ -226,7 +236,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 	desired := CronJob(cnspecImage, n.Mondoo, *n.MondooOperatorConfig)
 	obj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		k8s.UpdateCronJobFields(obj, desired)
 		return nil
 	})
@@ -236,8 +246,8 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 	// When a CronJob is updated, remove completed Jobs so they don't linger with stale config
 	if op == controllerutil.OperationResultUpdated {
-		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), logger); err != nil {
-			logger.Error(err, "Failed to clean up completed Jobs after CronJob update")
+		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), n.log()); err != nil {
+			n.log().Error(err, "Failed to clean up completed Jobs after CronJob update")
 			return err
 		}
 	}
@@ -256,7 +266,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 		err = n.KubeClient.List(ctx, pods, opts)
 		if err != nil {
-			logger.Error(err, "Failed to list Pods for Kubernetes Resource Scanning")
+			n.log().Error(err, "Failed to list Pods for Kubernetes Resource Scanning")
 			return err
 		}
 	}
@@ -268,12 +278,12 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 func (n *DeploymentHandler) syncConfigMap(ctx context.Context, integrationMrn, clusterUid string) error {
 	desired, err := ConfigMap(integrationMrn, clusterUid, *n.Mondoo, *n.MondooOperatorConfig)
 	if err != nil {
-		logger.Error(err, "failed to generate desired ConfigMap with inventory")
+		n.log().Error(err, "failed to generate desired ConfigMap with inventory")
 		return err
 	}
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -289,19 +299,19 @@ func (n *DeploymentHandler) reconcileExternalClusters(ctx context.Context) error
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		logger.Error(err, "Failed to resolve cnspec container image")
+		n.log().Error(err, "Failed to resolve cnspec container image")
 		return err
 	}
 
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
-		logger.Error(err, "failed to retrieve integration-mrn for MondooAuditConfig")
+		n.log().Error(err, "failed to retrieve integration-mrn for MondooAuditConfig")
 		return err
 	}
 
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID")
+		n.log().Error(err, "Failed to get cluster's UID")
 		return err
 	}
 
@@ -313,7 +323,7 @@ func (n *DeploymentHandler) reconcileExternalClusters(ctx context.Context) error
 
 		// Validate authentication configuration
 		if err := validateExternalClusterAuth(cluster); err != nil {
-			logger.Error(err, "invalid external cluster authentication configuration", "cluster", cluster.Name)
+			n.externalClusterLog(cluster.Name).Error(err, "invalid external cluster authentication configuration")
 			return err
 		}
 
@@ -358,14 +368,15 @@ func (n *DeploymentHandler) reconcileExternalClusters(ctx context.Context) error
 }
 
 func (n *DeploymentHandler) syncExternalClusterConfigMap(ctx context.Context, integrationMrn, clusterUid string, cluster v1alpha2.ExternalCluster) error {
+	log := n.externalClusterLog(cluster.Name)
 	desired, err := ExternalClusterConfigMap(integrationMrn, clusterUid, cluster, *n.Mondoo, *n.MondooOperatorConfig)
 	if err != nil {
-		logger.Error(err, "failed to generate desired ConfigMap for external cluster", "cluster", cluster.Name)
+		log.Error(err, "failed to generate desired ConfigMap for external cluster")
 		return err
 	}
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, log, func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -377,10 +388,11 @@ func (n *DeploymentHandler) syncExternalClusterConfigMap(ctx context.Context, in
 }
 
 func (n *DeploymentHandler) syncExternalClusterCronJob(ctx context.Context, image string, cluster v1alpha2.ExternalCluster) error {
+	log := n.externalClusterLog(cluster.Name)
 	desired := ExternalClusterCronJob(image, cluster, n.Mondoo, *n.MondooOperatorConfig)
 
 	obj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, log, func() error {
 		k8s.UpdateCronJobFields(obj, desired)
 		return nil
 	})
@@ -390,8 +402,8 @@ func (n *DeploymentHandler) syncExternalClusterCronJob(ctx context.Context, imag
 
 	// When a CronJob is updated, remove completed Jobs so they don't linger with stale config
 	if op == controllerutil.OperationResultUpdated {
-		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, ExternalClusterCronJobLabels(*n.Mondoo, cluster.Name), logger); err != nil {
-			logger.Error(err, "Failed to clean up completed Jobs after CronJob update for external cluster", "cluster", cluster.Name)
+		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, ExternalClusterCronJobLabels(*n.Mondoo, cluster.Name), log); err != nil {
+			log.Error(err, "Failed to clean up completed Jobs after CronJob update for external cluster")
 			return err
 		}
 	}
@@ -418,9 +430,11 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 		}
 
 		if !configuredClusters[clusterName] {
+			log := n.externalClusterLog(clusterName)
+
 			// This external cluster is no longer configured, delete its resources
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, &cj); err != nil {
-				logger.Error(err, "failed to delete orphaned CronJob for external cluster", "cluster", clusterName)
+				log.Error(err, "failed to delete orphaned CronJob for external cluster")
 				return err
 			}
 
@@ -432,7 +446,7 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 				},
 			}
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
-				logger.Error(err, "failed to delete orphaned ConfigMap for external cluster", "cluster", clusterName)
+				log.Error(err, "failed to delete orphaned ConfigMap for external cluster")
 				return err
 			}
 
@@ -444,7 +458,7 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 				},
 			}
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, saKubeconfigCM); err != nil {
-				logger.Error(err, "failed to delete orphaned SA kubeconfig ConfigMap for external cluster", "cluster", clusterName)
+				log.Error(err, "failed to delete orphaned SA kubeconfig ConfigMap for external cluster")
 				return err
 			}
 
@@ -456,7 +470,7 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 				},
 			}
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, wifSA); err != nil {
-				logger.Error(err, "failed to delete orphaned WIF ServiceAccount for external cluster", "cluster", clusterName)
+				log.Error(err, "failed to delete orphaned WIF ServiceAccount for external cluster")
 				return err
 			}
 
@@ -468,11 +482,11 @@ func (n *DeploymentHandler) cleanupOrphanedExternalClusterResources(ctx context.
 				},
 			}
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, vaultKubeconfigSecret); err != nil {
-				logger.Error(err, "failed to delete orphaned Vault kubeconfig Secret for external cluster", "cluster", clusterName)
+				log.Error(err, "failed to delete orphaned Vault kubeconfig Secret for external cluster")
 				return err
 			}
 
-			logger.Info("Cleaned up orphaned resources for external cluster", "cluster", clusterName)
+			log.Info("Cleaned up orphaned resources for external cluster")
 		}
 	}
 
@@ -486,7 +500,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 	// Lists only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
-		logger.Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
+		n.log().Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
 		return nil, err
 	}
 	return cronJobs.Items, nil
@@ -497,14 +511,14 @@ func (n *DeploymentHandler) downLocalCluster(ctx context.Context) error {
 	// Delete main cluster CronJob
 	cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace}}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, cronJob); err != nil {
-		logger.Error(err, "failed to clean up Kubernetes resource scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
+		n.log().Error(err, "failed to clean up Kubernetes resource scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
 		return err
 	}
 
 	// Delete main cluster ConfigMap
 	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace}}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
-		logger.Error(err, "failed to clean up Kubernetes resource scanning ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
+		n.log().Error(err, "failed to clean up Kubernetes resource scanning ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
 		return err
 	}
 
@@ -530,7 +544,7 @@ func (n *DeploymentHandler) cleanupWorkloadDeployment(ctx context.Context) error
 	}
 
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, dep); err != nil {
-		logger.Error(err, "failed to clean up old Deployment for workloads", "namespace", dep.Namespace, "name", dep.Name)
+		n.log().Error(err, "failed to clean up old Deployment for workloads", "namespace", dep.Namespace, "name", dep.Name)
 		return err
 	}
 
@@ -541,7 +555,7 @@ func (n *DeploymentHandler) cleanupWorkloadDeployment(ctx context.Context) error
 		},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, cfgMap); err != nil {
-		logger.Error(err, "failed to cleanup configmap", "namespace", cfgMap.Namespace, "name", cfgMap.Name)
+		n.log().Error(err, "failed to cleanup configmap", "namespace", cfgMap.Namespace, "name", cfgMap.Name)
 		return err
 	}
 	return nil
@@ -552,7 +566,7 @@ func (n *DeploymentHandler) syncExternalClusterSAKubeconfigConfigMap(ctx context
 	desired := ExternalClusterSAKubeconfigConfigMap(cluster, n.Mondoo)
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.externalClusterLog(cluster.Name), func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -573,7 +587,7 @@ func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterU
 		LabelSelector: labels.SelectorFromSet(CronJobLabels(*n.Mondoo)),
 	}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
-		logger.Error(err, "Failed to list CronJobs for garbage collection")
+		n.log().Error(err, "Failed to list CronJobs for garbage collection")
 		return
 	}
 
@@ -598,7 +612,7 @@ func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterU
 	}
 
 	if err := n.performGarbageCollection(ctx, mondoo.ManagedByLabel(clusterUid)); err != nil {
-		logger.Error(err, "Failed to perform garbage collection of K8s resource scan assets")
+		n.log().Error(err, "Failed to perform garbage collection of K8s resource scan assets")
 	}
 
 	// Always update the timestamp so we don't retry until the next new successful scan.
@@ -619,11 +633,11 @@ func (n *DeploymentHandler) performGarbageCollection(ctx context.Context, manage
 		},
 	}
 
-	if err := mondoo.GarbageCollectAssets(ctx, n.KubeClient, n.Mondoo, n.MondooOperatorConfig, n.MondooClientBuilder, req, logger); err != nil {
+	if err := mondoo.GarbageCollectAssets(ctx, n.KubeClient, n.Mondoo, n.MondooOperatorConfig, n.MondooClientBuilder, req, n.log()); err != nil {
 		return err
 	}
 
-	logger.Info("Successfully performed garbage collection of K8s resource scan assets")
+	n.log().Info("Successfully performed garbage collection of K8s resource scan assets")
 	return nil
 }
 
@@ -691,7 +705,7 @@ func (n *DeploymentHandler) syncVaultKubeconfigSecret(ctx context.Context, clust
 	// Create/update kubeconfig Secret
 	desired := VaultKubeconfigSecret(n.Mondoo, cluster.Name, kubeconfig)
 	obj := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.externalClusterLog(cluster.Name), func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -707,7 +721,7 @@ func (n *DeploymentHandler) syncWIFServiceAccount(ctx context.Context, cluster v
 	desired := WIFServiceAccount(cluster, n.Mondoo)
 
 	obj := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.externalClusterLog(cluster.Name), func() error {
 		obj.Labels = desired.Labels
 		obj.Annotations = desired.Annotations
 		return nil
@@ -747,7 +761,7 @@ func (n *DeploymentHandler) cleanupStaleCronJobs(ctx context.Context) error {
 		if clusterName, ok := cronJobs.Items[i].Labels["cluster_name"]; ok && !configuredClusters[clusterName] {
 			continue
 		}
-		logger.Info("Deleting stale k8s scan CronJob", "name", cronJobs.Items[i].Name)
+		n.log().Info("Deleting stale k8s scan CronJob", "name", cronJobs.Items[i].Name)
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, &cronJobs.Items[i]); err != nil {
 			return err
 		}

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -100,7 +100,12 @@ var MondooClientBuilder = mondooclient.NewClient
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcileResult ctrl.Result, reconcileError error) {
-	log := ctrllog.FromContext(ctx)
+	log := ctrllog.FromContext(ctx).WithValues(
+		"mondooAuditConfig", req.String(),
+		"mondooNamespace", req.Namespace,
+		"mondooName", req.Name,
+	)
+	ctx = ctrllog.IntoContext(ctx, log)
 
 	// Fetch the Mondoo instance
 	mondooAuditConfig := &v1alpha2.MondooAuditConfig{}
@@ -308,9 +313,9 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// (e.g. image resolution timeout) must not block the others.
 	var firstError error
 	finalResult := ctrl.Result{Requeue: true, RequeueAfter: time.Hour * 24 * 7}
-	collect := func(result ctrl.Result, err error, msg string) {
+	collect := func(result ctrl.Result, err error, msg, scanType string) {
 		if err != nil {
-			log.Error(err, msg+", continuing with other scan types")
+			log.Error(err, msg+", continuing with other scan types", "scanType", scanType)
 			if firstError == nil {
 				firstError = err
 			}
@@ -321,7 +326,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	result, err := nodes.Reconcile(ctx)
-	collect(result, err, "Failed to set up nodes scanning")
+	collect(result, err, "Failed to set up nodes scanning", "node-scanning")
 
 	containers := container_image.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -332,7 +337,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		RefreshDigests:         r.refreshDigests(mondooAuditConfig, config),
 	}
 	result, err = containers.Reconcile(ctx)
-	collect(result, err, "Failed to set up container scanning")
+	collect(result, err, "Failed to set up container scanning", "container-image-scanning")
 
 	workloads := k8s_scan.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -343,7 +348,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		VaultTokenFetcher:      k8s_scan.DefaultVaultTokenFetcher,
 	}
 	result, err = workloads.Reconcile(ctx)
-	collect(result, err, "Failed to set up Kubernetes resources scanning")
+	collect(result, err, "Failed to set up Kubernetes resources scanning", "k8s-resources-scanning")
 
 	resourceWatcher := resourcewatcher.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -352,7 +357,7 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		ContainerImageResolver: imageResolver,
 	}
 	result, err = resourceWatcher.Reconcile(ctx)
-	collect(result, err, "Failed to set up resource watcher")
+	collect(result, err, "Failed to set up resource watcher", "resource-watcher")
 
 	mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
 

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -9,9 +9,12 @@ import (
 	"slices"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	logutils "go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,6 +35,10 @@ type DeploymentHandler struct {
 	MondooOperatorConfig   *v1alpha2.MondooOperatorConfig
 	MondooClientBuilder    func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error)
 	IsOpenshift            bool
+}
+
+func (n *DeploymentHandler) log() logr.Logger {
+	return logutils.WithMondooAuditConfig(logger, n.Mondoo, "node-scanning")
 }
 
 func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) {
@@ -58,9 +65,9 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 
 	// Perform garbage collection of stale node scan assets if a new successful scan has completed.
 	// GC is only applicable in CronJob mode; for DaemonSet style this is a no-op since no CronJobs exist.
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID for node scan garbage collection")
+		n.log().Error(err, "Failed to get cluster's UID for node scan garbage collection")
 	} else {
 		n.garbageCollectIfNeeded(ctx, clusterUid)
 	}
@@ -72,19 +79,19 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		logger.Error(err, "Failed to resolve mondoo-client container image")
+		n.log().Error(err, "Failed to resolve mondoo-client container image")
 		return err
 	}
 
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID")
+		n.log().Error(err, "Failed to get cluster's UID")
 		return err
 	}
 
 	nodes := &corev1.NodeList{}
 	if err := n.KubeClient.List(ctx, nodes); err != nil {
-		logger.Error(err, "Failed to list cluster nodes")
+		n.log().Error(err, "Failed to list cluster nodes")
 		return err
 	}
 
@@ -93,7 +100,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, ds); err != nil {
-		logger.Error(err, "Failed to clean up node scanning DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
+		n.log().Error(err, "Failed to clean up node scanning DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
 		return err
 	}
 
@@ -101,7 +108,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	for _, node := range nodes.Items {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
-			logger.Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
+			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
 			return err
 		}
 
@@ -111,7 +118,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
 		cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cronJob, n.Mondoo, logger, func() error {
+		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cronJob, n.Mondoo, n.log(), func() error {
 			k8s.UpdateCronJobFields(cronJob, desired)
 			return nil
 		})
@@ -121,14 +128,14 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 
 		switch op {
 		case controllerutil.OperationResultCreated:
-			if err := mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger); err != nil {
-				logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
+			if err := mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, n.log()); err != nil {
+				n.log().Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
 				return err
 			}
 		case controllerutil.OperationResultUpdated:
 			// Remove completed Jobs so they don't linger with stale config
-			if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, NodeScanningLabels(*n.Mondoo), logger); err != nil {
-				logger.Error(err, "Failed to clean up completed Jobs after CronJob update")
+			if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, NodeScanningLabels(*n.Mondoo), n.log()); err != nil {
+				n.log().Error(err, "Failed to clean up completed Jobs after CronJob update")
 				return err
 			}
 		}
@@ -154,7 +161,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		}
 		err = n.KubeClient.List(ctx, pods, opts)
 		if err != nil {
-			logger.Error(err, "Failed to list Pods for Node Scanning")
+			n.log().Error(err, "Failed to list Pods for Node Scanning")
 			return err
 		}
 	}
@@ -166,7 +173,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: GarbageCollectCronJobName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, gcCronJob); err != nil {
-		logger.Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
+		n.log().Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
 		return err
 	}
 
@@ -177,19 +184,19 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		logger.Error(err, "Failed to resolve mondoo-client container image")
+		n.log().Error(err, "Failed to resolve mondoo-client container image")
 		return err
 	}
 
-	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, logger)
+	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
-		logger.Error(err, "Failed to get cluster's UID")
+		n.log().Error(err, "Failed to get cluster's UID")
 		return err
 	}
 
 	nodes := &corev1.NodeList{}
 	if err := n.KubeClient.List(ctx, nodes); err != nil {
-		logger.Error(err, "Failed to list cluster nodes")
+		n.log().Error(err, "Failed to list cluster nodes")
 		return err
 	}
 
@@ -200,13 +207,13 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 			ObjectMeta: metav1.ObjectMeta{Name: CronJobName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace},
 		}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cronJob); err != nil {
-			logger.Error(err, "Failed to clean up node scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
+			n.log().Error(err, "Failed to clean up node scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
 			return err
 		}
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
-			logger.Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
+			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
 			return err
 		}
 
@@ -217,7 +224,7 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		if n.Mondoo.Spec.Nodes.Style == v1alpha2.NodeScanStyle_Deployment {
 			dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 			if err := k8s.DeleteIfExists(ctx, n.KubeClient, dep); err != nil {
-				logger.Error(err, "Failed to clean up node scanning Deployment", "namespace", dep.Namespace, "name", dep.Name)
+				n.log().Error(err, "Failed to clean up node scanning Deployment", "namespace", dep.Namespace, "name", dep.Name)
 			}
 		}
 	}
@@ -231,7 +238,7 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 
 	desired := DaemonSet(*n.Mondoo, n.IsOpenshift, mondooClientImage, *n.MondooOperatorConfig, slices.Collect(maps.Keys(tolerations)))
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, ds, n.Mondoo, logger, func() error {
+	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, ds, n.Mondoo, n.log(), func() error {
 		k8s.UpdateDaemonSetFields(ds, desired)
 		return nil
 	})
@@ -240,14 +247,14 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	}
 
 	if op == controllerutil.OperationResultCreated {
-		if err := mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, logger); err != nil {
-			logger.Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
+		if err := mondoo.UpdateMondooAuditConfig(ctx, n.KubeClient, n.Mondoo, n.log()); err != nil {
+			n.log().Error(err, "Failed to update MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
 			return err
 		}
 	}
 
 	if err := n.KubeClient.Get(ctx, client.ObjectKeyFromObject(ds), ds); err != nil {
-		logger.Error(err, "Failed to get DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
+		n.log().Error(err, "Failed to get DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
 	}
 
 	// Get Pods for these Deployments
@@ -258,7 +265,7 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	}
 	err = n.KubeClient.List(ctx, pods, opts)
 	if err != nil {
-		logger.Error(err, "Failed to list Pods for Node Scanning")
+		n.log().Error(err, "Failed to list Pods for Node Scanning")
 		return err
 	}
 
@@ -269,7 +276,7 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: GarbageCollectCronJobName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, gcCronJob); err != nil {
-		logger.Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
+		n.log().Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
 		return err
 	}
 
@@ -279,18 +286,18 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 func (n *DeploymentHandler) syncConfigMap(ctx context.Context, clusterUid string) error {
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
-		logger.Error(err, "failed to retrieve IntegrationMRN")
+		n.log().Error(err, "failed to retrieve IntegrationMRN")
 		return err
 	}
 
 	desired, err := ConfigMap(integrationMrn, clusterUid, *n.Mondoo)
 	if err != nil {
-		logger.Error(err, "failed to generate ConfigMap")
+		n.log().Error(err, "failed to generate ConfigMap")
 		return err
 	}
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, logger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, n.KubeClient, obj, n.Mondoo, n.log(), func() error {
 		obj.Labels = desired.Labels
 		obj.Data = desired.Data
 		return nil
@@ -325,10 +332,10 @@ func (n *DeploymentHandler) cleanupCronJobsForDeletedNodes(ctx context.Context, 
 
 		// If the node for the CronJob has been deleted from the cluster, the CronJob needs to be deleted.
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, &c); err != nil {
-			logger.Error(err, "Failed to deleted CronJob", "namespace", c.Namespace, "name", c.Name)
+			n.log().Error(err, "Failed to deleted CronJob", "namespace", c.Namespace, "name", c.Name)
 			return err
 		}
-		logger.Info("Deleted CronJob", "namespace", c.Namespace, "name", c.Name)
+		n.log().Info("Deleted CronJob", "namespace", c.Namespace, "name", c.Name)
 	}
 	return nil
 }
@@ -340,7 +347,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 	// Lists only the CronJobs in the namespace of the MondooAuditConfig and only the ones that exactly match our labels.
 	listOpts := &client.ListOptions{Namespace: n.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(cronJobLabels)}
 	if err := n.KubeClient.List(ctx, cronJobs, listOpts); err != nil {
-		logger.Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
+		n.log().Error(err, "Failed to list CronJobs in namespace", "namespace", n.Mondoo.Namespace)
 		return nil, err
 	}
 	return cronJobs.Items, nil
@@ -349,7 +356,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 func (n *DeploymentHandler) down(ctx context.Context) error {
 	nodes := &corev1.NodeList{}
 	if err := n.KubeClient.List(ctx, nodes); err != nil {
-		logger.Error(err, "Failed to list cluster nodes")
+		n.log().Error(err, "Failed to list cluster nodes")
 		return err
 	}
 
@@ -358,7 +365,7 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 			ObjectMeta: metav1.ObjectMeta{Name: CronJobName(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace},
 		}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cronJob); err != nil {
-			logger.Error(err, "Failed to clean up node scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
+			n.log().Error(err, "Failed to clean up node scanning CronJob", "namespace", cronJob.Namespace, "name", cronJob.Name)
 			return err
 		}
 	}
@@ -367,7 +374,7 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, ds); err != nil {
-		logger.Error(err, "Failed to clean up node scanning DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
+		n.log().Error(err, "Failed to clean up node scanning DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
 		return err
 	}
 
@@ -375,7 +382,7 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
-		logger.Error(err, "Failed to clean up inventory ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
+		n.log().Error(err, "Failed to clean up inventory ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
 		return err
 	}
 
@@ -383,7 +390,7 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{Name: GarbageCollectCronJobName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
 	}
 	if err := k8s.DeleteIfExists(ctx, n.KubeClient, gcCronJob); err != nil {
-		logger.Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
+		n.log().Error(err, "Failed to clean up node garbage collect CronJob", "namespace", gcCronJob.Namespace, "name", gcCronJob.Name)
 		return err
 	}
 
@@ -398,7 +405,7 @@ func (n *DeploymentHandler) down(ctx context.Context) error {
 func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterUid string) {
 	cronJobs, err := n.getCronJobsForAuditConfig(ctx)
 	if err != nil {
-		logger.Error(err, "Failed to list CronJobs for node scan garbage collection")
+		n.log().Error(err, "Failed to list CronJobs for node scan garbage collection")
 		return
 	}
 
@@ -424,7 +431,7 @@ func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterU
 
 	managedBy := mondoo.ManagedByNodesLabel(clusterUid)
 	if err := n.performGarbageCollection(ctx, managedBy); err != nil {
-		logger.Error(err, "Failed to perform garbage collection of node scan assets")
+		n.log().Error(err, "Failed to perform garbage collection of node scan assets")
 	}
 
 	// Always update the timestamp so we don't retry until the next new successful scan.
@@ -448,10 +455,10 @@ func (n *DeploymentHandler) performGarbageCollection(ctx context.Context, manage
 		},
 	}
 
-	if err := mondoo.GarbageCollectAssets(ctx, n.KubeClient, n.Mondoo, n.MondooOperatorConfig, n.MondooClientBuilder, req, logger); err != nil {
+	if err := mondoo.GarbageCollectAssets(ctx, n.KubeClient, n.Mondoo, n.MondooOperatorConfig, n.MondooClientBuilder, req, n.log()); err != nil {
 		return err
 	}
 
-	logger.Info("Successfully performed garbage collection of node scan assets")
+	n.log().Info("Successfully performed garbage collection of node scan assets")
 	return nil
 }

--- a/controllers/resource_watcher/deployment_handler.go
+++ b/controllers/resource_watcher/deployment_handler.go
@@ -6,6 +6,7 @@ package resource_watcher
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,7 @@ import (
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
+	logutils "go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
 )
 
@@ -26,6 +28,10 @@ type DeploymentHandler struct {
 	Mondoo                 *v1alpha2.MondooAuditConfig
 	ContainerImageResolver mondoo.ContainerImageResolver
 	MondooOperatorConfig   *v1alpha2.MondooOperatorConfig
+}
+
+func (h *DeploymentHandler) log() logr.Logger {
+	return logutils.WithMondooAuditConfig(deploymentHandlerLogger, h.Mondoo, "resource-watcher")
 }
 
 // Reconcile ensures the resource watcher deployment matches the desired state.
@@ -46,25 +52,25 @@ func (h *DeploymentHandler) syncDeployment(ctx context.Context) error {
 	mondooClientImage, err := h.ContainerImageResolver.MondooOperatorImage(
 		ctx, h.Mondoo.Spec.Scanner.Image.Name, h.Mondoo.Spec.Scanner.Image.Tag, h.Mondoo.Spec.Scanner.Image.Digest, h.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
-		deploymentHandlerLogger.Error(err, "Failed to resolve mondoo-operator container image")
+		h.log().Error(err, "Failed to resolve mondoo-operator container image")
 		return err
 	}
 
 	// Get cluster UID for asset labeling (best-effort)
-	clusterUID, err := k8s.GetClusterUID(ctx, h.KubeClient, deploymentHandlerLogger)
+	clusterUID, err := k8s.GetClusterUID(ctx, h.KubeClient, h.log())
 	if err != nil {
-		deploymentHandlerLogger.Info("Failed to get cluster UID, continuing without it", "error", err)
+		h.log().Info("Failed to get cluster UID, continuing without it", "error", err)
 	}
 
 	// Get integration MRN if available (best-effort)
 	integrationMRN, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, h.KubeClient, *h.Mondoo)
 	if err != nil {
-		deploymentHandlerLogger.Info("Failed to get integration MRN, continuing without it", "error", err)
+		h.log().Info("Failed to get integration MRN, continuing without it", "error", err)
 	}
 
 	desired := Deployment(mondooClientImage, integrationMRN, clusterUID, h.Mondoo, *h.MondooOperatorConfig)
 	obj := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := k8s.CreateOrUpdate(ctx, h.KubeClient, obj, h.Mondoo, deploymentHandlerLogger, func() error {
+	if _, err := k8s.CreateOrUpdate(ctx, h.KubeClient, obj, h.Mondoo, h.log(), func() error {
 		k8s.UpdateDeploymentFields(obj, desired)
 		return nil
 	}); err != nil {
@@ -86,7 +92,7 @@ func (h *DeploymentHandler) syncDeployment(ctx context.Context) error {
 		}
 		err = h.KubeClient.List(ctx, pods, opts)
 		if err != nil {
-			deploymentHandlerLogger.Error(err, "Failed to list Pods for Resource Watcher")
+			h.log().Error(err, "Failed to list Pods for Resource Watcher")
 			return err
 		}
 	}
@@ -115,7 +121,7 @@ func (h *DeploymentHandler) getDeploymentsForAuditConfig(ctx context.Context) ([
 
 	listOpts := &client.ListOptions{Namespace: h.Mondoo.Namespace, LabelSelector: labels.SelectorFromSet(deploymentLabels)}
 	if err := h.KubeClient.List(ctx, deployments, listOpts); err != nil {
-		deploymentHandlerLogger.Error(err, "Failed to list Deployments in namespace", "namespace", h.Mondoo.Namespace)
+		h.log().Error(err, "Failed to list Deployments in namespace", "namespace", h.Mondoo.Namespace)
 		return nil, err
 	}
 	return deployments.Items, nil
@@ -125,7 +131,7 @@ func (h *DeploymentHandler) down(ctx context.Context) error {
 	// Delete Deployment
 	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName(h.Mondoo.Name), Namespace: h.Mondoo.Namespace}}
 	if err := k8s.DeleteIfExists(ctx, h.KubeClient, deployment); err != nil {
-		deploymentHandlerLogger.Error(
+		h.log().Error(
 			err, "failed to clean up resource watcher Deployment", "namespace", deployment.Namespace, "name", deployment.Name)
 		return err
 	}

--- a/pkg/utils/logger/context.go
+++ b/pkg/utils/logger/context.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package logger
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WithMondooAuditConfig adds stable reconcile object fields to controller logs.
+func WithMondooAuditConfig(log logr.Logger, auditConfig client.Object, scanType string) logr.Logger {
+	values := []any{}
+	if auditConfig != nil {
+		key := client.ObjectKeyFromObject(auditConfig)
+		values = append(values,
+			"mondooAuditConfig", key.String(),
+		)
+	}
+	if scanType != "" {
+		values = append(values, "scanType", scanType)
+	}
+	if len(values) == 0 {
+		return log
+	}
+	return log.WithValues(values...)
+}
+
+// WithExternalCluster adds the external cluster name to cluster-scoped scan logs.
+func WithExternalCluster(log logr.Logger, clusterName string) logr.Logger {
+	if clusterName == "" {
+		return log
+	}
+	return log.WithValues("externalCluster", clusterName)
+}

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -4,10 +4,15 @@
 package logger
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 )
 
 type testEncoder struct {
@@ -67,4 +72,40 @@ func TestNewLogger(t *testing.T) {
 
 	// Test that the logger can be used
 	logger.Info("test message", "key", "value")
+}
+
+func TestWithMondooAuditConfig(t *testing.T) {
+	var line string
+	log := funcr.NewJSON(func(obj string) {
+		line = obj
+	}, funcr.Options{})
+
+	auditConfig := &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "security",
+			Name:      "mondoo",
+		},
+	}
+
+	WithMondooAuditConfig(log, auditConfig, "node-scanning").Info("test")
+
+	fields := map[string]any{}
+	assert.NoError(t, json.Unmarshal([]byte(line), &fields))
+	assert.Equal(t, "security/mondoo", fields["mondooAuditConfig"])
+	assert.NotContains(t, fields, "mondooNamespace")
+	assert.NotContains(t, fields, "mondooName")
+	assert.Equal(t, "node-scanning", fields["scanType"])
+}
+
+func TestWithExternalCluster(t *testing.T) {
+	var line string
+	log := funcr.NewJSON(func(obj string) {
+		line = obj
+	}, funcr.Options{})
+
+	WithExternalCluster(log, "prod").Info("test")
+
+	fields := map[string]any{}
+	assert.NoError(t, json.Unmarshal([]byte(line), &fields))
+	assert.Equal(t, "prod", fields["externalCluster"])
 }


### PR DESCRIPTION
## Summary
- Add structured logger helpers for MondooAuditConfig and external cluster context.
- Scope scan-controller logs with `mondooAuditConfig`, `mondooNamespace`, `mondooName`, and `scanType`.
- Add `externalCluster` context for external Kubernetes resource scan reconciliation.

## Tests
- `go test ./pkg/utils/logger ./controllers/...`
- `git diff --check HEAD~1 HEAD`