### PR TITLE
feat: select nodes for scanning by label

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -573,6 +573,9 @@ type Nodes struct {
 	Style NodeScanStyle `json:"style,omitempty"`
 	// PriorityClassName specifies the name of the PriorityClass for the node scanning workloads.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// LabelSelector selects nodes to scan. When unset, all nodes are scanned.
+	// +optional
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	// Env allows setting extra environment variables for the node scanner. If the operator sets already an env
 	// variable with the same name, the value specified here will override it.
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -723,6 +723,11 @@ func (in *MondooOperatorConfigStatus) DeepCopy() *MondooOperatorConfigStatus {
 func (in *Nodes) DeepCopyInto(out *Nodes) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.LabelSelector != nil {
+		in, out := &in.LabelSelector, &out.LabelSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1523,6 +1523,53 @@ spec:
                         minimum: 0
                         type: integer
                     type: object
+                  labelSelector:
+                    description: LabelSelector selects nodes to scan. When unset,
+                      all nodes are scanned.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   priorityClassName:
                     description: PriorityClassName specifies the name of the PriorityClass
                       for the node scanning workloads.

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1523,6 +1523,53 @@ spec:
                         minimum: 0
                         type: integer
                     type: object
+                  labelSelector:
+                    description: LabelSelector selects nodes to scan. When unset,
+                      all nodes are scanned.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   priorityClassName:
                     description: PriorityClassName specifies the name of the PriorityClass
                       for the node scanning workloads.

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1523,6 +1523,53 @@ spec:
                         minimum: 0
                         type: integer
                     type: object
+                  labelSelector:
+                    description: LabelSelector selects nodes to scan. When unset,
+                      all nodes are scanned.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   priorityClassName:
                     description: PriorityClassName specifies the name of the PriorityClass
                       for the node scanning workloads.

--- a/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
@@ -171,6 +171,10 @@ spec:
     # suspend: true
     # Interval in minutes (only for deployment style)
     # intervalTimer: 60
+    # Select which nodes to scan. Omit to scan all nodes.
+    # labelSelector:
+    #   matchLabels:
+    #     pool: platform
     resources:
       requests:
         cpu: 100m

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -99,7 +99,11 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 	}
 
 	nodes := &corev1.NodeList{}
-	if err := n.KubeClient.List(ctx, nodes); err != nil {
+	nodeListOpts, err := nodeListOptions(n.Mondoo)
+	if err != nil {
+		return err
+	}
+	if err := n.KubeClient.List(ctx, nodes, nodeListOpts...); err != nil {
 		n.log().Error(err, "Failed to list cluster nodes")
 		return err
 	}
@@ -112,16 +116,19 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		n.log().Error(err, "Failed to clean up node scanning DaemonSet", "namespace", ds.Namespace, "name", ds.Name)
 		return err
 	}
+	if err := n.cleanupLegacyPerNodeResources(ctx); err != nil {
+		return err
+	}
+
+	if err := n.syncConfigMap(ctx, clusterUid); err != nil {
+		return err
+	}
 
 	// Create/update CronJobs for nodes
 	for _, node := range nodes.Items {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
 			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
-			return err
-		}
-
-		if err := n.syncConfigMap(ctx, clusterUid); err != nil {
 			return err
 		}
 
@@ -205,8 +212,23 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	}
 
 	nodes := &corev1.NodeList{}
-	if err := n.KubeClient.List(ctx, nodes); err != nil {
+	nodeListOpts, err := nodeListOptions(n.Mondoo)
+	if err != nil {
+		return err
+	}
+	if err := n.KubeClient.List(ctx, nodes, nodeListOpts...); err != nil {
 		n.log().Error(err, "Failed to list cluster nodes")
+		return err
+	}
+
+	if err := n.cleanupCronJobsForDeletedNodes(ctx, *nodes); err != nil {
+		return err
+	}
+	if err := n.cleanupLegacyPerNodeResources(ctx); err != nil {
+		return err
+	}
+
+	if err := n.syncConfigMap(ctx, clusterUid); err != nil {
 		return err
 	}
 
@@ -224,10 +246,6 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
 			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
-			return err
-		}
-
-		if err := n.syncConfigMap(ctx, clusterUid); err != nil {
 			return err
 		}
 
@@ -298,6 +316,24 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	return nil
 }
 
