### PR TITLE
feat: add OOM stress test framework with Terraform and Kubernetes resources

### DIFF
--- a/tests/integration/oom-stress/run.sh
+++ b/tests/integration/oom-stress/run.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# OOM Stress Test Runner
+#
+# Sets up everything via Terraform, then watches for the scan pod to OOM.
+#
+# Prerequisites:
+#   - Cluster running with mondoo-operator installed
+#   - terraform, kubectl available
+#   - MONDOO_API_TOKEN or ~/.config/mondoo/mondoo.yml configured
+#
+# Usage:
+#   cd tests/integration/oom-stress
+#   cp terraform/terraform.example.tfvars terraform/terraform.tfvars
+#   # edit terraform.tfvars with your mondoo_org_id
+#   ./run.sh [apply|watch|destroy|status]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="${SCRIPT_DIR}/terraform"
+
+TIMEOUT_SECONDS="${OOM_STRESS_TIMEOUT:-1500}"  # 25 minutes
+POLL_INTERVAL=5
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+cmd_apply() {
+  log "Running terraform apply..."
+  cd "$TF_DIR"
+  terraform init -upgrade
+  terraform apply -auto-approve
+
+  OPERATOR_NS=$(terraform output -raw operator_namespace 2>/dev/null || echo "mondoo-operator")
+  MEMORY_LIMIT=$(terraform output -raw scanner_memory_limit)
+  IMAGE_COUNT=$(terraform output -raw stress_image_count)
+
+  log ""
+  log "Infrastructure ready:"
+  log "  Space:        $(terraform output -raw mondoo_space_id)"
+  log "  Memory limit: ${MEMORY_LIMIT}"
+  log "  Images:       ${IMAGE_COUNT}"
+  log ""
+  log "Waiting for target pods to be ready..."
+  cd "$SCRIPT_DIR"
+
+  TARGET_NS=$(cd "$TF_DIR" && terraform output -raw target_namespace)
+  kubectl wait --for=condition=Ready pods \
+    -l app.kubernetes.io/part-of=oom-stress-test \
+    -n "$TARGET_NS" \
+    --timeout=300s 2>/dev/null || log "WARNING: some pods may not be ready yet"
+
+  log "Run './run.sh watch' to monitor the scan, or it will start automatically."
+}
+
+cmd_watch() {
+  cd "$TF_DIR"
+  OPERATOR_NS="mondoo-operator"
+  if [ -f terraform.tfstate ]; then
+    OPERATOR_NS=$(terraform output -raw operator_namespace 2>/dev/null || echo "mondoo-operator")
+  fi
+
+  SCAN_LABEL="app=mondoo-container-scan,mondoo_cr=oom-stress-test"
+  START_TIME=$(date +%s)
+
+  log "Watching for scan pod (label: ${SCAN_LABEL})..."
+  log "Timeout: ${TIMEOUT_SECONDS}s"
+  log ""
+
+  while true; do
+    ELAPSED=$(( $(date +%s) - START_TIME ))
+    if [ "$ELAPSED" -gt "$TIMEOUT_SECONDS" ]; then
+      log "TIMEOUT: No scan pod terminated within ${TIMEOUT_SECONDS}s"
+      cmd_status
+      exit 1
+    fi
+
+    POD_COUNT=$(kubectl get pods -n "$OPERATOR_NS" -l "$SCAN_LABEL" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$POD_COUNT" -eq 0 ]; then
+      CJ_EXISTS=$(kubectl get cronjob -n "$OPERATOR_NS" -l "mondoo_cr=oom-stress-test" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+      if [ "$CJ_EXISTS" -eq 0 ]; then
+        log "  No CronJob yet... (${ELAPSED}s) — check operator logs if this persists"
+      else
+        log "  CronJob exists, waiting for Job to spawn... (${ELAPSED}s)"
+      fi
+      sleep "$POLL_INTERVAL"
+      continue
+    fi
+
+    while IFS= read -r POD_NAME; do
+      [ -z "$POD_NAME" ] && continue
+      POD_PHASE=$(kubectl get pod -n "$OPERATOR_NS" "$POD_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+
+      TERM_REASON=$(kubectl get pod -n "$OPERATOR_NS" "$POD_NAME" \
+        -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' 2>/dev/null || true)
+      EXIT_CODE=$(kubectl get pod -n "$OPERATOR_NS" "$POD_NAME" \
+        -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+      LAST_REASON=$(kubectl get pod -n "$OPERATOR_NS" "$POD_NAME" \
+        -o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}' 2>/dev/null || true)
+
+      OOM_KILLED="false"
+      if [ "$TERM_REASON" = "OOMKilled" ] || [ "$LAST_REASON" = "OOMKilled" ] || [ "$EXIT_CODE" = "137" ]; then
+        OOM_KILLED="true"
+      fi
+
+      if [ "$OOM_KILLED" = "true" ]; then
+        COMPLETED=$(kubectl logs -n "$OPERATOR_NS" "$POD_NAME" --tail=10000 2>/dev/null | grep -c "successfully uploaded" || echo 0)
+        log ""
+        log "=== OOM DETECTED ==="
+        log "Pod:      $POD_NAME"
+        log "Phase:    $POD_PHASE"
+        log "Elapsed:  ${ELAPSED}s"
+        log "Images:   $COMPLETED completed before OOM"
+        log ""
+        log "PASSED: scanner OOM-killed as expected."
+        exit 0
+      fi
+
+      if [ "$POD_PHASE" = "Succeeded" ]; then
+        log ""
+        log "=== SCAN COMPLETED WITHOUT OOM ==="
+        log "Pod $POD_NAME completed successfully."
+        log "Lower scanner_memory_limit or add more images."
+        log ""
+        log "FAILED: no OOM observed."
+        exit 1
+      fi
+
+      if [ "$POD_PHASE" = "Failed" ] && [ "$OOM_KILLED" = "false" ]; then
+        log ""
+        log "=== SCAN FAILED (not OOM) ==="
+        kubectl describe pod -n "$OPERATOR_NS" "$POD_NAME" 2>/dev/null | tail -15 || true
+        log ""
+        log "INCONCLUSIVE: pod failed for non-OOM reason."
+        exit 2
+      fi
+    done < <(kubectl get pods -n "$OPERATOR_NS" -l "$SCAN_LABEL" --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null)
+
+    log "  Scan running... (${ELAPSED}s, phase: ${POD_PHASE:-unknown})"
+    sleep "$POLL_INTERVAL"
+  done
+}
+
+cmd_status() {
+  cd "$TF_DIR"
+  OPERATOR_NS="mondoo-operator"
+
+  log "=== Cluster State ==="
+  echo ""
+  echo "--- CronJobs ---"
+  kubectl get cronjobs -n "$OPERATOR_NS" -l "mondoo_cr=oom-stress-test" 2>/dev/null || echo "(none)"
+  echo ""
+  echo "--- Scan Pods ---"
+  kubectl get pods -n "$OPERATOR_NS" -l "app=mondoo-container-scan,mondoo_cr=oom-stress-test" -o wide 2>/dev/null || echo "(none)"
+  echo ""
+  echo "--- Target Pods ---"
+  TARGET_NS=$(terraform output -raw target_namespace 2>/dev/null || echo "oom-stress-targets")
+  kubectl get pods -n "$TARGET_NS" -l "app.kubernetes.io/part-of=oom-stress-test" --no-headers 2>/dev/null | wc -l | xargs -I{} echo "{} target pods"
+  echo ""
+  echo "--- MondooAuditConfig ---"
+  kubectl get mondooauditconfig -n "$OPERATOR_NS" oom-stress-test -o yaml 2>/dev/null | head -30 || echo "(not found)"
+  echo ""
+  echo "--- Operator Logs (last 10) ---"
+  kubectl logs -n "$OPERATOR_NS" deploy/mondoo-operator-controller-manager --tail=10 2>/dev/null || echo "(no operator)"
+}
+
+cmd_destroy() {
+  log "Destroying terraform resources..."
+  cd "$TF_DIR"
+  terraform destroy -auto-approve
+  log "Done."
+}
+
+# --- Main ---
+
+case "${1:-apply-and-watch}" in
+  apply)
+    cmd_apply
+    ;;
+  watch)
+    cmd_watch
+    ;;
+  apply-and-watch)
+    cmd_apply
+    cmd_watch
+    ;;
+  status)
+    cmd_status
+    ;;
+  destroy)
+    cmd_destroy
+    ;;
+  *)
+    echo "Usage: $0 [apply|watch|apply-and-watch|status|destroy]"
+    echo ""
+    echo "  apply-and-watch  (default) Provision + watch for OOM"
+    echo "  apply            Provision infrastructure only"
+    echo "  watch            Watch for scan pod OOM (after apply)"
+    echo "  status           Show current cluster state"
+    echo "  destroy          Tear down all resources"
+    exit 1
+    ;;
+esac

