### PR TITLE
feat: suspend scheduled scans

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [429, 200, 406]
+  "aliveStatusCodes": [200, 406, 429]
 }

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -134,6 +134,9 @@ type KubernetesResources struct {
 	ContainerImageScanning bool `json:"containerImageScanning,omitempty"`
 	// Specify a custom crontab schedule for the Kubernetes resource scanning job. If not specified, the default schedule is used.
 	Schedule string `json:"schedule,omitempty"`
+	// Suspend pauses scheduled Kubernetes resource scan CronJobs without deleting the generated resources.
+	// External cluster scan CronJobs inherit this value and can also be paused individually.
+	Suspend bool `json:"suspend,omitempty"`
 
 	// ResourceWatcher configures real-time resource watching and scanning.
 	// When enabled, a deployment will be created that watches for K8s resource changes
@@ -229,6 +232,11 @@ type ExternalCluster struct {
 	// If not specified, uses the schedule from KubernetesResources.Schedule.
 	// +optional
 	Schedule string `json:"schedule,omitempty"`
+
+	// Suspend pauses the scheduled scan CronJob for this external cluster.
+	// The CronJob is also paused when KubernetesResources.Suspend is true.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 
 	// Filtering allows namespace filtering specific to this external cluster.
 	// If omitted, the external cluster inherits the global filtering from MondooAuditConfigSpec.Filtering.
@@ -489,6 +497,8 @@ type Nodes struct {
 	// Schedule specifies a custom crontab schedule for the node scanning job. If not specified, the default schedule is
 	// used. Only applicable for CronJob style
 	Schedule string `json:"schedule,omitempty"`
+	// Suspend pauses scheduled node scan CronJobs without deleting generated resources. Only applicable for CronJob style.
+	Suspend bool `json:"suspend,omitempty"`
 	// IntervalTimer is the interval (in minutes) for the node scanning. The default is "60". Only applicable for Deployment
 	// style.
 	// +kubebuilder:default=60
@@ -513,6 +523,8 @@ type Containers struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Specify a custom crontab schedule for the container image scanning job. If not specified, the default schedule is used.
 	Schedule string `json:"schedule,omitempty"`
+	// Suspend pauses scheduled container image scan CronJobs without deleting generated resources.
+	Suspend bool `json:"suspend,omitempty"`
 	// Env allows setting extra environment variables for the node scanner. If the operator sets already an env
 	// variable with the same name, the value specified here will override it.
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -444,6 +444,10 @@ spec:
                       image scanning job. If not specified, the default schedule is
                       used.
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled container image scan CronJobs
+                      without deleting generated resources.
+                    type: boolean
                   workloadIdentity:
                     description: |-
                       WorkloadIdentity configures Workload Identity Federation for authenticating to cloud
@@ -783,6 +787,11 @@ spec:
                           - server
                           - trustBundleSecretRef
                           type: object
+                        suspend:
+                          description: |-
+                            Suspend pauses the scheduled scan CronJob for this external cluster.
+                            The CronJob is also paused when KubernetesResources.Suspend is true.
+                          type: boolean
                         vaultAuth:
                           description: |-
                             VaultAuth configures HashiCorp Vault Kubernetes secrets engine for dynamic credential generation.
@@ -1111,6 +1120,11 @@ spec:
                       resource scanning job. If not specified, the default schedule
                       is used.
                     type: string
+                  suspend:
+                    description: |-
+                      Suspend pauses scheduled Kubernetes resource scan CronJobs without deleting the generated resources.
+                      External cluster scan CronJobs inherit this value and can also be paused individually.
+                    type: boolean
                 type: object
               mondooCredsSecretRef:
                 description: Config is an example field of MondooAuditConfig. Edit
@@ -1463,6 +1477,10 @@ spec:
                     - deployment
                     - daemonset
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled node scan CronJobs without
+                      deleting generated resources. Only applicable for CronJob style.
+                    type: boolean
                 type: object
               scanner:
                 description: |-

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -444,6 +444,10 @@ spec:
                       image scanning job. If not specified, the default schedule is
                       used.
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled container image scan CronJobs
+                      without deleting generated resources.
+                    type: boolean
                   workloadIdentity:
                     description: |-
                       WorkloadIdentity configures Workload Identity Federation for authenticating to cloud
@@ -783,6 +787,11 @@ spec:
                           - server
                           - trustBundleSecretRef
                           type: object
+                        suspend:
+                          description: |-
+                            Suspend pauses the scheduled scan CronJob for this external cluster.
+                            The CronJob is also paused when KubernetesResources.Suspend is true.
+                          type: boolean
                         vaultAuth:
                           description: |-
                             VaultAuth configures HashiCorp Vault Kubernetes secrets engine for dynamic credential generation.
@@ -1111,6 +1120,11 @@ spec:
                       resource scanning job. If not specified, the default schedule
                       is used.
                     type: string
+                  suspend:
+                    description: |-
+                      Suspend pauses scheduled Kubernetes resource scan CronJobs without deleting the generated resources.
+                      External cluster scan CronJobs inherit this value and can also be paused individually.
+                    type: boolean
                 type: object
               mondooCredsSecretRef:
                 description: Config is an example field of MondooAuditConfig. Edit
@@ -1463,6 +1477,10 @@ spec:
                     - deployment
                     - daemonset
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled node scan CronJobs without
+                      deleting generated resources. Only applicable for CronJob style.
+                    type: boolean
                 type: object
               scanner:
                 description: |-

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -444,6 +444,10 @@ spec:
                       image scanning job. If not specified, the default schedule is
                       used.
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled container image scan CronJobs
+                      without deleting generated resources.
+                    type: boolean
                   workloadIdentity:
                     description: |-
                       WorkloadIdentity configures Workload Identity Federation for authenticating to cloud
@@ -783,6 +787,11 @@ spec:
                           - server
                           - trustBundleSecretRef
                           type: object
+                        suspend:
+                          description: |-
+                            Suspend pauses the scheduled scan CronJob for this external cluster.
+                            The CronJob is also paused when KubernetesResources.Suspend is true.
+                          type: boolean
                         vaultAuth:
                           description: |-
                             VaultAuth configures HashiCorp Vault Kubernetes secrets engine for dynamic credential generation.
@@ -1111,6 +1120,11 @@ spec:
                       resource scanning job. If not specified, the default schedule
                       is used.
                     type: string
+                  suspend:
+                    description: |-
+                      Suspend pauses scheduled Kubernetes resource scan CronJobs without deleting the generated resources.
+                      External cluster scan CronJobs inherit this value and can also be paused individually.
+                    type: boolean
                 type: object
               mondooCredsSecretRef:
                 description: Config is an example field of MondooAuditConfig. Edit
@@ -1463,6 +1477,10 @@ spec:
                     - deployment
                     - daemonset
                     type: string
+                  suspend:
+                    description: Suspend pauses scheduled node scan CronJobs without
+                      deleting generated resources. Only applicable for CronJob style.
+                    type: boolean
                 type: object
               scanner:
                 description: |-

--- a/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
@@ -53,6 +53,8 @@ spec:
     enable: true
     # Cron schedule (default: random minute each hour)
     # schedule: "0 * * * *"
+    # Pause scheduled Kubernetes resource scan CronJobs without deleting them.
+    # suspend: true
 
     # Real-time resource watching (alternative to CronJob scheduling)
     # When enabled, resources are scanned immediately when they change
@@ -80,6 +82,8 @@ spec:
     #       name: prod-kubeconfig
     #     # Optional: override schedule for this cluster
     #     # schedule: "0 */2 * * *"
+    #     # Optional: pause this external cluster scan CronJob
+    #     # suspend: true
     #     # Optional: cluster-specific filtering
     #     # filtering:
     #     #   namespaces:
@@ -146,6 +150,8 @@ spec:
     enable: true
     # Cron schedule (default: daily)
     # schedule: "0 0 * * *"
+    # Pause scheduled container image scan CronJobs without deleting them.
+    # suspend: true
     resources:
       requests:
         cpu: 100m
@@ -161,6 +167,8 @@ spec:
     style: cronjob
     # Cron schedule (only for cronjob style)
     # schedule: "0 * * * *"
+    # Pause scheduled node scan CronJobs without deleting them.
+    # suspend: true
     # Interval in minutes (only for deployment style)
     # intervalTimer: 60
     resources:

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -82,8 +82,8 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          m.Spec.Containers.Schedule,
+			Suspend:           ptr.To(m.Spec.Containers.Suspend || m.Status.ScanningPaused),
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
-			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/container_image/resources_test.go
+++ b/controllers/container_image/resources_test.go
@@ -373,6 +373,47 @@ func TestCronJob_Suspend(t *testing.T) {
 	assert.True(t, *cj.Spec.Suspend)
 }
 
+func TestCronJob_SuspendMatrix(t *testing.T) {
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("clearing Suspend resumes the CronJob", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.Containers.Suspend = true
+
+		current := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+		require.NotNil(t, current.Spec.Suspend)
+		assert.True(t, *current.Spec.Suspend)
+
+		m.Spec.Containers.Suspend = false
+		m.Status.ScanningPaused = false
+		desired := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+		k8s.UpdateCronJobFields(current, desired)
+
+		require.NotNil(t, current.Spec.Suspend)
+		assert.False(t, *current.Spec.Suspend)
+	})
+
+	t.Run("ScanningPaused suspends even when Suspend is false", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.Containers.Suspend = false
+		m.Status.ScanningPaused = true
+
+		cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.True(t, *cj.Spec.Suspend)
+	})
+
+	t.Run("both pause sources cleared resumes the CronJob", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.Containers.Suspend = false
+		m.Status.ScanningPaused = false
+
+		cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.False(t, *cj.Spec.Suspend)
+	})
+}
+
 func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
 	m := testAuditConfig()
 	m.Status.ScanningPaused = true