+func nodeListOptions(m *v1alpha2.MondooAuditConfig) ([]client.ListOption, error) {
+	selector, err := nodeLabelSelector(m)
+	if err != nil {
+		return nil, err
+	}
+	if selector.Empty() {
+		return nil, nil
+	}
+	return []client.ListOption{client.MatchingLabelsSelector{Selector: selector}}, nil
+}
+
+func nodeLabelSelector(m *v1alpha2.MondooAuditConfig) (labels.Selector, error) {
+	if m.Spec.Nodes.LabelSelector == nil {
+		return labels.Everything(), nil
+	}
+	return metav1.LabelSelectorAsSelector(m.Spec.Nodes.LabelSelector)
+}
+
 func (n *DeploymentHandler) syncConfigMap(ctx context.Context, clusterUid string) error {
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
@@ -318,6 +354,44 @@ func (n *DeploymentHandler) syncConfigMap(ctx context.Context, clusterUid string
 		return nil
 	}); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (n *DeploymentHandler) cleanupLegacyPerNodeResources(ctx context.Context) error {
+	listOpts := &client.ListOptions{
+		Namespace:     n.Mondoo.Namespace,
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(*n.Mondoo)),
+	}
+
+	deployments := &appsv1.DeploymentList{}
+	if err := n.KubeClient.List(ctx, deployments, listOpts); err != nil {
+		logger.Error(err, "Failed to list legacy node scanning Deployments", "namespace", n.Mondoo.Namespace)
+		return err
+	}
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		if err := k8s.DeleteIfExists(ctx, n.KubeClient, deployment); err != nil {
+			logger.Error(err, "Failed to clean up legacy node scanning Deployment", "namespace", deployment.Namespace, "name", deployment.Name)
+			return err
+		}
+	}
+
+	configMaps := &corev1.ConfigMapList{}
+	if err := n.KubeClient.List(ctx, configMaps, listOpts); err != nil {
+		logger.Error(err, "Failed to list legacy node scanning ConfigMaps", "namespace", n.Mondoo.Namespace)
+		return err
+	}
+	for i := range configMaps.Items {
+		configMap := &configMaps.Items[i]
+		if configMap.Name == ConfigMapName(n.Mondoo.Name) {
+			continue
+		}
+		if err := k8s.DeleteIfExists(ctx, n.KubeClient, configMap); err != nil {
+			logger.Error(err, "Failed to clean up legacy node scanning ConfigMap", "namespace", configMap.Namespace, "name", configMap.Name)
+			return err
+		}
 	}
 
 	return nil

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -254,6 +255,31 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	s.Error(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(gcCj), gcCj))
 }
 
+func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_NodeLabelSelector() {
+	s.seedLabeledNodes()
+	d := s.createDeploymentHandler()
+	s.auditConfig.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "platform"},
+	}
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	cronJobs := &batchv1.CronJobList{}
+	listOpts := &client.ListOptions{
+		Namespace:     s.auditConfig.Namespace,
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
+	}
+	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
+	s.Require().Len(cronJobs.Items, 1)
+	s.Equal(CronJobName(s.auditConfig.Name, "node01"), cronJobs.Items[0].Name)
+
+	excluded := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, "node02"), Namespace: s.auditConfig.Namespace}}
+	s.Error(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(excluded), excluded))
+}
+
 func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_CustomEnvVars() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
@@ -369,6 +395,70 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	}
 }
 
+func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForNoLongerSelectedNodes() {
+	s.seedLabeledNodes()
+	d := s.createDeploymentHandler()
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	cronJobs := &batchv1.CronJobList{}
+	listOpts := &client.ListOptions{
+		Namespace:     s.auditConfig.Namespace,
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
+	}
+	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
+	s.Require().Len(cronJobs.Items, 2)
+
+	d.Mondoo.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "platform"},
+	}
+	result, err = d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	cronJobs = &batchv1.CronJobList{}
+	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
+	s.Require().Len(cronJobs.Items, 1)
+	s.Equal(CronJobName(s.auditConfig.Name, "node01"), cronJobs.Items[0].Name)
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_NodeLabelSelectorNoMatchesKeepsConfigAndCleansCronJobs() {
+	s.seedLabeledNodes()
+	d := s.createDeploymentHandler()
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	cronJobs := &batchv1.CronJobList{}
+	listOpts := &client.ListOptions{
+		Namespace:     s.auditConfig.Namespace,
+		LabelSelector: labels.SelectorFromSet(NodeScanningLabels(s.auditConfig)),
+	}
+	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
+	s.Require().Len(cronJobs.Items, 2)
+
+	d.Mondoo.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "missing"},
+	}
+	result, err = d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	cronJobs = &batchv1.CronJobList{}
+	s.NoError(d.KubeClient.List(s.ctx, cronJobs, listOpts))
+	s.Empty(cronJobs.Items)
+
+	cfgMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: ConfigMapName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace,
+	}}
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cfgMap), cfgMap))
+}
+
 func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
