### PR TITLE
fix: set priorityClassName

### DIFF
--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -95,9 +95,10 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 							},
 						},
 						Spec: corev1.PodSpec{
-							NodeName:      node.Name,
-							RestartPolicy: corev1.RestartPolicyOnFailure,
-							Tolerations:   k8s.TaintsToTolerations(node.Spec.Taints),
+							NodeName:          node.Name,
+							PriorityClassName: m.Spec.Nodes.PriorityClassName,
+							RestartPolicy:     corev1.RestartPolicyOnFailure,
+							Tolerations:       k8s.TaintsToTolerations(node.Spec.Taints),
 							// The node scanning does not use the Kubernetes API at all, therefore the service account token
 							// should not be mounted at all.
 							AutomountServiceAccountToken: ptr.To(false),

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -277,6 +277,15 @@ func TestInventory_WithAnnotations(t *testing.T) {
 	}
 }
 
+func TestCronJob_WithPriorityClassName(t *testing.T) {
+	testNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-name"}}
+	mac := testMondooAuditConfig()
+	mac.Spec.Nodes.PriorityClassName = "high-priority"
+
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	assert.Equal(t, "high-priority", cj.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName)
+}
+
 func TestCronJob_WithProxy(t *testing.T) {
 	testNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-name"}}
 	mac := testMondooAuditConfig()

--- a/pkg/utils/k8s/update_fields_test.go
+++ b/pkg/utils/k8s/update_fields_test.go
@@ -26,6 +26,7 @@ func TestUpdateCronJobFields_ImagePullSecrets(t *testing.T) {
 								{Name: "my-secret"},
 								{Name: "another-secret"},
 							},
+							PriorityClassName: "high-priority",
 						},
 					},
 				},
@@ -39,6 +40,7 @@ func TestUpdateCronJobFields_ImagePullSecrets(t *testing.T) {
 	assert.Equal(t, desired.Spec.Schedule, obj.Spec.Schedule)
 	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.Containers, obj.Spec.JobTemplate.Spec.Template.Spec.Containers)
 	assert.Equal(t, desired.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets, obj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets)
+	assert.Equal(t, "high-priority", obj.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName)
 }
 
 func TestUpdateCronJobFields_PreservesUnmanagedFields(t *testing.T) {
@@ -48,8 +50,9 @@ func TestUpdateCronJobFields_PreservesUnmanagedFields(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							DNSPolicy:     corev1.DNSClusterFirst,
-							SchedulerName: "custom-scheduler",
+							DNSPolicy:         corev1.DNSClusterFirst,
+							SchedulerName:     "custom-scheduler",
+							PriorityClassName: "original-priority",
 						},
 					},
 				},
@@ -65,7 +68,8 @@ func TestUpdateCronJobFields_PreservesUnmanagedFields(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{Name: "test"}},
+							Containers:        []corev1.Container{{Name: "test"}},
+							PriorityClassName: "desired-priority",
 						},
 					},
 				},
@@ -77,6 +81,7 @@ func TestUpdateCronJobFields_PreservesUnmanagedFields(t *testing.T) {
 
 	// Managed fields are updated
 	assert.Equal(t, "*/10 * * * *", obj.Spec.Schedule)
+	assert.Equal(t, "desired-priority", obj.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName)
 	// Unmanaged fields are preserved
 	assert.Equal(t, corev1.DNSClusterFirst, obj.Spec.JobTemplate.Spec.Template.Spec.DNSPolicy)
 	assert.Equal(t, "custom-scheduler", obj.Spec.JobTemplate.Spec.Template.Spec.SchedulerName)


### PR DESCRIPTION
# The bug
We deployed a mondooauditconfig with a priorityClass in our environment, but noticed the priorityClass was not set on any of the jobs spawned by the cronjobs. here is an auditconfig for reproduction:

 ```yaml
apiVersion: k8s.mondoo.com/v1alpha2
kind: MondooAuditConfig
metadata:
 name: audit
 namespace: mondoo-operator
spec:
 consoleIntegration:
   enable: true
 kubernetesResources:
   enable: false
 containers:
   enable: false
 nodes:
   enable: true
   priorityClassName: system-node-critical
   style: cronjob
 mondooCredsSecretRef:
   name: mondoo-client
 mondooTokenSecretRef:
   name: mondoo-token
 ```

I looked through the code a bit and noticed, that the priorityClass is never set when using the cronjob style. 

## Fix
I added a bare minimum fix in this pr. I guess this could also be refactored out into a function, so this sort of problem doesn't happen again. Let me know if that's something you want implemented and I'll do it.