--- a/tests/integration/oom-stress/terraform/.gitignore
+++ b/tests/integration/oom-stress/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars

--- a/tests/integration/oom-stress/terraform/kubernetes.tf
+++ b/tests/integration/oom-stress/terraform/kubernetes.tf
@@ -1,0 +1,131 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Kubernetes resources for the OOM stress test:
+# - Target namespace with package-heavy pods for scanning
+# - Mondoo credentials secret
+# - MondooAuditConfig with reduced memory limits
+
+# --- Target namespace + pods ---
+
+resource "kubernetes_namespace_v1" "targets" {
+  metadata {
+    name = var.target_namespace
+  }
+}
+
+resource "kubernetes_pod_v1" "stress_target" {
+  for_each = { for img in var.stress_images : img.name => img }
+
+  metadata {
+    name      = each.value.name
+    namespace = kubernetes_namespace_v1.targets.metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/name"    = each.value.name
+      "app.kubernetes.io/part-of" = "oom-stress-test"
+    }
+  }
+
+  spec {
+    container {
+      name    = "target"
+      image   = each.value.image
+      command = ["sleep", "infinity"]
+    }
+  }
+}
+
+# --- Mondoo credentials ---
+
+resource "kubernetes_secret_v1" "mondoo_client" {
+  metadata {
+    name      = "mondoo-client"
+    namespace = var.operator_namespace
+  }
+
+  data = {
+    config = base64decode(mondoo_service_account.oom_stress.credential)
+  }
+
+  lifecycle {
+    # Don't destroy the secret if the operator is still running — it causes
+    # reconcile errors. The operator namespace cleanup handles this.
+    prevent_destroy = false
+  }
+}
+
+# --- Docker Hub pull secret (avoids rate limits) ---
+
+resource "kubernetes_secret_v1" "docker_pull" {
+  count = var.docker_hub_username != "" ? 1 : 0
+
+  metadata {
+    name      = "mondoo-private-registries-secrets"
+    namespace = var.operator_namespace
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "https://index.docker.io/v1/" = {
+          username = var.docker_hub_username
+          password = var.docker_hub_password
+          auth     = base64encode("${var.docker_hub_username}:${var.docker_hub_password}")
+        }
+      }
+    })
+  }
+}
+
+# --- MondooAuditConfig ---
+
+resource "kubernetes_manifest" "audit_config" {
+  manifest = {
+    apiVersion = "k8s.mondoo.com/v1alpha2"
+    kind       = "MondooAuditConfig"
+
+    metadata = {
+      name      = "oom-stress-test"
+      namespace = var.operator_namespace
+    }
+
+    spec = {
+      mondooCredsSecretRef = {
+        name = kubernetes_secret_v1.mondoo_client.metadata[0].name
+      }
+
+      # Using service account directly, not a console integration
+      consoleIntegration = {
+        enable = false
+      }
+
+      containers = {
+        enable   = true
+        schedule = var.scan_schedule
+        resources = {
+          limits = {
+            memory = var.scanner_memory_limit
+          }
+          requests = {
+            memory = var.scanner_memory_request
+          }
+        }
+      }
+
+      filtering = {
+        namespaces = {
+          include = [var.target_namespace]
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_secret_v1.mondoo_client,
+    kubernetes_namespace_v1.targets,
+    kubernetes_pod_v1.stress_target,
+  ]
+}

--- a/tests/integration/oom-stress/terraform/mondoo.tf
+++ b/tests/integration/oom-stress/terraform/mondoo.tf
@@ -1,0 +1,56 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Mondoo space + service account + policy assignments for the OOM stress test.
+# Policies match the SVA incident: mondoo-sbom, mondoo-linux-security, mondoo-edr-policy.
+#
+# Two modes:
+#   1. Create a new space: set mondoo_org_id, leave mondoo_space_id empty
+#   2. Use existing space: set mondoo_space_id (e.g. for local dev server)
+
+resource "mondoo_space" "oom_stress" {
+  count  = var.mondoo_space_id == "" ? 1 : 0
+  name   = "oom-stress-test"
+  org_id = var.mondoo_org_id
+}
+
+locals {
+  space_id = var.mondoo_space_id != "" ? var.mondoo_space_id : mondoo_space.oom_stress[0].id
+}
+
+resource "mondoo_service_account" "oom_stress" {
+  name        = "oom-stress-scanner"
+  description = "Service account for OOM stress test container scanning"
+  roles       = ["//iam.api.mondoo.app/roles/agent"]
+  space_id    = local.space_id
+}
+
+resource "mondoo_policy_assignment" "sbom" {
+  space_id = local.space_id
+
+  policies = [
+    "//policy.api.mondoo.app/policies/mondoo-sbom",
+  ]
+
+  state = "enabled"
+}
+
+resource "mondoo_policy_assignment" "linux_security" {
+  space_id = local.space_id
+
+  policies = [
+    "//policy.api.mondoo.app/policies/mondoo-linux-security",
+  ]
+
+  state = "enabled"
+}
+
+resource "mondoo_policy_assignment" "edr" {
+  space_id = local.space_id
+
+  policies = [
+    "//policy.api.mondoo.app/policies/mondoo-edr-policy",
+  ]
+
+  state = "enabled"
+}

--- a/tests/integration/oom-stress/terraform/outputs.tf
+++ b/tests/integration/oom-stress/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+output "mondoo_space_id" {
+  value = local.space_id
+}
+
+output "operator_namespace" {
+  value = var.operator_namespace
+}
+
+output "target_namespace" {
+  value = kubernetes_namespace_v1.targets.metadata[0].name
+}
+
+output "scanner_memory_limit" {
+  value = var.scanner_memory_limit
+}
+
+output "stress_image_count" {
+  value = length(var.stress_images)
+}

--- a/tests/integration/oom-stress/terraform/terraform.example.tfvars
+++ b/tests/integration/oom-stress/terraform/terraform.example.tfvars
@@ -1,0 +1,23 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Copy to terraform.tfvars and fill in your values.
+#
+# Auth: set MONDOO_CONFIG_PATH to a service account file, or use cnspec login.
+# The provider reads the API endpoint from the SA file automatically.
+
+mondoo_org_id = "your-mondoo-org-id"
+
+# To use an existing space instead of creating one:
+# mondoo_space_id = "existing-space-id"
+
+# Docker Hub credentials (required to avoid anonymous pull rate limits):
+# docker_hub_username = "your-dockerhub-user"
+# docker_hub_password = "dckr_pat_..."
+
+# Optional overrides:
+# kubeconfig_path       = "~/.kube/config"
+# kubeconfig_context    = "minikube"
+# operator_namespace    = "mondoo-operator"
+# scanner_memory_limit  = "512Mi"   # lower = OOM faster (try 256Mi if 512Mi doesn't OOM)
+# scan_schedule         = "*/5 * * * *"

--- a/tests/integration/oom-stress/terraform/variables.tf
+++ b/tests/integration/oom-stress/terraform/variables.tf
@@ -1,0 +1,103 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+variable "mondoo_org_id" {
+  description = "Mondoo organization ID for space creation (not needed if mondoo_space_id is set)"
+  type        = string
+  default     = ""
+}
+
+variable "mondoo_space_id" {
+  description = "Use an existing Mondoo space instead of creating one (for local dev server)"
+  type        = string
+  default     = ""
+}
+
+
+variable "kubeconfig_path" {
+  description = "Path to kubeconfig file (defaults to ~/.kube/config)"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kubeconfig_context" {
+  description = "Kubeconfig context to use (defaults to current context)"
+  type        = string
+  default     = null
+}
+
+variable "operator_namespace" {
+  description = "Namespace where the mondoo-operator is installed"
+  type        = string
+  default     = "mondoo-operator"
+}
+
+variable "target_namespace" {
+  description = "Namespace for the stress test target pods"
+  type        = string
+  default     = "oom-stress-targets"
+}
+
+variable "scanner_memory_limit" {
+  description = "Memory limit for the container scanner (lower = OOM faster)"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "scanner_memory_request" {
+  description = "Memory request for the container scanner"
+  type        = string
+  default     = "128Mi"
+}
+
+variable "docker_hub_username" {
+  description = "Docker Hub username for authenticated pulls (avoids rate limits)"
+  type        = string
+  default     = ""
+}
+
+variable "docker_hub_password" {
+  description = "Docker Hub password or personal access token"
+  type        = string
+  default     = ""
+  sensitive   = true
+
+  validation {
+    condition     = var.docker_hub_username == "" || var.docker_hub_password != ""
+    error_message = "docker_hub_password is required when docker_hub_username is set."
+  }
+}
+
+variable "scan_schedule" {
+  description = "Cron schedule for the container scan (default: every 5 minutes)"
+  type        = string
+  default     = "*/5 * * * *"
+}
+
+variable "stress_images" {
+  description = "List of container images to deploy as scan targets. Each must support the host architecture."
+  type = list(object({
+    name  = string
+    image = string
+  }))
+  default = [
+    { name = "ubuntu-2404", image = "ubuntu:24.04" },
+    { name = "ubuntu-2204", image = "ubuntu:22.04" },
+    { name = "ubuntu-2004", image = "ubuntu:20.04" },
+    { name = "debian-12", image = "debian:12" },
+    { name = "debian-11", image = "debian:11" },
+    { name = "fedora-40", image = "fedora:40" },
+    { name = "fedora-39", image = "fedora:39" },
+    { name = "amazonlinux-2023", image = "amazonlinux:2023" },
+    { name = "amazonlinux-2", image = "amazonlinux:2" },
+    { name = "rockylinux-9", image = "rockylinux:9" },
+    { name = "almalinux-9", image = "almalinux:9" },
+    { name = "oraclelinux-9", image = "oraclelinux:9" },
+    { name = "alpine-319", image = "alpine:3.19" },
+    { name = "python-312", image = "python:3.12" },
+    { name = "python-311", image = "python:3.11" },
+    { name = "node-20", image = "node:20" },
+    { name = "node-22", image = "node:22" },
+    { name = "ruby-33", image = "ruby:3.3" },
+  ]
+}

--- a/tests/integration/oom-stress/terraform/versions.tf
+++ b/tests/integration/oom-stress/terraform/versions.tf
@@ -1,0 +1,24 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    mondoo = {
+      source  = "mondoohq/mondoo"
+      version = ">= 0.19"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}
+
+provider "mondoo" {}
+
+provider "kubernetes" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kubeconfig_context
+}

--- a/tests/integration/oom-stress/validate.sh
+++ b/tests/integration/oom-stress/validate.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Validate OOM stress test: wait for a scan job, follow it, report outcome.
+#
+# Exit codes:
+#   0 — scan completed successfully
+#   1 — scan was OOM-killed
+#   2 — scan failed (non-OOM)
+#   3 — timeout / no job appeared
+#
+# Usage:
+#   ./validate.sh                    # wait for next scheduled job
+#   ./validate.sh --trigger          # delete old jobs, wait for fresh scheduled run
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-mondoo-operator}"
+CRONJOB="mondoo-container-scan-oom-stress-test"
+LABEL="app=mondoo-container-scan,mondoo_cr=oom-stress-test"
+TIMEOUT="${OOM_STRESS_TIMEOUT:-900}"
+POLL=5
+
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+warn() { echo "[$(date '+%H:%M:%S')] WARNING: $*"; }
+fail() { echo "[$(date '+%H:%M:%S')] FAIL: $*"; }
+pass() { echo "[$(date '+%H:%M:%S')] PASS: $*"; }
+
+list_pods() {
+  kubectl get pods -n "$NAMESPACE" -l "$LABEL" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true
+}
+
+# --- pre-flight ---
+
+if ! kubectl get cronjob "$CRONJOB" -n "$NAMESPACE" &>/dev/null; then
+  fail "CronJob $CRONJOB not found in $NAMESPACE. Run terraform apply first."
+  exit 3
+fi
+
+if [[ "${1:-}" == "--trigger" ]]; then
+  log "Deleting old scan jobs and waiting for pods to drain..."
+  kubectl delete jobs -n "$NAMESPACE" -l "mondoo_cr=oom-stress-test" --ignore-not-found 2>/dev/null
+  # wait for pods from deleted jobs to actually disappear
+  for i in $(seq 1 30); do
+    remaining=$(list_pods | grep -c . || true)
+    if (( remaining == 0 )); then break; fi
+    sleep 1
+  done
+fi
+
+# snapshot any pods that still exist — we'll ignore these
+EXISTING_PODS=$(list_pods)
+
+log "Waiting for a new scan pod (timeout ${TIMEOUT}s)..."
+schedule=$(kubectl get cronjob "$CRONJOB" -n "$NAMESPACE" -o jsonpath='{.spec.schedule}' 2>/dev/null || true)
+[[ -n "$schedule" ]] && log "CronJob schedule: $schedule"
+
+START=$(date +%s)
+POD=""
+
+while true; do
+  elapsed=$(( $(date +%s) - START ))
+  if (( elapsed > TIMEOUT )); then
+    fail "No new scan pod appeared within ${TIMEOUT}s"
+    exit 3
+  fi
+
+  while IFS= read -r p_name; do
+    [[ -z "$p_name" ]] && continue
+    if echo "$EXISTING_PODS" | grep -qxF "$p_name" 2>/dev/null; then
+      continue
+    fi
+    POD="$p_name"
+    break
+  done < <(list_pods)
+
+  if [[ -n "$POD" ]]; then
+    phase=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    log "Found pod $POD ($phase)"
+    break
+  fi
+
+  printf "\r  waiting for CronJob to fire... (%ds)" "$elapsed"
+  sleep "$POLL"
+done
+
+echo ""
+
+# --- follow the pod ---
+
+log "Following pod $POD..."
+prev_uploaded=0
+
+while true; do
+  elapsed=$(( $(date +%s) - START ))
+  if (( elapsed > TIMEOUT )); then
+    fail "Pod still running after ${TIMEOUT}s"
+    exit 3
+  fi
+
+  phase=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+
+  reason=$(kubectl get pod "$POD" -n "$NAMESPACE" \
+    -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' 2>/dev/null || true)
+  exit_code=$(kubectl get pod "$POD" -n "$NAMESPACE" \
+    -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+
+  uploaded=$(kubectl logs "$POD" -n "$NAMESPACE" 2>/dev/null \
+    | grep -c 'successfully uploaded' || true)
+  uploaded=$(( ${uploaded:-0} + 0 ))
+
+  if (( uploaded > prev_uploaded )); then
+    log "  scanned $uploaded image(s)..."
+    prev_uploaded=$uploaded
+  fi
+
+  # --- terminal states ---
+
+  if [[ "$reason" == "OOMKilled" || "$exit_code" == "137" ]]; then
+    echo ""
+    echo "════════════════════════════════════════"
+    fail "Scanner was OOM-killed after $uploaded image(s) (${elapsed}s)"
+    echo "  pod:    $POD"
+    echo "  reason: ${reason:-exit 137}"
+    echo "  limit:  $(kubectl get pod "$POD" -n "$NAMESPACE" \
+      -o jsonpath='{.spec.containers[0].resources.limits.memory}' 2>/dev/null || echo '?')"
+    echo "════════════════════════════════════════"
+    echo ""
+    log "Last 10 log lines:"
+    kubectl logs "$POD" -n "$NAMESPACE" --tail=10 2>/dev/null || true
+    exit 1
+  fi
+
+  if [[ "$phase" == "Succeeded" ]]; then
+    echo ""
+    echo "════════════════════════════════════════"
+    pass "Scan completed successfully — $uploaded image(s) in ${elapsed}s"
+    echo "════════════════════════════════════════"
+    exit 0
+  fi
+
+  if [[ "$phase" == "Failed" ]]; then
+    # cnspec exits 1 for both policy violations AND fatal errors —
+    # check logs to distinguish
+    has_ftl=$(kubectl logs "$POD" -n "$NAMESPACE" 2>/dev/null \
+      | grep -c 'FTL\|could not find an asset' || true)
+    has_ftl=$(( ${has_ftl:-0} + 0 ))
+    if [[ "$exit_code" == "1" ]] && (( has_ftl == 0 )) && (( uploaded > 0 )); then
+      echo ""
+      echo "════════════════════════════════════════"
+      pass "Scan completed with findings — $uploaded image(s) in ${elapsed}s"
+      echo "════════════════════════════════════════"
+      exit 0
+    fi
+    echo ""
+    echo "════════════════════════════════════════"
+    warn "Scan failed (not OOM) after $uploaded image(s) (${elapsed}s)"
+    echo "  pod:    $POD"
+    echo "  reason: ${reason:-unknown}"
+    echo "  exit:   ${exit_code:-?}"
+    echo "════════════════════════════════════════"
+    echo ""
+    log "Last 15 log lines:"
+    kubectl logs "$POD" -n "$NAMESPACE" --tail=15 2>/dev/null || true
+    exit 2
+  fi
+
+  sleep "$POLL"
+done

--- a/tests/integration/oom_stress_test.go
+++ b/tests/integration/oom_stress_test.go
@@ -1,0 +1,396 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mondoov2 "go.mondoo.com/mondoo-operator/api/v1alpha2"
+	"go.mondoo.com/mondoo-operator/controllers/container_image"
+	"go.mondoo.com/mondoo-operator/tests/framework/utils"
+)
+
+const (
+	oomStressNamespace = "oom-stress-targets"
+
+	// How long to wait for the scan pod to start and either OOM or complete.
+	oomStressTimeout = 25 * time.Minute
+
+	// Poll interval for checking pod status.
+	oomStressPollInterval = 5 * time.Second
+)
+
+// stressImage is a public container image with a real package manager.
+// These are chosen to maximize the number of packages discovered per image,
+// which increases heap pressure in the scanner process.
+type stressImage struct {
+	name  string
+	image string
+}
+
+var defaultStressImages = []stressImage{
+	{name: "ubuntu-2404", image: "ubuntu:24.04"},
+	{name: "ubuntu-2204", image: "ubuntu:22.04"},
+	{name: "ubuntu-2004", image: "ubuntu:20.04"},
+	{name: "debian-12", image: "debian:12"},
+	{name: "debian-11", image: "debian:11"},
+	{name: "fedora-40", image: "fedora:40"},
+	{name: "fedora-39", image: "fedora:39"},
+	{name: "amazonlinux-2023", image: "amazonlinux:2023"},
+	{name: "amazonlinux-2", image: "amazonlinux:2"},
+	{name: "rockylinux-9", image: "rockylinux:9"},
+	{name: "almalinux-9", image: "almalinux:9"},
+	{name: "oraclelinux-9", image: "oraclelinux:9"},
+	{name: "alpine-319", image: "alpine:3.19"},
+	{name: "python-312", image: "python:3.12"},
+	{name: "python-311", image: "python:3.11"},
+	{name: "node-20", image: "node:20"},
+	{name: "node-22", image: "node:22"},
+	{name: "ruby-33", image: "ruby:3.3"},
+}
+
+// OOMStressSuite reproduces the OOM condition observed in SVA's container
+// image scanning. It deploys many distinct, package-heavy images and runs
+// a container image scan with reduced memory limits. The test asserts that
+// the scan pod is OOM-killed, confirming the memory accumulation issue.
+//
+// This suite embeds AuditConfigBaseSuite so it can be trivially patched into
+// the main integration test flow later. It uses the same K8sHelper, installer,
+// and log-gathering infrastructure.
+//
+// Run with: go test -v -timeout 30m -run TestOOMStressSuite ./tests/integration/
+// Requires: OOM_STRESS_TEST=1 env var (skipped otherwise to avoid accidental runs)
+type OOMStressSuite struct {
+	AuditConfigBaseSuite
+	targetNamespaceCreated bool
+}
+
+func (s *OOMStressSuite) SetupSuite() {
+	s.AuditConfigBaseSuite.SetupSuite()
+	s.testCluster.Settings.SuiteName = "OOMStressSuite"
+}
+
+func (s *OOMStressSuite) TearDownSuite() {
+	s.cleanupTargetNamespace()
+	s.AuditConfigBaseSuite.TearDownSuite()
+}
+
+func (s *OOMStressSuite) AfterTest(suiteName, testName string) {
+	s.AuditConfigBaseSuite.AfterTest(suiteName, testName)
+	s.cleanupTargetNamespace()
+}
+
+func (s *OOMStressSuite) cleanupTargetNamespace() {
+	if !s.targetNamespaceCreated {
+		return
+	}
+	ctx := context.Background()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: oomStressNamespace}}
+	if err := s.testCluster.K8sHelper.Clientset.Delete(ctx, ns); err != nil {
+		zap.S().Warnf("Failed to delete stress test namespace: %v", err)
+	}
+	s.targetNamespaceCreated = false
+}
+
+// deployStressTargets creates the target namespace and deploys pods with
+// distinct package-heavy images for the scanner to discover.
+func (s *OOMStressSuite) deployStressTargets(images []stressImage) {
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: oomStressNamespace}}
+	s.Require().NoError(s.testCluster.K8sHelper.Clientset.Create(ctx, ns), "Failed to create stress target namespace")
+	s.targetNamespaceCreated = true
+
+	for _, img := range images {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      img.name,
+				Namespace: oomStressNamespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":    img.name,
+					"app.kubernetes.io/part-of": "oom-stress-test",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:    "target",
+					Image:   img.image,
+					Command: []string{"sleep", "infinity"},
+				}},
+			},
+		}
+		s.Require().NoErrorf(
+			s.testCluster.K8sHelper.Clientset.Create(ctx, pod),
+			"Failed to create stress target pod %s", img.name)
+	}
+
+	zap.S().Infof("Deployed %d stress target pods, waiting for them to be ready...", len(images))
+
+	allReady := s.testCluster.K8sHelper.IsPodReady(
+		"app.kubernetes.io/part-of=oom-stress-test", oomStressNamespace)
+	s.Require().True(allReady, "Not all stress target pods became ready")
+
+	zap.S().Info("All stress target pods are ready.")
+}
+
+// oomStressAuditConfig returns a MondooAuditConfig configured for the stress
+// test: container scanning enabled with reduced memory limits, targeting the
+// stress namespace.
+func (s *OOMStressSuite) oomStressAuditConfig(memoryLimit string) mondoov2.MondooAuditConfig {
+	auditConfig := utils.DefaultAuditConfigMinimal(s.testCluster.Settings.Namespace, false, true, false)
+
+	auditConfig.Spec.Containers.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(memoryLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+
+	// Only scan the stress namespace — exclude everything else so we control
+	// exactly which images are scanned.
+	auditConfig.Spec.Filtering.Namespaces.Include = []string{oomStressNamespace}
+
+	return auditConfig
+}
+
+// waitForScanPodTermination waits for the container scan Job's pod to reach a
+// terminal state (Succeeded, Failed, or OOMKilled). Returns the terminal pod.
+func (s *OOMStressSuite) waitForScanPodTermination(auditConfig mondoov2.MondooAuditConfig) *corev1.Pod {
+	ctx := context.Background()
+	cronJobLabels := container_image.CronJobLabels(auditConfig)
+	listOpts := &client.ListOptions{
+		Namespace:     auditConfig.Namespace,
+		LabelSelector: labels.SelectorFromSet(cronJobLabels),
+	}
+
+	deadline := time.Now().Add(oomStressTimeout)
+	var lastPod *corev1.Pod
+
+	for time.Now().Before(deadline) {
+		podList := &corev1.PodList{}
+		if err := s.testCluster.K8sHelper.Clientset.List(ctx, podList, listOpts); err != nil {
+			zap.S().Warnf("Failed to list scan pods: %v", err)
+			time.Sleep(oomStressPollInterval)
+			continue
+		}
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			lastPod = pod
+
+			switch pod.Status.Phase {
+			case corev1.PodSucceeded:
+				return pod
+			case corev1.PodFailed:
+				return pod
+			case corev1.PodRunning:
+				// Check for OOMKilled containers that haven't caused pod failure yet
+				for _, cs := range pod.Status.ContainerStatuses {
+					if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+						return pod
+					}
+					if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+						return pod
+					}
+				}
+			}
+		}
+		time.Sleep(oomStressPollInterval)
+	}
+
+	if lastPod != nil {
+		return lastPod
+	}
+	s.Fail("Timed out waiting for scan pod to appear")
+	return nil
+}
+
+// isOOMKilled checks whether any container in the pod was OOM-killed.
+func isOOMKilled(pod *corev1.Pod) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+			return true
+		}
+		if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+			return true
+		}
+	}
+	// Also check exit code 137 (SIGKILL from cgroup OOM)
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 137 {
+			return true
+		}
+	}
+	return false
+}
+
+// collectScanLogs retrieves logs from the scan pod for analysis.
+func (s *OOMStressSuite) collectScanLogs(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	logs, err := s.testCluster.K8sHelper.Kubectl(
+		"logs", "-n", pod.Namespace, pod.Name, "--tail=500")
+	if err != nil {
+		zap.S().Warnf("Failed to collect scan pod logs: %v", err)
+		return ""
+	}
+	return logs
+}
+
+func countCompletedImages(logs string) int {
+	return strings.Count(logs, "successfully uploaded")
+}
+
+// TestContainerScan_OOMUnderMemoryPressure is the main stress test.
+// It deploys 18 package-heavy container images, runs a scan with a 512Mi
+// memory limit, and asserts the scan pod is OOM-killed.
+func (s *OOMStressSuite) TestContainerScan_OOMUnderMemoryPressure() {
+	memoryLimit := envOrDefault("OOM_STRESS_MEMORY_LIMIT", "512Mi")
+
+	zap.S().Infof("Starting OOM stress test with memory limit %s and %d images", memoryLimit, len(defaultStressImages))
+
+	// 1. Deploy target pods with package-heavy images
+	s.deployStressTargets(defaultStressImages)
+
+	// 2. Create audit config with reduced memory
+	auditConfig := s.oomStressAuditConfig(memoryLimit)
+	s.auditConfig = auditConfig
+
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	zap.S().Info("Creating MondooAuditConfig for stress test...")
+	s.Require().NoError(
+		s.testCluster.K8sHelper.Clientset.Create(context.Background(), &auditConfig),
+		"Failed to create MondooAuditConfig")
+
+	// 3. Wait for the CronJob to be created
+	zap.S().Info("Waiting for container scan CronJob...")
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      container_image.CronJobName(auditConfig.Name),
+			Namespace: auditConfig.Namespace,
+		},
+	}
+	err := s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		if err := s.testCluster.K8sHelper.Clientset.Get(
+			context.Background(), client.ObjectKeyFromObject(cronJob), cronJob); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	s.Require().NoError(err, "Container scan CronJob was not created")
+
+	// 4. Wait for scan pod to terminate (OOM or complete)
+	zap.S().Info("Waiting for scan pod to terminate...")
+	pod := s.waitForScanPodTermination(auditConfig)
+	s.Require().NotNil(pod, "Scan pod never appeared")
+
+	// 5. Collect and log results
+	logs := s.collectScanLogs(pod)
+	imagesCompleted := countCompletedImages(logs)
+
+	zap.S().Infof("Scan pod terminated. Phase: %s, OOMKilled: %v, Images completed: %d/%d",
+		pod.Status.Phase, isOOMKilled(pod), imagesCompleted, len(defaultStressImages))
+
+	// Log container statuses for debugging
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil {
+			zap.S().Infof("Container %s: reason=%s, exitCode=%d",
+				cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
+		}
+	}
+
+	// 6. Assert OOM
+	s.True(isOOMKilled(pod),
+		fmt.Sprintf("Expected scan pod to be OOM-killed, but pod phase is %s. "+
+			"The scanner completed %d/%d images without running out of memory. "+
+			"Try lowering OOM_STRESS_MEMORY_LIMIT (currently %s) or adding more images.",
+			pod.Status.Phase, imagesCompleted, len(defaultStressImages), memoryLimit))
+
+	s.Less(imagesCompleted, len(defaultStressImages),
+		"Scanner should not complete all images before OOM")
+
+	zap.S().Infof("OOM stress test passed: scanner OOM-killed after %d/%d images at %s memory limit",
+		imagesCompleted, len(defaultStressImages), memoryLimit)
+}
+
+// TestContainerScan_CompletesWithAdequateMemory is the inverse test.
+// Same images, but with 4Gi memory — the scan should complete successfully.
+// This confirms the fix path: increasing memory resolves the OOM.
+func (s *OOMStressSuite) TestContainerScan_CompletesWithAdequateMemory() {
+	if os.Getenv("OOM_STRESS_FULL") != "1" {
+		s.T().Skip("Skipping adequate-memory test (set OOM_STRESS_FULL=1 to run)")
+	}
+
+	memoryLimit := envOrDefault("OOM_STRESS_ADEQUATE_MEMORY", "4Gi")
+
+	zap.S().Infof("Starting adequate-memory test with %s limit and %d images", memoryLimit, len(defaultStressImages))
+
+	s.deployStressTargets(defaultStressImages)
+
+	auditConfig := s.oomStressAuditConfig(memoryLimit)
+	s.auditConfig = auditConfig
+
+	cleanup := s.disableContainerImageResolution()
+	defer cleanup()
+
+	s.Require().NoError(
+		s.testCluster.K8sHelper.Clientset.Create(context.Background(), &auditConfig),
+		"Failed to create MondooAuditConfig")
+
+	cronJobLabels := container_image.CronJobLabels(auditConfig)
+	s.True(
+		s.testCluster.K8sHelper.WaitUntilCronJobsSuccessful(
+			utils.LabelsToLabelSelector(cronJobLabels), auditConfig.Namespace),
+		"Container scan should complete successfully with adequate memory")
+
+	zap.S().Infof("Adequate-memory test passed: scanner completed all images at %s", memoryLimit)
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func TestOOMStressSuite(t *testing.T) {
+	if os.Getenv("OOM_STRESS_TEST") != "1" {
+		t.Skip("OOM stress test skipped (set OOM_STRESS_TEST=1 to run)")
+	}
+
+	s := new(OOMStressSuite)
+	defer func(s *OOMStressSuite) {
+		HandlePanics(recover(), func() {
+			if err := s.testCluster.UninstallOperator(); err != nil {
+				zap.S().Errorf("Failed to uninstall Mondoo operator. %v", err)
+			}
+			if s.spaceClient != nil {
+				if err := s.spaceClient.Delete(s.ctx); err != nil {
+					zap.S().Errorf("Failed to delete Mondoo space. %v", err)
+				}
+			}
+		}, s.T)
+	}(s)
+	suite.Run(t, s)
+}


### PR DESCRIPTION
- Introduced `run.sh` script to manage OOM stress test lifecycle (apply, watch, destroy).
- Created Terraform configuration for Kubernetes resources including namespaces, pods, and MondooAuditConfig.
- Implemented validation script `validate.sh` to monitor scan job outcomes.
- Developed integration tests in `oom_stress_test.go` to verify OOM conditions and successful scans.
- Added necessary Terraform variables and outputs for configuration management.
- Included example Terraform variable file for user setup.
- Established `.gitignore` for Terraform state files and directories.