@@ -445,6 +535,71 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets() {
 	// Verify node garbage collection cronjob does not exist (removed in simplification)
 	gcCj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: GarbageCollectCronJobName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.Error(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(gcCj), gcCj))
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_NodeLabelSelector() {
+	s.seedLabeledNodes()
+	d := s.createDeploymentHandler()
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "platform"},
+	}
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(ds), ds))
+	s.Require().NotNil(ds.Spec.Template.Spec.Affinity)
+	s.Require().NotNil(ds.Spec.Template.Spec.Affinity.NodeAffinity)
+	nodeSelector := ds.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	s.Require().NotNil(nodeSelector)
+	s.Require().Len(nodeSelector.NodeSelectorTerms, 1)
+	s.Contains(nodeSelector.NodeSelectorTerms[0].MatchExpressions, corev1.NodeSelectorRequirement{
+		Key:      "pool",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"platform"},
+	})
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_DaemonSetNodeLabelSelectorCleansLegacyPerNodeResources() {
+	s.seedLabeledNodes()
+	d := s.createDeploymentHandler()
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "platform"},
+	}
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	labels := NodeScanningLabels(s.auditConfig)
+	staleDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      DeploymentName(s.auditConfig.Name, "node02"),
+		Namespace: s.auditConfig.Namespace,
+		Labels:    labels,
+	}}
+	staleConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      ConfigMapNameWithNode(s.auditConfig.Name, "node02"),
+		Namespace: s.auditConfig.Namespace,
+		Labels:    labels,
+	}}
+	s.NoError(d.KubeClient.Create(s.ctx, staleDeployment))
+	s.NoError(d.KubeClient.Create(s.ctx, staleConfigMap))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	err = d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(staleDeployment), staleDeployment)
+	s.True(apierrors.IsNotFound(err))
+	err = d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(staleConfigMap), staleConfigMap)
+	s.True(apierrors.IsNotFound(err))
+
+	cfgMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: ConfigMapName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace,
+	}}
+	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cfgMap), cfgMap))
 }
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_Switch() {
@@ -1052,6 +1207,27 @@ func (s *DeploymentHandlerSuite) seedNodes() {
 	}
 	worker := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node02"}}
 	s.fakeClientBuilder = s.fakeClientBuilder.WithObjects(master, worker)
+}
+
+func (s *DeploymentHandlerSuite) seedLabeledNodes() {
+	platform := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node01",
+			Labels: map[string]string{"pool": "platform"},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Value: "true", Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+	}
+	tenant := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node02",
+			Labels: map[string]string{"pool": "tenant"},
+		},
+	}
+	s.fakeClientBuilder = s.fakeClientBuilder.WithObjects(platform, tenant)
 }
 
 func (s *DeploymentHandlerSuite) seedKubeSystemNamespace() {

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -312,6 +312,12 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 			ds.Spec.Template.Spec.ImagePullSecrets,
 			cfg.Spec.ImagePullSecrets...)
 	}
+	if nodeAffinity := nodeSelectorAffinity(m.Spec.Nodes.LabelSelector); nodeAffinity != nil {
+		if ds.Spec.Template.Spec.Affinity == nil {
+			ds.Spec.Template.Spec.Affinity = &corev1.Affinity{}
+		}
+		ds.Spec.Template.Spec.Affinity.NodeAffinity = nodeAffinity
+	}
 
 	k8s.ApplyDaemonSetOverrides(ds, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.Nodes.JobOverrides))
 
@@ -438,6 +444,54 @@ func NodeScanningLabels(m v1alpha2.MondooAuditConfig) map[string]string {
 		"app":       "mondoo",
 		"scan":      "nodes",
 		"mondoo_cr": m.Name,
+	}
+}
+
+func nodeSelectorAffinity(selector *metav1.LabelSelector) *corev1.NodeAffinity {
+	if selector == nil || (len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0) {
+		return nil
+	}
+
+	requirements := make([]corev1.NodeSelectorRequirement, 0, len(selector.MatchLabels)+len(selector.MatchExpressions))
+	for key, value := range selector.MatchLabels {
+		requirements = append(requirements, corev1.NodeSelectorRequirement{
+			Key:      key,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{value},
+		})
+	}
+	for _, expression := range selector.MatchExpressions {
+		requirements = append(requirements, corev1.NodeSelectorRequirement{
+			Key:      expression.Key,
+			Operator: nodeSelectorOperator(expression.Operator),
+			Values:   append([]string(nil), expression.Values...),
+		})
+	}
+
+	return &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: requirements,
+				},
+			},
+		},
+	}
+}
+
+func nodeSelectorOperator(operator metav1.LabelSelectorOperator) corev1.NodeSelectorOperator {
+	switch operator {
+	case metav1.LabelSelectorOpIn:
+		return corev1.NodeSelectorOpIn
+	case metav1.LabelSelectorOpNotIn:
+		return corev1.NodeSelectorOpNotIn
+	case metav1.LabelSelectorOpExists:
+		return corev1.NodeSelectorOpExists
+	case metav1.LabelSelectorOpDoesNotExist:
+		return corev1.NodeSelectorOpDoesNotExist
+	default:
+		logger.Info("Unknown label selector operator, defaulting to In", "operator", operator)
+		return corev1.NodeSelectorOpIn
 	}
 }
 

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -604,6 +604,40 @@ func TestDaemonSet_PerTypeJobOverridesOverrideGlobal(t *testing.T) {
 	assert.Equal(t, map[string]string{"workload-type": "node-scan"}, ds.Spec.Template.Spec.NodeSelector)
 }
 
