### PR TITLE
✨ add pause/unpause scanning support via console integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ tests/e2e/**/kubeconfig
 tests/e2e/**/kubeconfig-target
 tests/e2e/**/gke_gcloud_auth_plugin_cache
 tests/e2e/**/mondoo.json
+tests/e2e/**/.integration-state
 
 # macOS
 .DS_Store

--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -543,6 +543,12 @@ type MondooAuditConfigStatus struct {
 	// garbage collection of stale node scan assets.
 	// +optional
 	LastNodeScanGarbageCollectionTime *metav1.Time `json:"lastNodeScanGarbageCollectionTime,omitempty"`
+
+	// ScanningPaused indicates that the Mondoo console has paused scanning for
+	// this integration. When true, all scan CronJobs are suspended.
+	// Only set when ConsoleIntegration is enabled.
+	// +optional
+	ScanningPaused bool `json:"scanningPaused,omitempty"`
 }
 
 type MondooAuditConfigCondition struct {
@@ -585,6 +591,8 @@ const (
 	// MondooIntegrationDegraded will hold the status for any issues encountered while trying to CheckIn()
 	// on behalf of the Mondoo integration MRN
 	MondooIntegrationDegraded MondooAuditConfigConditionType = "IntegrationDegraded"
+	// ScanningPausedCondition indicates that scanning has been paused from the Mondoo console
+	ScanningPausedCondition MondooAuditConfigConditionType = "ScanningPaused"
 )
 
 //+kubebuilder:object:root=true

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1547,6 +1547,12 @@ spec:
                 description: ReconciledByOperatorVersion contains the version of the
                   operator which reconciled this MondooAuditConfig
                 type: string
+              scanningPaused:
+                description: |-
+                  ScanningPaused indicates that the Mondoo console has paused scanning for
+                  this integration. When true, all scan CronJobs are suspended.
+                  Only set when ConsoleIntegration is enabled.
+                type: boolean
             type: object
         type: object
     served: true

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1547,6 +1547,12 @@ spec:
                 description: ReconciledByOperatorVersion contains the version of the
                   operator which reconciled this MondooAuditConfig
                 type: string
+              scanningPaused:
+                description: |-
+                  ScanningPaused indicates that the Mondoo console has paused scanning for
+                  this integration. When true, all scan CronJobs are suspended.
+                  Only set when ConsoleIntegration is enabled.
+                type: boolean
             type: object
         type: object
     served: true

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -82,6 +82,7 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 		Spec: batchv1.CronJobSpec{
 			Schedule:          m.Spec.Containers.Schedule,
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/integration/integration_controller.go
+++ b/controllers/integration/integration_controller.go
@@ -44,6 +44,7 @@ func Add(mgr manager.Manager) error {
 		Client:              mgr.GetClient(),
 		Interval:            interval,
 		MondooClientBuilder: mondooclient.NewClient,
+		configHashes:        make(map[string]string),
 	}
 	if err := mgr.Add(mc); err != nil {
 		logger.Error(err, "failed to add integration controller to manager")
@@ -59,6 +60,9 @@ type IntegrationReconciler struct {
 	Interval            time.Duration
 	MondooClientBuilder func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error)
 	ctx                 context.Context
+	// configHashes tracks the last-known configuration hash per integration MRN so CheckIn can
+	// detect server-side configuration changes (e.g. pause/unpause).
+	configHashes map[string]string
 }
 
 // Start begins the integration status loop.
@@ -123,11 +127,51 @@ func (r *IntegrationReconciler) processMondooAuditConfig(m v1alpha2.MondooAuditC
 		}
 	}
 
-	if err = mondoo.IntegrationCheckIn(r.ctx, integrationMrn, *serviceAccount, r.MondooClientBuilder, config.Spec.HttpProxy, config.Spec.HttpsProxy, config.Spec.NoProxy, logger); err != nil {
+	result, err := mondoo.IntegrationCheckIn(r.ctx, integrationMrn, r.configHashes[integrationMrn], *serviceAccount, r.MondooClientBuilder, config.Spec.HttpProxy, config.Spec.HttpsProxy, config.Spec.NoProxy, logger)
+	if err != nil {
 		logger.Error(err, "failed to CheckIn() for integration", "integrationMRN", string(integrationMrn))
 		return err
 	}
 
+	if result != nil && result.ConfigurationHash != "" {
+		if r.configHashes == nil {
+			r.configHashes = make(map[string]string)
+		}
+		r.configHashes[integrationMrn] = result.ConfigurationHash
+	}
+
+	if result != nil && result.ConfigFetched && result.Paused != m.Status.ScanningPaused {
+		m.Status.ScanningPaused = result.Paused
+		if updateErr := r.Client.Status().Update(r.ctx, &m); updateErr != nil {
+			logger.Error(updateErr, "failed to update ScanningPaused status")
+			return updateErr
+		}
+		logger.Info("updated ScanningPaused status", "paused", result.Paused)
+	}
+
+	return r.setScanningPausedCondition(&m)
+}
+
+func (r *IntegrationReconciler) setScanningPausedCondition(config *v1alpha2.MondooAuditConfig) error {
+	originalConfig := config.DeepCopy()
+
+	if config.Status.ScanningPaused {
+		config.Status.Conditions = mondoo.SetMondooAuditCondition(
+			config.Status.Conditions, v1alpha2.ScanningPausedCondition, corev1.ConditionTrue,
+			"ScanningPaused", "Scanning has been paused from the Mondoo console",
+			mondoo.UpdateConditionIfReasonOrMessageChange, nil, "",
+		)
+	} else {
+		config.Status.Conditions = mondoo.SetMondooAuditCondition(
+			config.Status.Conditions, v1alpha2.ScanningPausedCondition, corev1.ConditionFalse,
+			"ScanningActive", "Scanning is active",
+			mondoo.UpdateConditionIfReasonOrMessageChange, nil, "",
+		)
+	}
+
+	if !reflect.DeepEqual(originalConfig.Status.Conditions, config.Status.Conditions) {
+		return r.Client.Status().Update(r.ctx, config)
+	}
 	return nil
 }
 

--- a/controllers/integration/integration_controller_test.go
+++ b/controllers/integration/integration_controller_test.go
@@ -104,14 +104,22 @@ func (s *IntegrationCheckInSuite) TestCheckIn() {
 	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
 		Mrn: testIntegrationMRN, // make sure MRN in the CheckIn() in what is required for the real Mondoo API
 	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: true,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
 		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+		Details: &mondooclient.IntegrationConfigureDetails{
+			Config: `{}`,
+		},
 	}, nil)
 
 	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
 		return mClient, nil
 	}
 
