### PR TITLE
fix: use inventory-file for node scanner

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
+	"go.mondoo.com/mondoo-operator/pkg/constants"
 	"go.mondoo.com/mondoo-operator/pkg/utils/k8s"
 	logutils "go.mondoo.com/mondoo-operator/pkg/utils/logger"
 	"go.mondoo.com/mondoo-operator/pkg/utils/mondoo"
@@ -91,6 +92,11 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		n.log().Error(err, "Failed to resolve mondoo-client container image")
 		return err
 	}
+	renderImage, err := n.ContainerImageResolver.ContainerImage(ctx, constants.BusyBoxImage, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+	if err != nil {
+		logger.Error(err, "Failed to resolve node inventory render container image")
+		return err
+	}
 
 	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
@@ -125,7 +131,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			return err
 		}
 
-		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
+		desired := CronJob(mondooClientImage, renderImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
 		cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
 		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cronJob, n.Mondoo, n.log(), func() error {
 			k8s.UpdateCronJobFields(cronJob, desired)
@@ -197,6 +203,11 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		n.log().Error(err, "Failed to resolve mondoo-client container image")
 		return err
 	}
+	renderImage, err := n.ContainerImageResolver.ContainerImage(ctx, constants.BusyBoxImage, n.MondooOperatorConfig.Spec.SkipContainerResolution)
+	if err != nil {
+		logger.Error(err, "Failed to resolve node inventory render container image")
+		return err
+	}
 
 	clusterUid, err := k8s.GetClusterUID(ctx, n.KubeClient, n.log())
 	if err != nil {
@@ -250,7 +261,7 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 	tolerationList := slices.Collect(maps.Keys(tolerations))
 	k8s.SortTolerations(tolerationList)
 
-	desired := DaemonSet(*n.Mondoo, n.IsOpenshift, mondooClientImage, *n.MondooOperatorConfig, tolerationList)
+	desired := DaemonSet(*n.Mondoo, n.IsOpenshift, mondooClientImage, renderImage, *n.MondooOperatorConfig, tolerationList)
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
 	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, ds, n.Mondoo, n.log(), func() error {
 		k8s.UpdateDaemonSetFields(ds, desired)

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -242,7 +243,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, constants.BusyBoxImage, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -252,6 +253,40 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 	// Verify node garbage collection cronjob does not exist (removed in simplification)
 	gcCj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: GarbageCollectCronJobName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.Error(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(gcCj), gcCj))
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_CronJobUsesResolvedRenderImage() {
+	s.seedNodes()
+	d := s.createDeploymentHandler()
+	d.MondooOperatorConfig = &v1alpha2.MondooOperatorConfig{Spec: v1alpha2.MondooOperatorConfigSpec{
+		SkipContainerResolution: true,
+	}}
+	d.ContainerImageResolver = &fakeMondoo.ContainerImageResolverMock{
+		CnspecImageFunc: func(userImage, userTag, userDigest string, skipResolveImage bool) (string, error) {
+			return "registry.example.com/cnspec:13-rootless", nil
+		},
+		ContainerImageFunc: func(ctx context.Context, image string, skipResolveImage bool) (string, error) {
+			s.Equal(constants.BusyBoxImage, image)
+			s.True(skipResolveImage)
+			return "registry.example.com/dockerhub/library/busybox:1.36", nil
+		},
+	}
+
+	mondooAuditConfig := &s.auditConfig
+	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	nodes := &corev1.NodeList{}
+	s.NoError(d.KubeClient.List(s.ctx, nodes))
+	for _, n := range nodes.Items {
+		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
+		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
+		s.Len(cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers, 1)
+		s.Equal("registry.example.com/dockerhub/library/busybox:1.36", cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers[0].Image)
+	}
 }
 
 func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_CustomEnvVars() {
@@ -276,7 +311,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_CustomEnvVars() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, constants.BusyBoxImage, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -309,7 +344,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_Switch() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, constants.BusyBoxImage, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -349,7 +384,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.NoError(err)
 
 	// Make sure a cron job exists for one of the nodes
-	cj := CronJob(image, nodes.Items[1], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob(image, constants.BusyBoxImage, nodes.Items[1], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 	cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, cj))
 
@@ -361,7 +396,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, constants.BusyBoxImage, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -407,7 +442,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, nodes.Items[0].Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-	cjExpected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	cjExpected := CronJob(image, constants.BusyBoxImage, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
 	// Make sure the env vars for both are sorted
 	utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 	utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -435,7 +470,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets() {
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(ds), ds))
 
-	dsExpected := DaemonSet(s.auditConfig, false, image, v1alpha2.MondooOperatorConfig{},
+	dsExpected := DaemonSet(s.auditConfig, false, image, constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{},
 		[]corev1.Toleration{{Key: "node-role.kubernetes.io/master", Value: "true", Effect: corev1.TaintEffectNoExecute}})
 	// Make sure the env vars for both are sorted
 	utils.SortEnvVars(dsExpected.Spec.Template.Spec.Containers[0].Env)
@@ -468,7 +503,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_Switch() {
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(ds), ds))
 
-	dsExpected := DaemonSet(s.auditConfig, false, image, v1alpha2.MondooOperatorConfig{},
+	dsExpected := DaemonSet(s.auditConfig, false, image, constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{},
 		[]corev1.Toleration{{Key: "node-role.kubernetes.io/master", Value: "true", Effect: corev1.TaintEffectNoExecute}})
 	s.Equal(dsExpected.Spec, ds.Spec)
 
@@ -506,7 +541,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateDaemonSets() {
 	s.NoError(err)
 
 	// Make sure a daemonset exists
-	ds := DaemonSet(s.auditConfig, false, image, v1alpha2.MondooOperatorConfig{}, nil)
+	ds := DaemonSet(s.auditConfig, false, image, constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
 	ds.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, ds))
 
@@ -517,7 +552,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateDaemonSets() {
 	ds = &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(ds), ds))
 
-	depExpected := DaemonSet(s.auditConfig, false, image, v1alpha2.MondooOperatorConfig{},
+	depExpected := DaemonSet(s.auditConfig, false, image, constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{},
 		[]corev1.Toleration{{Key: "node-role.kubernetes.io/master", Value: "true", Effect: corev1.TaintEffectNoExecute}})
 	s.Equal(depExpected.Spec, ds.Spec)
 }
@@ -853,8 +888,9 @@ func (s *DeploymentHandlerSuite) TestReconcile_Deployment_CustomInterval() {
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(s.auditConfig.Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(ds), ds))
 
-	s.Contains(ds.Spec.Template.Spec.Containers[0].Command, "--timer")
-	s.Contains(ds.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("%d", s.auditConfig.Spec.Nodes.IntervalTimer))
+	command := strings.Join(ds.Spec.Template.Spec.Containers[0].Command, " ")
+	s.Contains(command, "--timer")
+	s.Contains(command, fmt.Sprintf("%d", s.auditConfig.Spec.Nodes.IntervalTimer))
 }
 
 func (s *DeploymentHandlerSuite) TestGarbageCollection_RunsAfterSuccessfulScan() {

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -7,10 +7,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
@@ -35,16 +37,19 @@ const (
 
 	ignoreQueryAnnotationPrefix = "policies.k8s.mondoo.com/"
 
-	ignoreAnnotationValue = "ignore"
+	ignoreAnnotationValue            = "ignore"
+	nodeInventoryTemplatePath        = "/etc/opt/mondoo/inventory_template.yml"
+	nodeInventoryRenderedPath        = "/tmp/mondoo-node-inventory.yml"
+	nodeInventoryNodeNamePlaceholder = "__MONDOO_NODE_NAME__"
 )
 
 // CronJob creates a CronJob for node scanning
-func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
+func CronJob(image, renderImage string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
 	ls := NodeScanningLabels(*m)
 	cmd := []string{
 		"cnspec", "scan", "local",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
-		"--inventory-template", "/etc/opt/mondoo/inventory_template.yml",
+		"--inventory-file", nodeInventoryRenderedPath,
 		"--report-type", "none",
 	}
 
@@ -102,6 +107,9 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 							// The node scanning does not use the Kubernetes API at all, therefore the service account token
 							// should not be mounted at all.
 							AutomountServiceAccountToken: ptr.To(false),
+							InitContainers: []corev1.Container{
+								renderNodeInventoryInitContainer(node.Name, renderImage),
+							},
 							Containers: []corev1.Container{
 								{
 									Image:     image,
@@ -188,12 +196,12 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 }
 
 // DaemonSet creates a DaemonSet for node scanning
-func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg v1alpha2.MondooOperatorConfig, tolerations []corev1.Toleration) *appsv1.DaemonSet {
+func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image, renderImage string, cfg v1alpha2.MondooOperatorConfig, tolerations []corev1.Toleration) *appsv1.DaemonSet {
 	labels := NodeScanningLabels(m)
 	cmd := []string{
 		"cnspec", "serve",
 		"--config", "/etc/opt/mondoo/mondoo.yml",
-		"--inventory-template", "/etc/opt/mondoo/inventory_template.yml",
+		"--inventory-file", nodeInventoryRenderedPath,
 		"--timer", fmt.Sprintf("%d", m.Spec.Nodes.IntervalTimer),
 	}
 	// Add API proxy if configured (respect SkipProxyForCnspec since node scanning uses cnspec)
@@ -235,6 +243,9 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 					// should not be mounted at all.
 					AutomountServiceAccountToken: ptr.To(false),
 					Tolerations:                  tolerations,
+					InitContainers: []corev1.Container{
+						renderNodeInventoryInitContainer("", renderImage),
+					},
 					Containers: []corev1.Container{
 						{
 							Image:     image,
@@ -391,12 +402,12 @@ func Inventory(integrationMRN, clusterUID string, m v1alpha2.MondooAuditConfig) 
 			Assets: []*inventory.Asset{
 				{
 					Id:   "host",
-					Name: `{{ getenv "NODE_NAME" }}`,
+					Name: nodeInventoryNodeNamePlaceholder,
 					Connections: []*inventory.Config{
 						{
 							Type:       "filesystem",
 							Host:       "/mnt/host",
-							PlatformId: fmt.Sprintf(`{{ printf "//platformid.api.mondoo.app/runtime/k8s/uid/%%s/node/%%s" "%s" (getenv "NODE_NAME")}}`, clusterUID),
+							PlatformId: fmt.Sprintf("//platformid.api.mondoo.app/runtime/k8s/uid/%s/node/%s", clusterUID, nodeInventoryNodeNamePlaceholder),
 						},
 					},
 					Labels: map[string]string{
@@ -431,6 +442,60 @@ func Inventory(integrationMRN, clusterUID string, m v1alpha2.MondooAuditConfig) 
 	}
 
 	return string(invBytes), nil
+}
+
+func renderNodeInventoryInitContainer(nodeName, image string) corev1.Container {
+	render := fmt.Sprintf("sed \"s#%s#${NODE_NAME}#g\" %s > %s",
+		nodeInventoryNodeNamePlaceholder,
+		shellQuote(nodeInventoryTemplatePath),
+		shellQuote(nodeInventoryRenderedPath),
+	)
+	env := []corev1.EnvVar{{
+		Name: "NODE_NAME",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	}}
+	if nodeName != "" {
+		env[0].ValueFrom = nil
+		env[0].Value = nodeName
+	}
+
+	return corev1.Container{
+		Name:            "render-node-inventory",
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"/bin/sh", "-ec", render},
+		Env:             env,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			RunAsNonRoot:             ptr.To(true),
+			RunAsUser:                ptr.To(int64(65532)),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "config", ReadOnly: true, MountPath: "/etc/opt/"},
+			{Name: "temp", MountPath: "/tmp"},
+		},
+	}
+}
+
+func shellQuote(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
 }
 
 func NodeScanningLabels(m v1alpha2.MondooAuditConfig) map[string]string {

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -120,7 +120,7 @@ func TestResources(t *testing.T) {
 				},
 			}
 			mac := test.mondooauditconfig()
-			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+			cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 			assert.Equal(t, test.expectedResources, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 		})
 	}
@@ -131,7 +131,7 @@ func TestCronJob_HasReportTypeNone(t *testing.T) {
 	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
 	cfg := v1alpha2.MondooOperatorConfig{}
 
-	cj := CronJob("test-image:latest", node, m, false, cfg)
+	cj := CronJob("test-image:latest", constants.BusyBoxImage, node, m, false, cfg)
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmd := strings.Join(container.Command, " ")
@@ -187,7 +187,7 @@ func TestResources_GOMEMLIMIT(t *testing.T) {
 				},
 			}
 			mac := test.mondooauditconfig()
-			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+			cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 			goMemLimitEnv := corev1.EnvVar{}
 			for _, env := range cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env {
 				if env.Name == "GOMEMLIMIT" {
@@ -202,7 +202,7 @@ func TestResources_GOMEMLIMIT(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mac := *test.mondooauditconfig()
-			ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+			ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
 			goMemLimitEnv := corev1.EnvVar{}
 			for _, env := range ds.Spec.Template.Spec.Containers[0].Env {
 				if env.Name == "GOMEMLIMIT" {
@@ -222,7 +222,7 @@ func TestCronJob_PrivilegedOpenshift(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cj := CronJob("test123", testNode, mac, true, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, true, v1alpha2.MondooOperatorConfig{})
 	sc := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext
 	assert.True(t, *sc.Privileged)
 	assert.True(t, *sc.AllowPrivilegeEscalation)
@@ -236,7 +236,7 @@ func TestCronJob_Privileged(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 	sc := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext
 	assert.False(t, *sc.Privileged)
 	assert.False(t, *sc.AllowPrivilegeEscalation)
@@ -265,7 +265,7 @@ func TestCronJob_JobOverrides(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 
 	// User labels are applied
@@ -312,7 +312,7 @@ func TestDaemonSet_Capabilities(t *testing.T) {
 	mac := testMondooAuditConfig()
 
 	t.Run("non-OpenShift adds proc capabilities", func(t *testing.T) {
-		ds := DaemonSet(*mac, false, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+		ds := DaemonSet(*mac, false, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
 		sc := ds.Spec.Template.Spec.Containers[0].SecurityContext
 		assert.False(t, *sc.Privileged)
 		assert.Contains(t, sc.Capabilities.Add, corev1.Capability("DAC_READ_SEARCH"))
@@ -321,7 +321,7 @@ func TestDaemonSet_Capabilities(t *testing.T) {
 	})
 
 	t.Run("OpenShift runs privileged without extra capabilities", func(t *testing.T) {
-		ds := DaemonSet(*mac, true, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+		ds := DaemonSet(*mac, true, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
 		sc := ds.Spec.Template.Spec.Containers[0].SecurityContext
 		assert.True(t, *sc.Privileged)
 		assert.Empty(t, sc.Capabilities.Add)
@@ -416,6 +416,9 @@ func TestInventory(t *testing.T) {
 	inventory, err := Inventory("", testClusterUID, auditConfig)
 	assert.NoError(t, err, "unexpected error generating inventory")
 	assert.NotContains(t, inventory, constants.MondooAssetsIntegrationLabel)
+	assert.NotContains(t, inventory, "{{")
+	assert.Contains(t, inventory, nodeInventoryNodeNamePlaceholder)
+	assert.Contains(t, inventory, fmt.Sprintf("//platformid.api.mondoo.app/runtime/k8s/uid/%s/node/%s", testClusterUID, nodeInventoryNodeNamePlaceholder))
 
 	const integrationMRN = "//test-MRN"
 	inventory, err = Inventory(integrationMRN, testClusterUID, auditConfig)
@@ -458,7 +461,7 @@ func TestCronJob_WithProxy(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, cfg)
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -468,6 +471,35 @@ func TestCronJob_WithProxy(t *testing.T) {
 	envMap := envToMap(container.Env)
 	assert.Equal(t, "http://proxy:8080", envMap["HTTP_PROXY"])
 	assert.Equal(t, "https://proxy:8443", envMap["HTTPS_PROXY"])
+}
+
+func TestCronJob_UsesInventoryFileFlag(t *testing.T) {
+	testNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-name"}}
+	mac := testMondooAuditConfig()
+
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	mainCommand := strings.Join(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command, " ")
+
+	assert.Contains(t, mainCommand, "cnspec scan local")
+	assert.Contains(t, mainCommand, "--inventory-file")
+	assert.Contains(t, mainCommand, nodeInventoryRenderedPath)
+	assert.NotContains(t, mainCommand, "/bin/sh")
+	assert.NotContains(t, mainCommand, "sed")
+	assert.NotContains(t, mainCommand, "--inventory-template")
+
+	initContainers := cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers
+	require.Len(t, initContainers, 1)
+	init := initContainers[0]
+	assert.Equal(t, "render-node-inventory", init.Name)
+	assert.Equal(t, constants.BusyBoxImage, init.Image)
+	initCommand := strings.Join(init.Command, " ")
+	assert.Contains(t, initCommand, "/bin/sh -ec")
+	assert.Contains(t, initCommand, "sed")
+	assert.Contains(t, initCommand, nodeInventoryNodeNamePlaceholder)
+	assert.Contains(t, initCommand, nodeInventoryTemplatePath)
+	assert.Contains(t, initCommand, nodeInventoryRenderedPath)
+	envMap := envToMap(init.Env)
+	assert.Equal(t, "test-node-name", envMap["NODE_NAME"])
 }
 
 func TestCronJob_SkipProxyForCnspec(t *testing.T) {
@@ -480,7 +512,7 @@ func TestCronJob_SkipProxyForCnspec(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, cfg)
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -502,7 +534,7 @@ func TestCronJob_WithImagePullSecrets(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, cfg)
 	secrets := cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
@@ -517,7 +549,7 @@ func TestDaemonSet_WithProxy(t *testing.T) {
 		},
 	}
 
-	ds := DaemonSet(mac, false, "test123", cfg, nil)
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, cfg, nil)
 	container := ds.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -529,6 +561,36 @@ func TestDaemonSet_WithProxy(t *testing.T) {
 	assert.Equal(t, "https://proxy:8443", envMap["HTTPS_PROXY"])
 }
 
+func TestDaemonSet_UsesInventoryFileFlag(t *testing.T) {
+	mac := *testMondooAuditConfig()
+
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
+	mainCommand := strings.Join(ds.Spec.Template.Spec.Containers[0].Command, " ")
+
+	assert.Contains(t, mainCommand, "cnspec serve")
+	assert.Contains(t, mainCommand, "--inventory-file")
+	assert.Contains(t, mainCommand, nodeInventoryRenderedPath)
+	assert.NotContains(t, mainCommand, "/bin/sh")
+	assert.NotContains(t, mainCommand, "sed")
+	assert.NotContains(t, mainCommand, "--inventory-template")
+
+	initContainers := ds.Spec.Template.Spec.InitContainers
+	require.Len(t, initContainers, 1)
+	init := initContainers[0]
+	assert.Equal(t, "render-node-inventory", init.Name)
+	assert.Equal(t, constants.BusyBoxImage, init.Image)
+	initCommand := strings.Join(init.Command, " ")
+	assert.Contains(t, initCommand, "/bin/sh -ec")
+	assert.Contains(t, initCommand, "sed")
+	assert.Contains(t, initCommand, nodeInventoryNodeNamePlaceholder)
+	assert.Contains(t, initCommand, nodeInventoryTemplatePath)
+	assert.Contains(t, initCommand, nodeInventoryRenderedPath)
+	require.Len(t, init.Env, 1)
+	require.NotNil(t, init.Env[0].ValueFrom)
+	require.NotNil(t, init.Env[0].ValueFrom.FieldRef)
+	assert.Equal(t, "spec.nodeName", init.Env[0].ValueFrom.FieldRef.FieldPath)
+}
+
 func TestDaemonSet_SkipProxyForCnspec(t *testing.T) {
 	mac := *testMondooAuditConfig()
 	cfg := v1alpha2.MondooOperatorConfig{
@@ -538,7 +600,7 @@ func TestDaemonSet_SkipProxyForCnspec(t *testing.T) {
 		},
 	}
 
-	ds := DaemonSet(mac, false, "test123", cfg, nil)
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, cfg, nil)
 	container := ds.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -559,7 +621,7 @@ func TestDaemonSet_WithImagePullSecrets(t *testing.T) {
 		},
 	}
 
-	ds := DaemonSet(mac, false, "test123", cfg, nil)
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, cfg, nil)
 	secrets := ds.Spec.Template.Spec.ImagePullSecrets
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -302,7 +302,7 @@ func TestCronJob_GlobalJobOverrides(t *testing.T) {
 		Labels:                  map[string]string{"team": "platform"},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", constants.BusyBoxImage, testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 	assert.Equal(t, "platform", cj.Spec.JobTemplate.Labels["team"])
 	assert.Equal(t, "prod", cj.Spec.JobTemplate.Labels["env"])
@@ -642,7 +642,7 @@ func TestDaemonSet_WithJobOverrides(t *testing.T) {
 		{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists},
 	}
 
-	ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, existingTolerations)
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, existingTolerations)
 
 	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, ds.Spec.Template.Spec.NodeSelector)
 	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
@@ -661,7 +661,7 @@ func TestDaemonSet_PerTypeJobOverridesOverrideGlobal(t *testing.T) {
 		NodeSelector: map[string]string{"workload-type": "node-scan"},
 	}
 
-	ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+	ds := DaemonSet(mac, false, "test123", constants.BusyBoxImage, v1alpha2.MondooOperatorConfig{}, nil)
 
 	assert.Equal(t, map[string]string{"workload-type": "node-scan"}, ds.Spec.Template.Spec.NodeSelector)
 }

--- a/controllers/status/operator_status_test.go
+++ b/controllers/status/operator_status_test.go
@@ -222,6 +222,10 @@ func (m *mockContainerImageResolver) MondooOperatorImage(_ context.Context, _, _
 	return "ghcr.io/mondoohq/mondoo-operator@sha256:def456", nil
 }
 
+func (m *mockContainerImageResolver) ContainerImage(_ context.Context, image string, _ bool) (string, error) {
+	return image, nil
+}
+
 func (m *mockContainerImageResolver) WithImageRegistry(_ string) mondooutils.ContainerImageResolver {
 	return m
 }

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1329,6 +1329,8 @@ spec:
     enable: true
 ```
 
+Node scanning pods include a lightweight `render-node-inventory` init container that renders the node-specific inventory file before `cnspec` starts. This keeps custom scanner images simple: the scanner image must provide `cnspec`, but it does not need a POSIX shell or `sed`. The init container image uses the same `imageRegistry`, `registryMirrors`, `imagePullSecrets`, and `skipContainerResolution` settings as other operator-managed images.
+
 ### Why are (some of) my nodes unscored?
 
 In some cases a node scan can require more memory than initially allotted. You can check whether that is the case by running:

--- a/pkg/constants/images.go
+++ b/pkg/constants/images.go
@@ -19,4 +19,7 @@ const (
 	// SPIFFE Helper image
 	// https://github.com/spiffe/spiffe-helper/releases
 	SPIFFEHelperImage = "ghcr.io/spiffe/spiffe-helper:0.8.0"
+
+	// BusyBox image used for lightweight init helpers.
+	BusyBoxImage = "docker.io/library/busybox:1.36"
 )

--- a/pkg/utils/k8s/registry_wif.go
+++ b/pkg/utils/k8s/registry_wif.go
@@ -142,7 +142,7 @@ echo "Docker config generated for ACR: ${ACR_LOGIN_SERVER}"
 		}
 
 	default:
-		image = "busybox:1.36"
+		image = constants.BusyBoxImage
 		shell = "/bin/sh"
 		script = `echo "ERROR: Unknown workload identity provider"; exit 1`
 		env = []corev1.EnvVar{}

--- a/pkg/utils/k8s/update_fields.go
+++ b/pkg/utils/k8s/update_fields.go
@@ -60,6 +60,7 @@ func UpdateDeploymentFields(obj, desired *appsv1.Deployment) {
 	ps.ServiceAccountName = dps.ServiceAccountName
 	ps.NodeSelector = dps.NodeSelector
 	ps.Tolerations = dps.Tolerations
+	ps.InitContainers = dps.InitContainers
 	ps.Containers = dps.Containers
 	ps.Volumes = dps.Volumes
 	ps.ImagePullSecrets = dps.ImagePullSecrets
@@ -81,6 +82,7 @@ func UpdateDaemonSetFields(obj, desired *appsv1.DaemonSet) {
 	ps.AutomountServiceAccountToken = dps.AutomountServiceAccountToken
 	ps.NodeSelector = dps.NodeSelector
 	ps.Tolerations = dps.Tolerations
+	ps.InitContainers = dps.InitContainers
 	ps.Containers = dps.Containers
 	ps.Volumes = dps.Volumes
 	ps.ImagePullSecrets = dps.ImagePullSecrets

--- a/pkg/utils/k8s/update_fields_test.go
+++ b/pkg/utils/k8s/update_fields_test.go
@@ -22,7 +22,8 @@ func TestUpdateCronJobFields_ImagePullSecrets(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{Name: "test", Image: "test:latest"}},
+							InitContainers: []corev1.Container{{Name: "init", Image: "busybox:1.36"}},
+							Containers:     []corev1.Container{{Name: "test", Image: "test:latest"}},
 							ImagePullSecrets: []corev1.LocalObjectReference{
 								{Name: "my-secret"},
 								{Name: "another-secret"},
@@ -38,6 +39,7 @@ func TestUpdateCronJobFields_ImagePullSecrets(t *testing.T) {
 	UpdateCronJobFields(obj, desired)
 
 	assert.Equal(t, desired.Spec.Schedule, obj.Spec.Schedule)
+	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.InitContainers, obj.Spec.JobTemplate.Spec.Template.Spec.InitContainers)
 	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.Containers, obj.Spec.JobTemplate.Spec.Template.Spec.Containers)
 	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets, obj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets)
 }
@@ -136,7 +138,8 @@ func TestUpdateDeploymentFields_ImagePullSecrets(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "test", Image: "test:latest"}},
+					InitContainers: []corev1.Container{{Name: "init", Image: "busybox:1.36"}},
+					Containers:     []corev1.Container{{Name: "test", Image: "test:latest"}},
 					ImagePullSecrets: []corev1.LocalObjectReference{
 						{Name: "my-secret"},
 					},
@@ -149,6 +152,7 @@ func TestUpdateDeploymentFields_ImagePullSecrets(t *testing.T) {
 	UpdateDeploymentFields(obj, desired)
 
 	assert.Equal(t, desired.Spec.Template.Spec.ImagePullSecrets, obj.Spec.Template.Spec.ImagePullSecrets)
+	assert.Equal(t, desired.Spec.Template.Spec.InitContainers, obj.Spec.Template.Spec.InitContainers)
 	assert.Equal(t, desired.Spec.Template.Spec.Containers, obj.Spec.Template.Spec.Containers)
 }
 
@@ -178,7 +182,8 @@ func TestUpdateDaemonSetFields_ImagePullSecrets(t *testing.T) {
 		Spec: appsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "test", Image: "test:latest"}},
+					InitContainers: []corev1.Container{{Name: "init", Image: "busybox:1.36"}},
+					Containers:     []corev1.Container{{Name: "test", Image: "test:latest"}},
 					ImagePullSecrets: []corev1.LocalObjectReference{
 						{Name: "my-secret"},
 					},
@@ -191,6 +196,7 @@ func TestUpdateDaemonSetFields_ImagePullSecrets(t *testing.T) {
 	UpdateDaemonSetFields(obj, desired)
 
 	assert.Equal(t, desired.Spec.Template.Spec.ImagePullSecrets, obj.Spec.Template.Spec.ImagePullSecrets)
+	assert.Equal(t, desired.Spec.Template.Spec.InitContainers, obj.Spec.Template.Spec.InitContainers)
 	assert.Equal(t, desired.Spec.Template.Spec.Containers, obj.Spec.Template.Spec.Containers)
 }
 

--- a/pkg/utils/mondoo/container_image_resolver.go
+++ b/pkg/utils/mondoo/container_image_resolver.go
@@ -49,6 +49,10 @@ type ContainerImageResolver interface {
 	// When userDigest is specified, it takes precedence over userTag.
 	MondooOperatorImage(ctx context.Context, userImage, userTag, userDigest string, skipImageResolution bool) (string, error)
 
+	// ContainerImage returns the supplied image after applying registry mirror or registry prefix settings.
+	// If skipResolveImage is false, then the image tag is replaced by a digest.
+	ContainerImage(ctx context.Context, image string, skipImageResolution bool) (string, error)
+
 	// WithImageRegistry returns a new ContainerImageResolver that uses the specified image registry prefix.
 	// Use this for simple registry mirrors where all images go to the same mirror.
 	WithImageRegistry(imageRegistry string) ContainerImageResolver
@@ -159,6 +163,10 @@ func (c *containerImageResolver) MondooOperatorImage(ctx context.Context, userIm
 		skipImageResolution = true
 	}
 
+	return c.resolveImage(ctx, image, skipImageResolution)
+}
+
+func (c *containerImageResolver) ContainerImage(ctx context.Context, image string, skipImageResolution bool) (string, error) {
 	return c.resolveImage(ctx, image, skipImageResolution)
 }
 

--- a/pkg/utils/mondoo/container_image_resolver_test.go
+++ b/pkg/utils/mondoo/container_image_resolver_test.go
@@ -18,6 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"go.mondoo.com/mondoo-operator/pkg/constants"
 	"go.mondoo.com/mondoo-operator/pkg/imagecache"
 )
 
@@ -181,6 +182,32 @@ func (s *ContainerImageResolverSuite) TestMondooOperatorImage_SkipImageResolutio
 	s.Equal(fmt.Sprintf("%s:%s", image, tag), res)
 	s.Equalf(0, s.remoteCallsCount, "remote call has been performed")
 	s.Equal("ghcr.io/mondoo/testimage:testtag", res)
+}
+
+func (s *ContainerImageResolverSuite) TestContainerImageUsesRegistryMirror() {
+	resolver := s.containerImageResolver()
+	resolver.registryMirrors = map[string]string{
+		"docker.io": "registry.example.com/dockerhub",
+	}
+
+	res, err := resolver.ContainerImage(context.Background(), "docker.io/library/busybox:1.36", true)
+	s.NoError(err)
+
+	s.Equal("registry.example.com/dockerhub/library/busybox:1.36", res)
+	s.Equalf(0, s.remoteCallsCount, "remote call has been performed")
+}
+
+func (s *ContainerImageResolverSuite) TestBusyBoxImageUsesRegistryMirror() {
+	resolver := s.containerImageResolver()
+	resolver.registryMirrors = map[string]string{
+		"docker.io": "registry.example.com/dockerhub",
+	}
+
+	res, err := resolver.ContainerImage(context.Background(), constants.BusyBoxImage, true)
+	s.NoError(err)
+
+	s.Equal("registry.example.com/dockerhub/library/busybox:1.36", res)
+	s.Equalf(0, s.remoteCallsCount, "remote call has been performed")
 }
 
 func (s *ContainerImageResolverSuite) TestCnspecImage_DigestOnly() {

--- a/pkg/utils/mondoo/fake/container_image_resolver.go
+++ b/pkg/utils/mondoo/fake/container_image_resolver.go
@@ -56,6 +56,7 @@ func (c *noOpContainerImageResolver) MondooOperatorImage(ctx context.Context, us
 type ContainerImageResolverMock struct {
 	CnspecImageFunc         func(userImage, userTag, userDigest string, skipResolveImage bool) (string, error)
 	MondooOperatorImageFunc func(ctx context.Context, userImage, userTag, userDigest string, skipResolveImage bool) (string, error)
+	ContainerImageFunc      func(ctx context.Context, image string, skipResolveImage bool) (string, error)
 }
 
 func (c *ContainerImageResolverMock) CnspecImageVersion(_, _, _ string) string {
@@ -74,6 +75,17 @@ func (c *ContainerImageResolverMock) MondooOperatorImage(ctx context.Context, us
 		return c.MondooOperatorImageFunc(ctx, userImage, userTag, userDigest, skipResolveImage)
 	}
 	return fmt.Sprintf("%s:%s", mondoo.MondooOperatorImage, mondoo.MondooOperatorTag), nil
+}
+
+func (c *noOpContainerImageResolver) ContainerImage(ctx context.Context, image string, skipResolveImage bool) (string, error) {
+	return image, nil
+}
+
+func (c *ContainerImageResolverMock) ContainerImage(ctx context.Context, image string, skipResolveImage bool) (string, error) {
+	if c.ContainerImageFunc != nil {
+		return c.ContainerImageFunc(ctx, image, skipResolveImage)
+	}
+	return image, nil
 }
 
 func (c *noOpContainerImageResolver) WithImageRegistry(imageRegistry string) mondoo.ContainerImageResolver {


### PR DESCRIPTION
## Summary
- replace node scanner Go-template inventory values with a stable node-name placeholder
- render the placeholder to a writable `/tmp` inventory file in a lightweight `render-node-inventory` init container
- run the main scanner container directly as `cnspec ... --inventory-file`, so custom scanner images only need `cnspec` and no longer need `/bin/sh` or `sed`
- resolve the render-helper image through the shared container image resolver so `imageRegistry`, `registryMirrors`, `imagePullSecrets`, and `skipContainerResolution` apply to the helper image too
- document the init-container behavior in the node-scanning user manual

## Review fixes
- removed the hard-coded upstream helper image from rendered workloads by passing a resolver-managed helper image into CronJob and DaemonSet builders
- added resolver and reconciliation regression tests for registry-mirrored helper images

## Validation
- `git diff --check`
- `go test ./controllers/nodes ./pkg/utils/mondoo ./pkg/utils/k8s ./controllers/status`
- `go build -o /tmp/mondoo-operator-node ./cmd/mondoo-operator/main.go`
- `make lint/actions`
- `make lint`
- `kubectl --context kind-mondoo-oidc-kind apply -k config/crd`
- `kubectl --context kind-mondoo-oidc-kind apply --server-side --dry-run=server -k config/rbac`
- `kubectl --context kind-mondoo-oidc-kind apply --server-side --dry-run=server -f config/samples/k8s_v1alpha2_mondooauditconfig.yaml`
- `kubectl --context kind-mondoo-oidc-kind apply --server-side --dry-run=server -f config/samples/k8s_v1alpha2_mondoooperatorconfig.yaml`
- targeted `kind-mondoo-oidc-kind` server-side dry-run for a node-scanning `MondooAuditConfig` plus registry-mirrored `MondooOperatorConfig`

## Notes
- The init helper uses the existing lightweight BusyBox helper image pattern. Pod-level `imagePullSecrets` still apply to both the helper and scanner containers.

- `go test ./pkg/utils/mondoo -run 'TestContainerImageResolverSuite/Test(ContainerImageUsesRegistryMirror|BusyBoxImageUsesRegistryMirror|ApplyImageRegistry)'`
- `go test ./controllers/nodes -run 'TestResources|TestCronJob_UsesInventoryFileFlag|TestDaemonSet_UsesInventoryFileFlag|TestDeploymentHandlerSuite/TestReconcile_(CreateCronJobs|CronJobUsesResolvedRenderImage|CreateDaemonSet)'`
- `go test ./controllers/nodes ./pkg/utils/mondoo ./pkg/utils/k8s ./controllers/status`
- `make lint/actions`
- `make lint`