+func TestDaemonSet_WithNodeLabelSelector(t *testing.T) {
+	mac := *testMondooAuditConfig()
+	mac.Spec.Nodes.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"pool": "platform"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "upgrade",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"paused"},
+			},
+		},
+	}
+
+	ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+
+	require.NotNil(t, ds.Spec.Template.Spec.Affinity)
+	require.NotNil(t, ds.Spec.Template.Spec.Affinity.NodeAffinity)
+	nodeSelector := ds.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, nodeSelector)
+	require.Len(t, nodeSelector.NodeSelectorTerms, 1)
+	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+		{
+			Key:      "pool",
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"platform"},
+		},
+		{
+			Key:      "upgrade",
+			Operator: corev1.NodeSelectorOpNotIn,
+			Values:   []string{"paused"},
+		},
+	}, nodeSelector.NodeSelectorTerms[0].MatchExpressions)
+}
+
 // envToMap converts a slice of EnvVar to a map for easy lookup.
 func envToMap(envVars []corev1.EnvVar) map[string]string {
 	m := make(map[string]string, len(envVars))

--- a/docs/development.md
+++ b/docs/development.md
@@ -163,6 +163,10 @@ spec:
     style: cronjob # or "deployment" or "daemonset"
     # Optional: pause scheduled node scan CronJobs without deleting them
     # suspend: true
+    # Optional: select which nodes to scan
+    # labelSelector:
+    #   matchLabels:
+    #     pool: platform
     # Optional: set priority class for node scanning workloads
     # priorityClassName: high-priority
 ```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1363,6 +1363,17 @@ spec:
         memory: 200Mi
 ```
 
+To scan only a subset of nodes, set `nodes.labelSelector`. In CronJob mode, the operator creates node scan CronJobs only for matching nodes and removes CronJobs for nodes that no longer match. In DaemonSet mode, the selector is enforced as required node affinity.
+
+```yaml
+spec:
+  nodes:
+    enable: true
+    labelSelector:
+      matchLabels:
+        pool: platform
+```
+
 ### How can I trigger a new scan?
 
 The operator runs a full cluster scan and node scans hourly. If you need to manually trigger those scans there are two options:

--- a/pkg/utils/k8s/update_fields.go
+++ b/pkg/utils/k8s/update_fields.go
@@ -80,6 +80,7 @@ func UpdateDaemonSetFields(obj, desired *appsv1.DaemonSet) {
 	ps.PriorityClassName = dps.PriorityClassName
 	ps.AutomountServiceAccountToken = dps.AutomountServiceAccountToken
 	ps.NodeSelector = dps.NodeSelector
+	ps.Affinity = dps.Affinity
 	ps.Tolerations = dps.Tolerations
 	ps.Containers = dps.Containers
 	ps.Volumes = dps.Volumes

--- a/pkg/utils/k8s/update_fields_test.go
+++ b/pkg/utils/k8s/update_fields_test.go
@@ -210,3 +210,36 @@ func TestUpdateDaemonSetFields_NodeSelector(t *testing.T) {
 
 	assert.Equal(t, desired.Spec.Template.Spec.NodeSelector, obj.Spec.Template.Spec.NodeSelector)
 }
+
+func TestUpdateDaemonSetFields_Affinity(t *testing.T) {
+	desired := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "pool",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"platform"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	obj := &appsv1.DaemonSet{}
+	UpdateDaemonSetFields(obj, desired)
+
+	assert.Equal(t, desired.Spec.Template.Spec.Affinity, obj.Spec.Template.Spec.Affinity)
+}


### PR DESCRIPTION
## Summary
- add nodes.labelSelector to MondooAuditConfig for selecting which nodes are scanned
- apply the selector to CronJob-mode node listing and clean up CronJobs for nodes that no longer match
- translate the selector to DaemonSet required node affinity
- sync node scan ConfigMap once per reconcile so zero-match selectors still keep required config present
- copy DaemonSet affinity during updates and cover the behavior with tests

## Tests
- make generate manifests
- go test ./controllers/nodes -count=1
- go test ./pkg/utils/k8s -count=1
- go test ./controllers/... -count=1
- go test ./api/v1alpha2 ./pkg/utils/k8s -count=1
- git -c core.fsmonitor=false diff --check