-	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).Build()
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjects...).WithStatusSubresource(mondooAuditConfig).Build()
 
 	r := &IntegrationReconciler{
 		Client:              fakeClient,
@@ -123,7 +131,6 @@ func (s *IntegrationCheckInSuite) TestCheckIn() {
 
 	// Assert
 	s.NoError(err, "should not error while processing valid MondooAuditConfig")
-	s.Zero(len(mondooAuditConfig.Status.Conditions), "expected no condition set on happy path")
 	mockCtrl.Finish()
 }
 
@@ -149,7 +156,15 @@ func (s *IntegrationCheckInSuite) TestClearPreviousCondition() {
 	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
 		Mrn: testIntegrationMRN, // make sure MRN in the CheckIn() in what is required for the real Mondoo API
 	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: true,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
 		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+		Details: &mondooclient.IntegrationConfigureDetails{
+			Config: `{}`,
+		},
 	}, nil)
 
 	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
@@ -293,6 +308,239 @@ func (s *IntegrationCheckInSuite) TestFailedCheckIn() {
 	// this controller doesn't make changes to k8s resources...the only side effect here are the mondooclient API calls
 	s.Error(err, "expected error when CheckIn() return error")
 	assertConditionExists(s.T(), fakeClient, corev1.ConditionTrue, "failed to CheckIn")
+	mockCtrl.Finish()
+}
+
+func (s *IntegrationCheckInSuite) TestCheckInPausesScanning() {
+	// Arrange
+	mondooAuditConfig := testMondooAuditConfig()
+	mondooAuditConfig.Spec.ConsoleIntegration.Enable = true
+
+	existingObjects := []client.Object{
+		testMondooCredsSecret(),
+		mondooAuditConfig,
+	}
+
+	mockCtrl := gomock.NewController(s.T())
+
+	mClient := mockmondoo.NewMockMondooClient(mockCtrl)
+	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: false,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+		Details: &mondooclient.IntegrationConfigureDetails{
+			Config: `{"pauseScanning":true}`,
+		},
+	}, nil)
+
+	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
+		return mClient, nil
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithStatusSubresource(existingObjects...).
+		WithObjects(existingObjects...).
+		Build()
+
+	r := &IntegrationReconciler{
+		Client:              fakeClient,
+		MondooClientBuilder: testMondooClientBuilder,
+	}
+
+	// Act
+	err := r.processMondooAuditConfig(*mondooAuditConfig)
+
+	// Assert
+	s.NoError(err)
+
+	updated := testMondooAuditConfig()
+	s.NoError(fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(updated), updated))
+	s.True(updated.Status.ScanningPaused, "expected ScanningPaused=true after pause")
+	mockCtrl.Finish()
+}
+
+func (s *IntegrationCheckInSuite) TestCheckInUnpausesScanning() {
+	// Arrange
+	mondooAuditConfig := testMondooAuditConfig()
+	mondooAuditConfig.Spec.ConsoleIntegration.Enable = true
+	mondooAuditConfig.Status.ScanningPaused = true
+
+	existingObjects := []client.Object{
+		testMondooCredsSecret(),
+		mondooAuditConfig,
+	}
+
+	mockCtrl := gomock.NewController(s.T())
+
+	mClient := mockmondoo.NewMockMondooClient(mockCtrl)
+	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: false,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+		Details: &mondooclient.IntegrationConfigureDetails{
+			Config: `{"pauseScanning":false}`,
+		},
+	}, nil)
+
+	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
+		return mClient, nil
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithStatusSubresource(existingObjects...).
+		WithObjects(existingObjects...).
+		Build()
+
+	r := &IntegrationReconciler{
+		Client:              fakeClient,
+		MondooClientBuilder: testMondooClientBuilder,
+	}
+
+	// Act
+	err := r.processMondooAuditConfig(*mondooAuditConfig)
+
+	// Assert
+	s.NoError(err)
+
+	updated := testMondooAuditConfig()
+	s.NoError(fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(updated), updated))
+	s.False(updated.Status.ScanningPaused, "expected ScanningPaused=false after unpause")
+	mockCtrl.Finish()
+}
+
+func (s *IntegrationCheckInSuite) TestCheckInConfigMatchCallsConfigureWhenNoStoredHash() {
+	// ConfigurationMatch=true but Configure is still called because we have no stored hash
+	mondooAuditConfig := testMondooAuditConfig()
+	mondooAuditConfig.Spec.ConsoleIntegration.Enable = true
+
+	existingObjects := []client.Object{
+		testMondooCredsSecret(),
+		mondooAuditConfig,
+	}
+
+	mockCtrl := gomock.NewController(s.T())
+
+	mClient := mockmondoo.NewMockMondooClient(mockCtrl)
+	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: true,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
+		Mrn: testIntegrationMRN,
+	}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+		Details: &mondooclient.IntegrationConfigureDetails{
+			Config: `{"pauseScanning":false}`,
+		},
+	}, nil)
+
+	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
+		return mClient, nil
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(existingObjects...).WithStatusSubresource(mondooAuditConfig).Build()
+
+	r := &IntegrationReconciler{
+		Client:              fakeClient,
+		MondooClientBuilder: testMondooClientBuilder,
+	}
+
+	// Act
+	err := r.processMondooAuditConfig(*mondooAuditConfig)
+
+	// Assert
+	s.NoError(err)
+	mockCtrl.Finish()
+}
+
+func (s *IntegrationCheckInSuite) TestCheckInConfigMatchSkipsConfigureWithStoredHash() {
+	// When we have a stored hash and ConfigurationMatch=true, Configure must NOT be called
+	mondooAuditConfig := testMondooAuditConfig()
+	mondooAuditConfig.Spec.ConsoleIntegration.Enable = true
+
+	existingObjects := []client.Object{
+		testMondooCredsSecret(),
+		mondooAuditConfig,
+	}
+
+	mockCtrl := gomock.NewController(s.T())
+
+	mClient := mockmondoo.NewMockMondooClient(mockCtrl)
+	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
+		Mrn:               testIntegrationMRN,
+		ConfigurationHash: "abc123",
+	}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: true,
+	}, nil)
+	// IntegrationConfigure must NOT be called — gomock will fail if it is
+
+	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
+		return mClient, nil
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(existingObjects...).WithStatusSubresource(mondooAuditConfig).Build()
+
+	r := &IntegrationReconciler{
+		Client:              fakeClient,
+		MondooClientBuilder: testMondooClientBuilder,
+		configHashes:        map[string]string{testIntegrationMRN: "abc123"},
+	}
+
+	err := r.processMondooAuditConfig(*mondooAuditConfig)
+
+	s.NoError(err)
+	mockCtrl.Finish()
+}
+
+func (s *IntegrationCheckInSuite) TestConfigureFailureDoesNotCrash() {
+	// Configure fails — operator must NOT error, scanning state must NOT change
+	mondooAuditConfig := testMondooAuditConfig()
+	mondooAuditConfig.Spec.ConsoleIntegration.Enable = true
+
+	existingObjects := []client.Object{
+		testMondooCredsSecret(),
+		mondooAuditConfig,
+	}
+
+	mockCtrl := gomock.NewController(s.T())
+
+	mClient := mockmondoo.NewMockMondooClient(mockCtrl)
+	mClient.EXPECT().IntegrationCheckIn(gomock.Any(), gomock.Any()).Times(1).Return(&mondooclient.IntegrationCheckInOutput{
+		Mrn:                testIntegrationMRN,
+		ConfigurationMatch: false,
+	}, nil)
+	mClient.EXPECT().IntegrationConfigure(gomock.Any(), gomock.Any()).Times(1).Return(
+		nil, fmt.Errorf("connection refused"),
+	)
+
+	testMondooClientBuilder := func(mondooclient.MondooClientOptions) (mondooclient.MondooClient, error) {
+		return mClient, nil
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(existingObjects...).WithStatusSubresource(mondooAuditConfig).Build()
+
+	r := &IntegrationReconciler{
+		Client:              fakeClient,
+		MondooClientBuilder: testMondooClientBuilder,
+	}
+
+	// Act
+	err := r.processMondooAuditConfig(*mondooAuditConfig)
+
+	// Assert — no error returned, operator stays healthy
+	s.NoError(err)
 	mockCtrl.Finish()
 }
 

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -85,6 +85,7 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 		Spec: batchv1.CronJobSpec{
 			Schedule:          m.Spec.KubernetesResources.Schedule,
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{
@@ -450,6 +451,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 		Spec: batchv1.CronJobSpec{
 			Schedule:          schedule,
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			Suspend:           ptr.To(m.Status.ScanningPaused),
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: ls},
 				Spec: batchv1.JobSpec{

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -288,13 +288,24 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		IsOpenshift:            r.RunningOnOpenShift,
 	}
 
+	// Reconcile each scan type independently. A transient failure in one
+	// (e.g. image resolution timeout) must not block the others.
 	var firstError error
-	result, reconcileError := nodes.Reconcile(ctx)
-	if reconcileError != nil {
-		log.Error(reconcileError, "Failed to set up nodes scanning, continuing with other scan types")
-		firstError = reconcileError
-		reconcileError = nil
+	finalResult := ctrl.Result{Requeue: true, RequeueAfter: time.Hour * 24 * 7}
+	collect := func(result ctrl.Result, err error, msg string) {
+		if err != nil {
+			log.Error(err, msg+", continuing with other scan types")
+			if firstError == nil {
+				firstError = err
+			}
+		}
+		if result.RequeueAfter > 0 && result.RequeueAfter < finalResult.RequeueAfter {
+			finalResult.RequeueAfter = result.RequeueAfter
+		}
 	}
+
+	result, err := nodes.Reconcile(ctx)
+	collect(result, err, "Failed to set up nodes scanning")
 
 	containers := container_image.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -302,14 +313,8 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		ContainerImageResolver: imageResolver,
 		MondooOperatorConfig:   config,
 	}
-
-	result, reconcileError = containers.Reconcile(ctx)
-	if reconcileError != nil {
-		log.Error(reconcileError, "Failed to set up container scanning")
-	}
-	if reconcileError != nil || result.RequeueAfter > 0 {
-		return result, reconcileError
-	}
+	result, err = containers.Reconcile(ctx)
+	collect(result, err, "Failed to set up container scanning")
 
 	workloads := k8s_scan.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -319,14 +324,8 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		MondooClientBuilder:    r.MondooClientBuilder,
 		VaultTokenFetcher:      k8s_scan.DefaultVaultTokenFetcher,
 	}
-
-	result, reconcileError = workloads.Reconcile(ctx)
-	if reconcileError != nil {
-		log.Error(reconcileError, "Failed to set up Kubernetes resources scanning")
-	}
-	if reconcileError != nil || result.RequeueAfter > 0 {
-		return result, reconcileError
-	}
+	result, err = workloads.Reconcile(ctx)
+	collect(result, err, "Failed to set up Kubernetes resources scanning")
 
 	resourceWatcher := resourcewatcher.DeploymentHandler{
 		Mondoo:                 mondooAuditConfig,
@@ -334,27 +333,16 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		MondooOperatorConfig:   config,
 		ContainerImageResolver: imageResolver,
 	}
+	result, err = resourceWatcher.Reconcile(ctx)
+	collect(result, err, "Failed to set up resource watcher")
 
-	result, reconcileError = resourceWatcher.Reconcile(ctx)
-	if reconcileError != nil {
-		log.Error(reconcileError, "Failed to set up resource watcher")
-	}
-	if reconcileError != nil || result.RequeueAfter > 0 {
-		return result, reconcileError
-	}
-
-	// Update status.ReconciledByOperatorVersion to the running operator version
-	// This should only happen, after all objects have been reconciled
 	mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
 
-	// If a non-critical scan type (e.g. nodes) failed but we continued, return the
-	// error so the controller requeues and retries, while still having reconciled the
-	// remaining scan types.
 	if firstError != nil {
 		return ctrl.Result{}, firstError
 	}
 
-	return ctrl.Result{Requeue: true, RequeueAfter: time.Hour * 24 * 7}, nil
+	return finalResult, nil
 }
 
 // nodeEventsRequestMapper Maps node events to enqueue all MondooAuditConfigs that have node scanning enabled for

--- a/controllers/mondooauditconfig_controller_test.go
+++ b/controllers/mondooauditconfig_controller_test.go
@@ -227,10 +227,15 @@ func TestTokenRegistration(t *testing.T) {
 					Creds: testMondooServiceAccount,
 				}, nil)
 
