### PR TITLE
Fix GraphQL input type wrapping in integration and space tests

### DIFF
--- a/tests/framework/nexus/k8s/integration.go
+++ b/tests/framework/nexus/k8s/integration.go
@@ -138,7 +138,7 @@ func (i *Integration) GetCiCdProject(ctx context.Context) (*CiCdProject, error) 
 		} `graphql:"cicdProjects(input: $input)"`
 	}
 
-	err := i.gqlClient.Query(ctx, &q, map[string]interface{}{"input": mondoogql.CicdProjectsInput{SpaceMrn: i.spaceMrn}, "first": mondoogql.Int(100)})
+	err := i.gqlClient.Query(ctx, &q, map[string]interface{}{"input": mondoogql.CicdProjectsInput{SpaceMrn: mondoogql.NewIDPtr(i.spaceMrn)}, "first": mondoogql.Int(100)})
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/nexus/space.go
+++ b/tests/framework/nexus/space.go
@@ -58,5 +58,5 @@ func (s *Space) DeleteAssets(ctx context.Context) error {
 		} `graphql:"deleteAssets(input: $input)"`
 	}
 
-	return s.gqlClient.Mutate(ctx, &m, mondoogql.DeleteAssetsInput{SpaceMrn: mondoogql.String(s.spaceMrn)}, nil)
+	return s.gqlClient.Mutate(ctx, &m, mondoogql.DeleteAssetsInput{SpaceMrn: mondoogql.NewStringPtr(mondoogql.String(s.spaceMrn))}, nil)
 }


### PR DESCRIPTION
## Summary
Updates GraphQL input field assignments to use proper pointer wrapper functions for type safety and API compatibility.

## Changes
- **integration.go**: Wrapped `SpaceMrn` field with `mondoogql.NewIDPtr()` in `CicdProjectsInput` to properly convert the string MRN to an ID pointer type
- **space.go**: Wrapped `SpaceMrn` field with `mondoogql.NewStringPtr()` in `DeleteAssetsInput` to properly convert the string value to a string pointer type

## Details
These changes ensure that GraphQL input fields are correctly typed according to the API schema. The wrapper functions handle the necessary type conversions and pointer management, preventing potential type mismatches when executing GraphQL queries and mutations.

https://claude.ai/code/session_01VgqbisX2pbbLvzYzn2KZ3u