### PR TITLE
🧹 improve integration tests workflows stability

### DIFF
--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.32.0, v1.35.0]
+        k8s-version: [v1.34.0, v1.36.0]
 
     steps:
       - name: Checkout

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.32.0, v1.35.0]
+        k8s-version: [v1.34, v1.36]
         k8s-distro: [minikube, k3d]
 
     steps:
@@ -84,7 +84,7 @@ jobs:
         uses: nolar/setup-k3d-k3s@62c9d1bd2bc843275c85d2e7dcd696edc1160eee # v1.1.0
         if: matrix.k8s-distro == 'k3d'
         with:
-          version: ${{ matrix.k8s-version }}
+          channel: ${{ matrix.k8s-version }}
           k3d-args: --k3s-arg=--disable=traefik@server:*
           github-token: ${{ github.token }}
 
@@ -147,7 +147,7 @@ jobs:
       - name: Start k3d
         uses: nolar/setup-k3d-k3s@62c9d1bd2bc843275c85d2e7dcd696edc1160eee # v1.1.0
         with:
-          version: v1.32.0
+          channel: v1.34
           k3d-args: --k3s-arg=--disable=traefik@server:*
           github-token: ${{ github.token }}
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -86,6 +86,7 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           k3d-args: --k3s-arg=--disable=traefik@server:*
+          github-token: ${{ github.token }}
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -148,6 +149,7 @@ jobs:
         with:
           version: v1.32.0
           k3d-args: --k3s-arg=--disable=traefik@server:*
+          github-token: ${{ github.token }}
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/tests/integration/audit_config_base_suite.go
+++ b/tests/integration/audit_config_base_suite.go
@@ -383,14 +383,42 @@ func (s *AuditConfigBaseSuite) testMondooAuditConfigNodesCronjobs(auditConfig mo
 	s.NoError(err, "Failed to find MondooAuditConfig")
 	s.Equal(cronJobs.Items[0].Spec.Schedule, foundMondooAuditConfig.Spec.Nodes.Schedule, "CronJob schedule was not updated in MondooAuditConfig")
 
-	// The number of assets from upstream is limited by paganiation.
-	// In case we have more than 100 workloads, we need to call this mutlple times, with different page numbers.
-	assets, err := s.spaceClient.ListAssetsWithScores(s.ctx)
-	s.NoError(err, "Failed to list assets")
-	assetNames := utils.AssetNames(assets)
+	// Poll for assets to appear upstream and be scored. Scoring is asynchronous,
+	// so we poll until assets are both present and scored.
+	zap.S().Info("Waiting for node scan results to appear and be scored upstream.")
+	nodeNameSet := make(map[string]struct{}, len(nodeNames))
+	for _, n := range nodeNames {
+		nodeNameSet[n] = struct{}{}
+	}
 
-	s.ElementsMatch(assetNames, nodeNames, "Node names do not match")
-	s.AssetsNotUnscored(assets)
+	var nodeAssets []assets.AssetWithScore
+	err = s.testCluster.K8sHelper.ExecuteWithRetries(func() (bool, error) {
+		allAssets, listErr := s.spaceClient.ListAssetsWithScores(s.ctx)
+		if listErr != nil {
+			zap.S().Infof("Failed to list assets: %v", listErr)
+			return false, nil
+		}
+		nodeAssets = nil
+		for _, asset := range allAssets {
+			if _, ok := nodeNameSet[asset.Name]; ok {
+				nodeAssets = append(nodeAssets, asset)
+			}
+		}
+		if len(nodeAssets) != len(nodeNames) {
+			zap.S().Infof("Expected %d node assets but found %d, retrying...", len(nodeNames), len(nodeAssets))
+			return false, nil
+		}
+		for _, asset := range nodeAssets {
+			if asset.Grade == "U" || asset.Grade == "" {
+				zap.S().Infof("Asset %s not yet scored, retrying...", asset.Name)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	s.NoError(err, "Node assets were not scored in time")
+	s.ElementsMatch(utils.AssetNames(nodeAssets), nodeNames, "Node names do not match")
+	s.AssetsNotUnscored(nodeAssets)
 
 	status, err := s.integration.GetStatus(s.ctx)
 	s.NoError(err, "Failed to get status")


### PR DESCRIPTION
- 🐛 adds `GITHUB_TOKEN` to `nolar/setup-k3d-k3s` in order to prevent rate-limiting
- 🧹 Also bumps the k3s versions and switches CI from hardcoded version+build to channel
- 🐛 extends scoring await time in tests