-				// expect initial CheckIn()
+				// expect initial CheckIn() + Configure (always called)
 				mClient.EXPECT().IntegrationCheckIn(gomock.Any(), &mondooclient.IntegrationCheckInInput{
 					Mrn: testIntegrationMRN,
-				}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{}, nil)
+				}).Times(1).Return(&mondooclient.IntegrationCheckInOutput{ConfigurationMatch: true}, nil)
+				mClient.EXPECT().IntegrationConfigure(gomock.Any(), &mondooclient.IntegrationConfigureInput{
+					Mrn: testIntegrationMRN,
+				}).Times(1).Return(&mondooclient.IntegrationConfigureOutput{
+					Details: &mondooclient.IntegrationConfigureDetails{Config: `{}`},
+				}, nil)
 
 				mClient.EXPECT().IntegrationReportStatus(gomock.Any(), &mondooclient.ReportStatusRequest{
 					Mrn:    testIntegrationMRN,

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -75,6 +75,7 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 		Spec: batchv1.CronJobSpec{
 			Schedule:                   m.Spec.Nodes.Schedule,
 			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			Suspend:                    ptr.To(m.Status.ScanningPaused),
 			SuccessfulJobsHistoryLimit: ptr.To(int32(1)),
 			FailedJobsHistoryLimit:     ptr.To(int32(1)),
 			JobTemplate: batchv1.JobTemplateSpec{

--- a/pkg/client/mondooclient/client.go
+++ b/pkg/client/mondooclient/client.go
@@ -18,6 +18,7 @@ const (
 	ExchangeRegistrationTokenEndpoint = "/AgentManager/ExchangeRegistrationToken"
 	IntegrationRegisterEndpoint       = "/IntegrationsManager/Register"
 	IntegrationCheckInEndpoint        = "/IntegrationsManager/CheckIn"
+	IntegrationConfigureEndpoint      = "/IntegrationsManager/Configure"
 	IntegrationReportStatusEndpoint   = "/IntegrationsManager/ReportStatus"
 	GarbageCollectAssetsEndpoint      = "/PolicyResolver/PurgeAssets"
 )
@@ -127,6 +128,27 @@ func (s *mondooClient) IntegrationCheckIn(ctx context.Context, in *IntegrationCh
 	}
 
 	out := &IntegrationCheckInOutput{}
+	if err = json.Unmarshal(respBodyBytes, out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	return out, nil
+}
+
+func (s *mondooClient) IntegrationConfigure(ctx context.Context, in *IntegrationConfigureInput) (*IntegrationConfigureOutput, error) {
+	url := s.ApiEndpoint + IntegrationConfigureEndpoint
+
+	reqBodyBytes, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	respBodyBytes, err := common.Request(ctx, s.httpClient, url, s.Token, reqBodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	out := &IntegrationConfigureOutput{}
 	if err = json.Unmarshal(respBodyBytes, out); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
 	}

--- a/pkg/client/mondooclient/mock/client_generated.go
+++ b/pkg/client/mondooclient/mock/client_generated.go
@@ -95,6 +95,21 @@ func (mr *MockMondooClientMockRecorder) IntegrationCheckIn(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntegrationCheckIn", reflect.TypeOf((*MockMondooClient)(nil).IntegrationCheckIn), arg0, arg1)
 }
 
+// IntegrationConfigure mocks base method.
+func (m *MockMondooClient) IntegrationConfigure(arg0 context.Context, arg1 *mondooclient.IntegrationConfigureInput) (*mondooclient.IntegrationConfigureOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IntegrationConfigure", arg0, arg1)
+	ret0, _ := ret[0].(*mondooclient.IntegrationConfigureOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IntegrationConfigure indicates an expected call of IntegrationConfigure.
+func (mr *MockMondooClientMockRecorder) IntegrationConfigure(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntegrationConfigure", reflect.TypeOf((*MockMondooClient)(nil).IntegrationConfigure), arg0, arg1)
+}
+
 // IntegrationRegister mocks base method.
 func (m *MockMondooClient) IntegrationRegister(arg0 context.Context, arg1 *mondooclient.IntegrationRegisterInput) (*mondooclient.IntegrationRegisterOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/client/mondooclient/types.go
+++ b/pkg/client/mondooclient/types.go
@@ -17,6 +17,7 @@ type MondooClient interface {
 
 	IntegrationRegister(context.Context, *IntegrationRegisterInput) (*IntegrationRegisterOutput, error)
 	IntegrationCheckIn(context.Context, *IntegrationCheckInInput) (*IntegrationCheckInOutput, error)
+	IntegrationConfigure(context.Context, *IntegrationConfigureInput) (*IntegrationConfigureOutput, error)
 	IntegrationReportStatus(context.Context, *ReportStatusRequest) error
 
 	GarbageCollectAssets(context.Context, *GarbageCollectAssetsRequest) error
@@ -67,6 +68,22 @@ type IntegrationCheckInOutput struct {
 	Mrn string `protobuf:"bytes,1,opt,name=mrn,proto3" json:"mrn,omitempty"`
 	// true if the configuration hash sent in matches the hash of the stored configuration
 	ConfigurationMatch bool `protobuf:"varint,2,opt,name=configuration_match,json=configurationMatch,proto3" json:"configuration_match,omitempty"`
+}
+
+type IntegrationConfigureInput struct {
+	Mrn string `protobuf:"bytes,1,opt,name=mrn,proto3" json:"mrn,omitempty"`
+}
+
+type IntegrationConfigureOutput struct {
+	Details *IntegrationConfigureDetails `json:"details,omitempty"`
+}
+
+type IntegrationConfigureDetails struct {
+	Config string `json:"config,omitempty"`
+}
+
+type K8sIntegrationConfig struct {
+	PauseScanning bool `json:"pauseScanning,omitempty"`
 }
 
 type ReportStatusRequest struct {

--- a/pkg/utils/k8s/integration_mrn.go
+++ b/pkg/utils/k8s/integration_mrn.go
@@ -12,12 +12,14 @@ import (
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 	"go.mondoo.com/mondoo-operator/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TryGetIntegrationMrnForAuditConfig tries to get the integration-mrn for a MondooAuditConfig. If ConsoleIntegration is disabled, no
-// integration-mrn is returned but also no error.
+// integration-mrn is returned but also no error. If the secret does not exist yet or is missing the integrationmrn key
+// (token exchange has not completed), an empty string is returned without error so the operator can continue reconciling.
 func TryGetIntegrationMrnForAuditConfig(ctx context.Context, kubeClient client.Client, auditConfig v1alpha2.MondooAuditConfig) (string, error) {
 	if !auditConfig.Spec.ConsoleIntegration.Enable {
 		return "", nil
@@ -25,10 +27,17 @@ func TryGetIntegrationMrnForAuditConfig(ctx context.Context, kubeClient client.C
 
 	secret, err := GetIntegrationSecretForAuditConfig(ctx, kubeClient, auditConfig)
 	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return "", nil
+		}
 		return "", err
 	}
 
-	return GetIntegrationMrnFromSecret(*secret)
+	mrn, ok := secret.Data[constants.MondooCredsSecretIntegrationMRNKey]
+	if !ok {
+		return "", nil
+	}
+	return string(mrn), nil
 }
 
 // GetIntegrationSecretForAuditConfig retrieves the MondooCredsSecretRef for the give MondooAuditConfig.

--- a/pkg/utils/k8s/update_fields.go
+++ b/pkg/utils/k8s/update_fields.go
@@ -10,7 +10,7 @@ import (
 
 // UpdateCronJobFields copies managed fields from desired to obj,
 // preserving server-set defaults on unmanaged fields like
-// Suspend, Completions, Parallelism, DNSPolicy, SchedulerName, etc.
+// Completions, Parallelism, DNSPolicy, SchedulerName, etc.
 func UpdateCronJobFields(obj, desired *batchv1.CronJob) {
 	obj.Labels = desired.Labels
 	obj.Annotations = desired.Annotations
@@ -18,6 +18,7 @@ func UpdateCronJobFields(obj, desired *batchv1.CronJob) {
 	obj.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 	obj.Spec.SuccessfulJobsHistoryLimit = desired.Spec.SuccessfulJobsHistoryLimit
 	obj.Spec.FailedJobsHistoryLimit = desired.Spec.FailedJobsHistoryLimit
+	obj.Spec.Suspend = desired.Spec.Suspend
 
 	obj.Spec.JobTemplate.Labels = desired.Spec.JobTemplate.Labels
 	obj.Spec.JobTemplate.Annotations = desired.Spec.JobTemplate.Annotations

--- a/pkg/utils/mondoo/integration.go
+++ b/pkg/utils/mondoo/integration.go
@@ -5,26 +5,42 @@ package mondoo
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	"go.mondoo.com/mondoo-operator/pkg/client/mondooclient"
 )
 
+// IntegrationCheckInResult carries the pause-state change information returned by IntegrationCheckIn.
+type IntegrationCheckInResult struct {
+	// ConfigFetched is true when the server signalled a configuration mismatch and Configure was
+	// successfully fetched. When false, Paused should be ignored.
+	ConfigFetched bool
+	// Paused is the desired scanning-paused value from the server, valid only when ConfigFetched is true.
+	Paused bool
+	// ConfigurationHash is the SHA-256 hex digest of the raw configuration JSON returned by the
+	// server's Configure endpoint. The caller should persist this and pass it back on the next
+	// CheckIn so the server can detect configuration changes.
+	ConfigurationHash string
+}
+
 func IntegrationCheckIn(
 	ctx context.Context,
 	integrationMrn string,
+	configurationHash string,
 	sa mondooclient.ServiceAccountCredentials,
 	mondooClientBuilder MondooClientBuilder,
 	httpProxy *string,
 	httpsProxy *string,
 	noProxy *string,
 	logger logr.Logger,
-) error {
+) (*IntegrationCheckInResult, error) {
 	token, err := GenerateTokenFromServiceAccount(sa, logger)
 	if err != nil {
 		msg := "unable to generate token from service account"
-		return fmt.Errorf("%s: %s", msg, err)
+		return nil, fmt.Errorf("%s: %s", msg, err)
 	}
 	mondooClient, err := mondooClientBuilder(mondooclient.MondooClientOptions{
 		ApiEndpoint: sa.ApiEndpoint,
@@ -34,16 +50,53 @@ func IntegrationCheckIn(
 		NoProxy:     noProxy,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Do the actual check-in
-	if _, err := mondooClient.IntegrationCheckIn(ctx, &mondooclient.IntegrationCheckInInput{
-		Mrn: integrationMrn,
-	}); err != nil {
+	checkInResp, err := mondooClient.IntegrationCheckIn(ctx, &mondooclient.IntegrationCheckInInput{
+		Mrn:               integrationMrn,
+		ConfigurationHash: configurationHash,
+	})
+	if err != nil {
 		msg := "failed to CheckIn() to Mondoo API"
-		return fmt.Errorf("%s: %s", msg, err)
+		return nil, fmt.Errorf("%s: %s", msg, err)
 	}
 
-	return nil
+	logger.Info("CheckIn response", "configurationMatch", checkInResp.ConfigurationMatch, "sentHash", configurationHash)
+
+	result := &IntegrationCheckInResult{
+		ConfigurationHash: configurationHash,
+	}
+
+	// Fetch config when:
+	// 1. The server signals a change (hash mismatch), OR
+	// 2. We have no stored hash (first run after restart) — the server may treat
+	//    an empty hash as matching, so we must fetch to establish initial state.
+	if !checkInResp.ConfigurationMatch || configurationHash == "" {
+		configResp, err := mondooClient.IntegrationConfigure(ctx, &mondooclient.IntegrationConfigureInput{
+			Mrn: integrationMrn,
+		})
+		if err != nil {
+			logger.Error(err, "failed to fetch configuration, will retry next cycle")
+			return result, nil
+		}
+
+		if configResp.Details != nil && configResp.Details.Config != "" {
+			logger.Info("Configure response", "rawConfig", configResp.Details.Config)
+			var k8sCfg mondooclient.K8sIntegrationConfig
+			if err := json.Unmarshal([]byte(configResp.Details.Config), &k8sCfg); err != nil {
+				logger.Error(err, "failed to parse integration config JSON, will retry next cycle")
+				return result, nil
+			}
+			result.ConfigFetched = true
+			result.Paused = k8sCfg.PauseScanning
+			h := sha256.Sum256([]byte(configResp.Details.Config))
+			result.ConfigurationHash = fmt.Sprintf("%x", h[:])
+			logger.Info("parsed integration config", "pauseScanning", k8sCfg.PauseScanning, "newHash", result.ConfigurationHash)
+		} else {
+			logger.Info("Configure response had no config details", "hasDetails", configResp.Details != nil)
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/utils/mondoo/token_exchange.go
+++ b/pkg/utils/mondoo/token_exchange.go
@@ -128,7 +128,7 @@ func CreateServiceAccountFromToken(ctx context.Context, kubeClient client.Client
 }
 
 func performInitialCheckIn(ctx context.Context, mondooClientBuilder MondooClientBuilder, integrationMrn string, sa mondooclient.ServiceAccountCredentials, httpProxy *string, httpsProxy *string, noProxy *string, logger logr.Logger) error {
-	if err := IntegrationCheckIn(ctx, integrationMrn, sa, mondooClientBuilder, httpProxy, httpsProxy, noProxy, logger); err != nil {
+	if _, err := IntegrationCheckIn(ctx, integrationMrn, "", sa, mondooClientBuilder, httpProxy, httpsProxy, noProxy, logger); err != nil {
 		logger.Error(err, "initial CheckIn() failed, will CheckIn() periodically", "integrationMRN", integrationMrn)
 		return err
 	}

--- a/tests/e2e/aks/terraform/outputs.tf
+++ b/tests/e2e/aks/terraform/outputs.tf
@@ -82,3 +82,7 @@ output "enable_private_endpoint_access" {
   description = "Whether the scanner-to-target private endpoint NSG rule is enabled."
   value       = var.enable_private_endpoint_access
 }
+
+output "enable_integration" {
+  value = var.enable_integration
+}

--- a/tests/e2e/aks/terraform/variables.tf
+++ b/tests/e2e/aks/terraform/variables.tf
@@ -40,3 +40,9 @@ variable "enable_private_endpoint_access" {
   type        = bool
   default     = true
 }
+
+variable "enable_integration" {
+  description = "Create a K8s integration and use integration token instead of service account credentials"
+  type        = bool
+  default     = false
+}

--- a/tests/e2e/cmd/integration/main.go
+++ b/tests/e2e/cmd/integration/main.go
@@ -1,0 +1,123 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	mondoogql "go.mondoo.com/mondoo-go"
+	"go.mondoo.com/mondoo-go/option"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <create|delete>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "create":
+		if err := createIntegration(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "delete":
+		if err := deleteIntegration(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func loadSAData() ([]byte, error) {
+	if path := os.Getenv("MONDOO_CONFIG_PATH"); path != "" {
+		return os.ReadFile(path) //nolint:gosec // trusted env-var path from CI
+	}
+	if b64 := os.Getenv("MONDOO_CONFIG_BASE64"); b64 != "" {
+		return base64.StdEncoding.DecodeString(b64)
+	}
+	if b64 := os.Getenv("MONDOO_CREDS_B64"); b64 != "" {
+		return base64.StdEncoding.DecodeString(b64)
+	}
+	return nil, fmt.Errorf("set MONDOO_CONFIG_PATH, MONDOO_CONFIG_BASE64, or MONDOO_CREDS_B64")
+}
+
+func newClient() (*mondoogql.Client, error) {
+	data, err := loadSAData()
+	if err != nil {
+		return nil, err
+	}
+	return mondoogql.NewClient(option.WithServiceAccount(data))
+}
+
+func createIntegration() error {
+	spaceMrn := os.Getenv("MONDOO_SPACE_MRN")
+	if spaceMrn == "" {
+		return fmt.Errorf("MONDOO_SPACE_MRN must be set")
+	}
+	name := os.Getenv("INTEGRATION_NAME")
+	if name == "" {
+		name = "e2e-k8s-integration"
+	}
+
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	var m struct {
+		CreateIntegration struct {
+			Integration struct {
+				Mrn   string
+				Token string
+			}
+		} `graphql:"createClientIntegration(input: $input)"`
+	}
+	err = client.Mutate(context.Background(), &m, mondoogql.CreateClientIntegrationInput{
+		SpaceMrn: mondoogql.NewStringPtr(mondoogql.String(spaceMrn)),
+		Name:     mondoogql.String(name),
+		Type:     mondoogql.ClientIntegrationTypeK8s,
+		ConfigurationOptions: mondoogql.ClientIntegrationConfigurationInput{
+			K8sConfigurationOptions: &mondoogql.K8sConfigurationOptionsInput{
+				ScanNodes:        mondoogql.Boolean(true),
+				ScanWorkloads:    mondoogql.Boolean(true),
+				ScanPublicImages: mondoogql.NewBooleanPtr(mondoogql.Boolean(true)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("createClientIntegration: %w", err)
+	}
+
+	fmt.Printf("MRN=%s\n", m.CreateIntegration.Integration.Mrn)
+	fmt.Printf("TOKEN=%s\n", m.CreateIntegration.Integration.Token)
+	return nil
+}
+
+func deleteIntegration() error {
+	mrn := os.Getenv("INTEGRATION_MRN")
+	if mrn == "" {
+		return fmt.Errorf("INTEGRATION_MRN must be set")
+	}
+
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	var m struct {
+		DeleteIntegration struct {
+			Mrn string
+		} `graphql:"deleteClientIntegration(input: $input)"`
+	}
+	return client.Mutate(context.Background(), &m, mondoogql.DeleteClientIntegrationInput{
+		Mrn: mondoogql.String(mrn),
+	}, nil)
+}

--- a/tests/e2e/eks/terraform/outputs.tf
+++ b/tests/e2e/eks/terraform/outputs.tf
@@ -63,3 +63,7 @@ output "enable_private_endpoint_access" {
   description = "Whether the scanner-to-target private endpoint SG rule is enabled."
   value       = var.enable_private_endpoint_access
 }
+
+output "enable_integration" {
+  value = var.enable_integration
+}

--- a/tests/e2e/eks/terraform/variables.tf
+++ b/tests/e2e/eks/terraform/variables.tf
@@ -41,3 +41,9 @@ variable "enable_private_endpoint_access" {
   type        = bool
   default     = true
 }
+
+variable "enable_integration" {
+  description = "Create a K8s integration and use integration token instead of service account credentials"
+  type        = bool
+  default     = false
+}

--- a/tests/e2e/gke/terraform/outputs.tf
+++ b/tests/e2e/gke/terraform/outputs.tf
@@ -107,3 +107,7 @@ output "enable_asset_routing_test" {
 output "developers_space_id" {
   value = var.enable_asset_routing_test ? mondoo_space.developers[0].id : ""
 }
+
+output "enable_integration" {
+  value = var.enable_integration
+}

--- a/tests/e2e/gke/terraform/variables.tf
+++ b/tests/e2e/gke/terraform/variables.tf
@@ -58,3 +58,9 @@ variable "enable_asset_routing_test" {
   type        = bool
   default     = false
 }
+
+variable "enable_integration" {
+  description = "Create a K8s integration and use integration token instead of service account credentials"
+  type        = bool
+  default     = false
+}

--- a/tests/e2e/scripts/apply-mondoo-config.sh
+++ b/tests/e2e/scripts/apply-mondoo-config.sh
@@ -2,30 +2,59 @@
 # Copyright Mondoo, Inc. 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-# Create the Mondoo credentials secret and apply MondooAuditConfig
+# Create the Mondoo credentials secret and apply MondooAuditConfig.
+#
+# Integration mode (ENABLE_INTEGRATION=true) is orthogonal to the manifest
+# variant — any suite can opt in via the terraform variable. When enabled,
+# consoleIntegration and mondooTokenSecretRef are injected into whichever
+# manifest the suite selects.
+#
+# In integration mode the mondoo-client secret is NOT pre-created — the
+# operator creates it via token exchange (IntegrationRegister). Pre-creating
+# it would block the exchange because the operator uses CreateIfNotExist.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
-: "${MONDOO_CREDS_B64:?MONDOO_CREDS_B64 must be set}"
 : "${NAMESPACE:?NAMESPACE must be set}"
 
-info "Creating mondoo-client secret..."
+# --- Credentials ---
 
-# Decode the base64-encoded credentials and create/update the secret
-echo "${MONDOO_CREDS_B64}" | base64 -d > /tmp/mondoo-creds.json
-kubectl create secret generic mondoo-client \
-  --from-file=config=/tmp/mondoo-creds.json \
-  --namespace "${NAMESPACE}" \
-  --dry-run=client -o yaml | kubectl apply -f -
-rm -f /tmp/mondoo-creds.json
+if [[ "${ENABLE_INTEGRATION:-false}" == "true" ]]; then
+  # Integration mode: create integration, then only the token secret.
+  # The operator will exchange the token for SA creds + integration MRN
+  # and create the mondoo-client secret itself via CreateIfNotExist.
+  # Delete any pre-existing mondoo-client secret so the exchange isn't skipped.
+  info "Deleting stale mondoo-client secret (if any)..."
+  kubectl delete secret mondoo-client -n "${NAMESPACE}" --ignore-not-found
+
+  source "${SCRIPT_DIR}/create-integration.sh"
+
+  info "Creating mondoo-token secret..."
+  kubectl create secret generic mondoo-token \
+    --from-literal=token="${INTEGRATION_TOKEN}" \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+else
+  # Non-integration mode: create SA creds secret directly.
+  : "${MONDOO_CREDS_B64:?MONDOO_CREDS_B64 must be set}"
+
+  info "Creating mondoo-client secret..."
+  echo "${MONDOO_CREDS_B64}" | base64 -d > /tmp/mondoo-creds.json
+  kubectl create secret generic mondoo-client \
+    --from-file=config=/tmp/mondoo-creds.json \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  rm -f /tmp/mondoo-creds.json
+fi
+
+# --- Manifest selection ---
 
 info "Applying MondooAuditConfig..."
 export NAMESPACE
 
 # Select manifest based on test type and cluster mode.
-# Autopilot variants are GKE-specific; other clouds just use the base manifest.
 if [[ "${ENABLE_ENDPOINT_OVERRIDE_TEST:-false}" == "true" ]]; then
   MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config-wif-endpoint-override.yaml.tpl"
 elif [[ "${ENABLE_WIF_TEST:-false}" == "true" ]]; then
@@ -51,7 +80,21 @@ elif [[ "${AUTOPILOT:-false}" == "true" ]]; then
 else
   MANIFEST="${MANIFESTS_DIR}/mondoo-audit-config.yaml.tpl"
 fi
+
 info "Using manifest: $(basename "${MANIFEST}")"
-envsubst < "${MANIFEST}" | kubectl apply -f -
+RENDERED=$(envsubst < "${MANIFEST}")
+
+# Inject consoleIntegration fields when integration mode is enabled.
+# This works with any manifest variant — no need for separate -integration templates.
+if [[ "${ENABLE_INTEGRATION:-false}" == "true" ]]; then
+  info "Injecting consoleIntegration into manifest"
+  RENDERED=$(echo "${RENDERED}" | sed '/^spec:/a\
+  mondooTokenSecretRef:\
+    name: mondoo-token\
+  consoleIntegration:\
+    enable: true')
+fi
+
+echo "${RENDERED}" | kubectl apply -f -
 
 info "MondooAuditConfig applied."

--- a/tests/e2e/scripts/cleanup.sh
+++ b/tests/e2e/scripts/cleanup.sh
@@ -32,9 +32,16 @@ done
 info "Deleting MondooAuditConfigs..."
 kubectl delete mondooauditconfigs.k8s.mondoo.com --all -n "${NAMESPACE}" --ignore-not-found --timeout=30s || true
 
-# Mondoo credentials secret
+# Mondoo credentials/token secrets
 info "Deleting mondoo-client secret..."
 kubectl delete secret mondoo-client -n "${NAMESPACE}" --ignore-not-found
+info "Deleting mondoo-token secret..."
+kubectl delete secret mondoo-token -n "${NAMESPACE}" --ignore-not-found
+
+# Delete integration if one was created (reads state file from TF_DIR)
+if [[ "${ENABLE_INTEGRATION:-false}" == "true" ]]; then
+  source "${SCRIPT_DIR}/delete-integration.sh" || warn "Failed to delete integration"
+fi
 
 # Target cluster kubeconfig secret
 info "Deleting target-kubeconfig secret..."

--- a/tests/e2e/scripts/common.sh
+++ b/tests/e2e/scripts/common.sh
@@ -65,6 +65,8 @@ load_tf_outputs() {
     export TARGET_SPACE_ID="${TARGET_SPACE_ID:-$(terraform output -raw target_space_id)}"
   fi
 
+  export ENABLE_INTEGRATION="$(terraform output -raw enable_integration 2>/dev/null || echo "false")"
+
   cd ->/dev/null
 
   # Delegate to cloud-specific loader for remaining outputs and credential setup

--- a/tests/e2e/scripts/create-integration.sh
+++ b/tests/e2e/scripts/create-integration.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Idempotent integration lifecycle — creates once per terraform apply cycle,
+# reuses on subsequent suite runs within the same infra.
+#
+# State is persisted to $TF_DIR/.integration-state so cleanup.sh can delete it.
+# The token is single-use (consumed by the operator's token exchange), so we
+# delete and recreate the integration on each suite run to get a fresh token.
+#
+# Exports:
+#   INTEGRATION_MRN   — MRN of the integration
+#   INTEGRATION_TOKEN — registration token
+#
+# Auth: uses MONDOO_CONFIG_PATH, MONDOO_CONFIG_BASE64, or MONDOO_CREDS_B64
+# Required: MONDOO_SPACE_MRN, TF_DIR
+
+set -euo pipefail
+
+if ! type info &>/dev/null; then
+  info()  { echo "[INFO]  $(date '+%H:%M:%S') $*"; }
+  err()   { echo "[ERROR] $(date '+%H:%M:%S') $*" >&2; }
+fi
+
+: "${MONDOO_SPACE_MRN:?MONDOO_SPACE_MRN must be set}"
+: "${TF_DIR:?TF_DIR must be set}"
+
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+
+STATE_FILE="${TF_DIR}/.integration-state"
+
+# Clean up previous integration if one exists (token is single-use, can't reuse)
+if [[ -f "${STATE_FILE}" ]]; then
+  source "${STATE_FILE}"
+  if [[ -n "${INTEGRATION_MRN:-}" ]]; then
+    info "Deleting previous integration: ${INTEGRATION_MRN}"
+    export INTEGRATION_MRN
+    go run "${REPO_ROOT}/tests/e2e/cmd/integration" delete 2>/dev/null || true
+    unset INTEGRATION_MRN
+  fi
+  rm -f "${STATE_FILE}"
+fi
+
+info "Creating K8s integration in space ${MONDOO_SPACE_MRN}..."
+
+OUTPUT=$(go run "${REPO_ROOT}/tests/e2e/cmd/integration" create)
+
+INTEGRATION_MRN=$(echo "${OUTPUT}" | grep '^MRN=' | cut -d= -f2-)
+INTEGRATION_TOKEN=$(echo "${OUTPUT}" | grep '^TOKEN=' | cut -d= -f2-)
+
+if [[ -z "${INTEGRATION_MRN}" ]]; then
+  err "Failed to create integration"
+  exit 1
+fi
+
+# Persist state for cleanup
+cat > "${STATE_FILE}" <<EOF
+INTEGRATION_MRN="${INTEGRATION_MRN}"
+INTEGRATION_SPACE_MRN="${MONDOO_SPACE_MRN}"
+EOF
+
+export INTEGRATION_MRN
+export INTEGRATION_TOKEN
+
+info "Created integration: ${INTEGRATION_MRN}"

--- a/tests/e2e/scripts/delete-integration.sh
+++ b/tests/e2e/scripts/delete-integration.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Deletes a Mondoo K8s integration and removes the state file.
+#
+# Reads INTEGRATION_MRN from $TF_DIR/.integration-state if not already set.
+# Auth: uses MONDOO_CONFIG_PATH, MONDOO_CONFIG_BASE64, or MONDOO_CREDS_B64
+
+set -euo pipefail
+
+if ! type info &>/dev/null; then
+  info()  { echo "[INFO]  $(date '+%H:%M:%S') $*"; }
+  warn()  { echo "[WARN]  $(date '+%H:%M:%S') $*" >&2; }
+  err()   { echo "[ERROR] $(date '+%H:%M:%S') $*" >&2; }
+fi
+
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+
+STATE_FILE="${TF_DIR:+${TF_DIR}/.integration-state}"
+
+# Load from state file if INTEGRATION_MRN is not already set
+if [[ -z "${INTEGRATION_MRN:-}" && -n "${STATE_FILE}" && -f "${STATE_FILE}" ]]; then
+  source "${STATE_FILE}"
+fi
+
+if [[ -z "${INTEGRATION_MRN:-}" ]]; then
+  info "No integration to delete (no MRN found)"
+  return 0 2>/dev/null || exit 0
+fi
+
+info "Deleting integration ${INTEGRATION_MRN}..."
+
+export INTEGRATION_MRN
+go run "${REPO_ROOT}/tests/e2e/cmd/integration" delete
+
+# Clean up state file
+if [[ -n "${STATE_FILE}" && -f "${STATE_FILE}" ]]; then
+  rm -f "${STATE_FILE}"
+fi
+
+info "Deleted integration: ${INTEGRATION_MRN}"

--- a/tests/e2e/scripts/deploy-operator.sh
+++ b/tests/e2e/scripts/deploy-operator.sh
@@ -14,6 +14,11 @@ source "${SCRIPT_DIR}/common.sh"
 
 info "Deploying operator from local chart (image: ${IMAGE_REPO}:${IMAGE_TAG})..."
 
+# Helm does not update CRDs on upgrade, only on first install.
+# Apply them explicitly so schema changes (new status fields, etc.) take effect.
+info "Applying CRDs from local chart..."
+kubectl apply --server-side --force-conflicts -f "${REPO_ROOT}/charts/mondoo-operator/crds/"
+
 # Adopt any existing Mondoo CRDs so Helm can manage them
 for crd in $(kubectl get crds -o name 2>/dev/null | grep mondoo || true); do
   info "Adopting existing CRD for Helm: ${crd}"


### PR DESCRIPTION
Add operator-side support for pausing and unpausing K8s integration scanning from the Mondoo console. The integration controller now sends a configuration hash during CheckIn, detects config mismatches, fetches the updated configuration via the Configure endpoint, and reads the pauseScanning flag. When paused, all scan CronJobs are suspended.

Also adds e2e test infrastructure for integration mode: a Go CLI tool for creating/deleting K8s integrations via GraphQL, shell scripts for integration lifecycle management, and Terraform variables/outputs.