--- a/controllers/container_image/resources_test.go
+++ b/controllers/container_image/resources_test.go
@@ -361,6 +361,17 @@ func TestCronJob_WIF_EKS(t *testing.T) {
 	assert.Equal(t, "arn:aws:iam::123456789012:role/ecr-reader", initEnv["ROLE_ARN"])
 }
 
+func TestCronJob_Suspend(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.Containers.Suspend = true
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+
+	require.NotNil(t, cj.Spec.Suspend)
+	assert.True(t, *cj.Spec.Suspend)
+}
+
 func TestCronJob_WIF_AKS(t *testing.T) {
 	m := testAuditConfig()
 	m.Spec.Containers.WorkloadIdentity = &v1alpha2.WorkloadIdentityConfig{

--- a/controllers/container_image/resources_test.go
+++ b/controllers/container_image/resources_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
@@ -370,6 +371,23 @@ func TestCronJob_Suspend(t *testing.T) {
 
 	require.NotNil(t, cj.Spec.Suspend)
 	assert.True(t, *cj.Spec.Suspend)
+}
+
+func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
+	m := testAuditConfig()
+	m.Status.ScanningPaused = true
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	current := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+	require.NotNil(t, current.Spec.Suspend)
+	assert.True(t, *current.Spec.Suspend)
+
+	m.Status.ScanningPaused = false
+	desired := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+	k8s.UpdateCronJobFields(current, desired)
+
+	require.NotNil(t, current.Spec.Suspend)
+	assert.False(t, *current.Spec.Suspend)
 }
 
 func TestCronJob_WIF_AKS(t *testing.T) {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -84,8 +84,8 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          m.Spec.KubernetesResources.Schedule,
+			Suspend:           ptr.To(m.Spec.KubernetesResources.Suspend || m.Status.ScanningPaused),
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
-			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{
@@ -455,8 +455,8 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:          schedule,
+			Suspend:           ptr.To(m.Spec.KubernetesResources.Suspend || cluster.Suspend || m.Status.ScanningPaused),
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
-			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
@@ -401,6 +402,23 @@ func TestCronJob_Suspend(t *testing.T) {
 	assert.True(t, *cj.Spec.Suspend)
 }
 
+func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
+	m := testAuditConfig()
+	m.Status.ScanningPaused = true
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	current := CronJob("test-image:latest", m, cfg)
+	require.NotNil(t, current.Spec.Suspend)
+	assert.True(t, *current.Spec.Suspend)
+
+	m.Status.ScanningPaused = false
+	desired := CronJob("test-image:latest", m, cfg)
+	k8s.UpdateCronJobFields(current, desired)
+
+	require.NotNil(t, current.Spec.Suspend)
+	assert.False(t, *current.Spec.Suspend)
+}
+
 func TestExternalClusterCronJob_WithProxy(t *testing.T) {
 	m := testAuditConfig()
 	cluster := v1alpha2.ExternalCluster{
@@ -491,6 +509,29 @@ func TestExternalClusterCronJob_Suspend(t *testing.T) {
 
 	require.NotNil(t, cj.Spec.Suspend)
 	assert.True(t, *cj.Spec.Suspend)
+}
+
+func TestExternalClusterCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
+	m := testAuditConfig()
+	m.Status.ScanningPaused = true
+	cluster := v1alpha2.ExternalCluster{
+		Name: "remote",
+		KubeconfigSecretRef: &corev1.LocalObjectReference{
+			Name: "kubeconfig-secret",
+		},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	current := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
+	require.NotNil(t, current.Spec.Suspend)
+	assert.True(t, *current.Spec.Suspend)
+
+	m.Status.ScanningPaused = false
+	desired := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
+	k8s.UpdateCronJobFields(current, desired)
+
+	require.NotNil(t, current.Spec.Suspend)
+	assert.False(t, *current.Spec.Suspend)
 }
 
 func TestExternalClusterCronJob_InheritsKubernetesResourcesSuspend(t *testing.T) {

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -390,6 +390,17 @@ func TestExternalClusterCronJob_ActiveDeadline_Unset(t *testing.T) {
 	assert.Nil(t, cj.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
 }
 
+func TestCronJob_Suspend(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.KubernetesResources.Suspend = true
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", m, cfg)
+
+	require.NotNil(t, cj.Spec.Suspend)
+	assert.True(t, *cj.Spec.Suspend)
+}
+
 func TestExternalClusterCronJob_WithProxy(t *testing.T) {
 	m := testAuditConfig()
 	cluster := v1alpha2.ExternalCluster{
@@ -463,6 +474,40 @@ func TestExternalClusterCronJob_ImagePullSecrets(t *testing.T) {
 	secrets := cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
+}
+
+func TestExternalClusterCronJob_Suspend(t *testing.T) {
+	m := testAuditConfig()
+	cluster := v1alpha2.ExternalCluster{
+		Name:    "remote",
+		Suspend: true,
+		KubeconfigSecretRef: &corev1.LocalObjectReference{
+			Name: "kubeconfig-secret",
+		},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
+
+	require.NotNil(t, cj.Spec.Suspend)
+	assert.True(t, *cj.Spec.Suspend)
+}
+
+func TestExternalClusterCronJob_InheritsKubernetesResourcesSuspend(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.KubernetesResources.Suspend = true
+	cluster := v1alpha2.ExternalCluster{
+		Name: "remote",
+		KubeconfigSecretRef: &corev1.LocalObjectReference{
+			Name: "kubeconfig-secret",
+		},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
+
+	require.NotNil(t, cj.Spec.Suspend)
+	assert.True(t, *cj.Spec.Suspend)
 }
 
 func TestExternalClusterCronJob_HasMondooTmpDir(t *testing.T) {

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -402,6 +402,47 @@ func TestCronJob_Suspend(t *testing.T) {
 	assert.True(t, *cj.Spec.Suspend)
 }
 
+func TestCronJob_SuspendMatrix(t *testing.T) {
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("clearing Suspend resumes the CronJob", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.KubernetesResources.Suspend = true
+
+		current := CronJob("test-image:latest", m, cfg)
+		require.NotNil(t, current.Spec.Suspend)
+		assert.True(t, *current.Spec.Suspend)
+
+		m.Spec.KubernetesResources.Suspend = false
+		m.Status.ScanningPaused = false
+		desired := CronJob("test-image:latest", m, cfg)
+		k8s.UpdateCronJobFields(current, desired)
+
+		require.NotNil(t, current.Spec.Suspend)
+		assert.False(t, *current.Spec.Suspend)
+	})
+
+	t.Run("ScanningPaused suspends even when Suspend is false", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.KubernetesResources.Suspend = false
+		m.Status.ScanningPaused = true
+
+		cj := CronJob("test-image:latest", m, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.True(t, *cj.Spec.Suspend)
+	})
+
+	t.Run("both pause sources cleared resumes the CronJob", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.KubernetesResources.Suspend = false
+		m.Status.ScanningPaused = false
+
+		cj := CronJob("test-image:latest", m, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.False(t, *cj.Spec.Suspend)
+	})
+}
+
 func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
 	m := testAuditConfig()
 	m.Status.ScanningPaused = true

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -74,8 +74,8 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:                   m.Spec.Nodes.Schedule,
+			Suspend:                    ptr.To(m.Spec.Nodes.Suspend || m.Status.ScanningPaused),
 			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
-			Suspend:                    ptr.To(m.Status.ScanningPaused),
 			SuccessfulJobsHistoryLimit: ptr.To(int32(1)),
 			FailedJobsHistoryLimit:     ptr.To(int32(1)),
 			JobTemplate: batchv1.JobTemplateSpec{

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -318,6 +318,27 @@ func TestCronJob_Suspend(t *testing.T) {
 	assert.True(t, *cj.Spec.Suspend)
 }
 
+func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
+	testNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-name",
+		},
+	}
+	mac := testMondooAuditConfig()
+	mac.Status.ScanningPaused = true
+
+	current := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	require.NotNil(t, current.Spec.Suspend)
+	assert.True(t, *current.Spec.Suspend)
+
+	mac.Status.ScanningPaused = false
+	desired := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	k8s.UpdateCronJobFields(current, desired)
+
+	require.NotNil(t, current.Spec.Suspend)
+	assert.False(t, *current.Spec.Suspend)
+}
+
 func TestInventory(t *testing.T) {
 	auditConfig := v1alpha2.MondooAuditConfig{ObjectMeta: metav1.ObjectMeta{Name: "mondoo-client"}}
 

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -303,6 +303,21 @@ func TestDaemonSet_Capabilities(t *testing.T) {
 	})
 }
 
+func TestCronJob_Suspend(t *testing.T) {
+	testNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-name",
+		},
+	}
+	mac := testMondooAuditConfig()
+	mac.Spec.Nodes.Suspend = true
+
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+
+	require.NotNil(t, cj.Spec.Suspend)
+	assert.True(t, *cj.Spec.Suspend)
+}
+
 func TestInventory(t *testing.T) {
 	auditConfig := v1alpha2.MondooAuditConfig{ObjectMeta: metav1.ObjectMeta{Name: "mondoo-client"}}
 

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -318,6 +318,52 @@ func TestCronJob_Suspend(t *testing.T) {
 	assert.True(t, *cj.Spec.Suspend)
 }
 
+func TestCronJob_SuspendMatrix(t *testing.T) {
+	testNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-name",
+		},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("clearing Suspend resumes the CronJob", func(t *testing.T) {
+		mac := testMondooAuditConfig()
+		mac.Spec.Nodes.Suspend = true
+
+		current := CronJob("test123", testNode, mac, false, cfg)
+		require.NotNil(t, current.Spec.Suspend)
+		assert.True(t, *current.Spec.Suspend)
+
+		mac.Spec.Nodes.Suspend = false
+		mac.Status.ScanningPaused = false
+		desired := CronJob("test123", testNode, mac, false, cfg)
+		k8s.UpdateCronJobFields(current, desired)
+
+		require.NotNil(t, current.Spec.Suspend)
+		assert.False(t, *current.Spec.Suspend)
+	})
+
+	t.Run("ScanningPaused suspends even when Suspend is false", func(t *testing.T) {
+		mac := testMondooAuditConfig()
+		mac.Spec.Nodes.Suspend = false
+		mac.Status.ScanningPaused = true
+
+		cj := CronJob("test123", testNode, mac, false, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.True(t, *cj.Spec.Suspend)
+	})
+
+	t.Run("both pause sources cleared resumes the CronJob", func(t *testing.T) {
+		mac := testMondooAuditConfig()
+		mac.Spec.Nodes.Suspend = false
+		mac.Status.ScanningPaused = false
+
+		cj := CronJob("test123", testNode, mac, false, cfg)
+		require.NotNil(t, cj.Spec.Suspend)
+		assert.False(t, *cj.Spec.Suspend)
+	})
+}
+
 func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
 	testNode := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,6 +161,8 @@ spec:
   nodes:
     enable: true
     style: cronjob # or "deployment" or "daemonset"
+    # Optional: pause scheduled node scan CronJobs without deleting them
+    # suspend: true
     # Optional: set priority class for node scanning workloads
     # priorityClassName: high-priority
 ```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -290,6 +290,8 @@ externalClusters:
       name: prod-kubeconfig
     # Custom schedule for this cluster
     schedule: "0 */2 * * *"  # Every 2 hours
+    # Pause this external cluster scan CronJob
+    suspend: true
     # Cluster-specific namespace filtering
     filtering:
       namespaces:
@@ -310,6 +312,7 @@ externalClusters:
 | `name` | Unique identifier for the cluster (used in CronJob names) |
 | `kubeconfigSecretRef` | Reference to Secret containing kubeconfig |
 | `schedule` | Override the default scan schedule (cron format) |
+| `suspend` | Pause this external cluster scan CronJob without deleting it |
 | `filtering` | Namespace include/exclude specific to this cluster |
 | `containerImageScanning` | Enable container image scanning for this cluster |
 | `privateRegistriesPullSecretRef` | Registry credentials for private images |
@@ -969,6 +972,26 @@ Notes:
   the operator take precedence and cannot be overwritten.
 - `nodeSelector` is ignored for node scan pods because they are pinned to a specific node.
 - `nodes.jobOverrides` only applies to the `cronjob` node scanning style.
+
+To pause scheduled scan CronJobs without deleting generated resources, set `suspend: true` on the relevant scan configuration:
+
+```yaml
+spec:
+ kubernetesResources:
+   enable: true
+   suspend: true
+ containers:
+   enable: true
+   suspend: true
+ nodes:
+   enable: true
+   suspend: true
+```
+
+Suspending a scan type pauses future scheduled CronJob runs while leaving the
+generated resources and last reported scan status intact. Mondoo status
+reporting continues to show the most recent completed run until a later
+unsuspended scan updates it.
 
 ## Real-time Resource Watcher (Opt-in)
 

--- a/pkg/utils/k8s/update_fields.go
+++ b/pkg/utils/k8s/update_fields.go
@@ -15,6 +15,7 @@ func UpdateCronJobFields(obj, desired *batchv1.CronJob) {
 	obj.Labels = desired.Labels
 	obj.Annotations = desired.Annotations
 	obj.Spec.Schedule = desired.Spec.Schedule
+	obj.Spec.Suspend = desired.Spec.Suspend
 	obj.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 	obj.Spec.SuccessfulJobsHistoryLimit = desired.Spec.SuccessfulJobsHistoryLimit
 	obj.Spec.FailedJobsHistoryLimit = desired.Spec.FailedJobsHistoryLimit

--- a/pkg/utils/k8s/update_fields_test.go
+++ b/pkg/utils/k8s/update_fields_test.go
@@ -77,6 +77,19 @@ func TestUpdateCronJobFields_JobOverrides(t *testing.T) {
 	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.Tolerations, obj.Spec.JobTemplate.Spec.Template.Spec.Tolerations)
 }
 
+func TestUpdateCronJobFields_Suspend(t *testing.T) {
+	desired := &batchv1.CronJob{
+		Spec: batchv1.CronJobSpec{
+			Suspend: ptr.To(true),
+		},
+	}
+
+	obj := &batchv1.CronJob{}
+	UpdateCronJobFields(obj, desired)
+
+	assert.Equal(t, desired.Spec.Suspend, obj.Spec.Suspend)
+}
+
 func TestUpdateCronJobFields_PreservesUnmanagedFields(t *testing.T) {
 	obj := &batchv1.CronJob{
 		Spec: batchv1.CronJobSpec{


### PR DESCRIPTION
## Summary
- add suspend flags for scheduled Kubernetes resource, external cluster, container image, and node scan CronJobs
- wire the suspend settings into generated CronJobs while keeping resources present
- update CronJob reconciliation to manage spec.suspend changes
- document suspension for upgrade-hiatus workflows and add focused tests

## Tests
- make generate manifests
- go test ./controllers/k8s_scan ./controllers/container_image ./controllers/nodes ./pkg/utils/k8s -count=1
- go test ./api/v1alpha2 -count=1
- go test ./controllers/... -count=1
- go test ./api/v1alpha2 ./pkg/utils/k8s -count=1
- git -c core.fsmonitor=false diff --check