### PR TITLE
✨ expose cnspec image version (semver) via CRD status

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -534,6 +534,15 @@ type MondooAuditConfigStatus struct {
 	// ReconciledByOperatorVersion contains the version of the operator which reconciled this MondooAuditConfig
 	ReconciledByOperatorVersion string `json:"reconciledByOperatorVersion,omitempty"`
 
+	// CnspecVersion contains the semantic version of the cnspec image, extracted from the
+	// org.opencontainers.image.version OCI label.
+	// +optional
+	CnspecVersion string `json:"cnspecVersion,omitempty"`
+
+	// CnspecImageDigest contains the digest of the cnspec image used for scanning
+	// +optional
+	CnspecImageDigest string `json:"cnspecImageDigest,omitempty"`
+
 	// LastK8sResourceGarbageCollectionTime tracks the last time the operator performed
 	// garbage collection of stale K8s resource scan assets.
 	// +optional

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1483,6 +1483,15 @@ spec:
           status:
             description: MondooAuditConfigStatus defines the observed state of MondooAuditConfig
             properties:
+              cnspecImageDigest:
+                description: CnspecImageDigest contains the digest of the cnspec image
+                  used for scanning
+                type: string
+              cnspecVersion:
+                description: |-
+                  CnspecVersion contains the semantic version of the cnspec image, extracted from the
+                  org.opencontainers.image.version OCI label.
+                type: string
               conditions:
                 description: Conditions includes detailed status for the MondooAuditConfig
                 items:

--- a/controllers/mondooauditconfig_controller.go
+++ b/controllers/mondooauditconfig_controller.go
@@ -338,6 +338,20 @@ func (r *MondooAuditConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	mondooAuditConfig.Status.ReconciledByOperatorVersion = version.Version
 
+	if imageResolver != nil {
+		// CnspecImage is also called by the sub-reconcilers above; the image cacher
+		// deduplicates via a 24h TTL cache, so this is a map lookup, not a registry call.
+		resolvedCnspecImage, err := imageResolver.CnspecImage(
+			mondooAuditConfig.Spec.Scanner.Image.Name, mondooAuditConfig.Spec.Scanner.Image.Tag, mondooAuditConfig.Spec.Scanner.Image.Digest, config.Spec.SkipContainerResolution)
+		if err == nil {
+			if _, digest, ok := strings.Cut(resolvedCnspecImage, "@"); ok {
+				mondooAuditConfig.Status.CnspecImageDigest = digest
+			}
+		}
+		mondooAuditConfig.Status.CnspecVersion = imageResolver.CnspecImageVersion(
+			mondooAuditConfig.Spec.Scanner.Image.Name, mondooAuditConfig.Spec.Scanner.Image.Tag, mondooAuditConfig.Spec.Scanner.Image.Digest)
+	}
+
 	if firstError != nil {
 		return ctrl.Result{}, firstError
 	}

--- a/controllers/status/operator_status_test.go
+++ b/controllers/status/operator_status_test.go
@@ -202,6 +202,10 @@ type mockContainerImageResolver struct {
 	operatorSkipValues []bool
 }
 
+func (m *mockContainerImageResolver) CnspecImageVersion(_, _, _ string) string {
+	return ""
+}
+
 func (m *mockContainerImageResolver) CnspecImage(_, _, _ string, skipImageResolution bool) (string, error) {
 	m.cnspecSkipValues = append(m.cnspecSkipValues, skipImageResolution)
 	if skipImageResolution {

--- a/pkg/imagecache/imagecache.go
+++ b/pkg/imagecache/imagecache.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"go.mondoo.com/mql/v13/providers/os/connection/container/auth"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,8 @@ const (
 
 type ImageCacher interface {
 	GetImage(string) (string, error)
+	// GetImageVersion returns the OCI version label for a previously resolved image.
+	GetImageVersion(image string) string
 	// WithAuth returns a new ImageCacher that uses the provided authentication keychain
 	WithAuth(keychain authn.Keychain) ImageCacher
 }
@@ -35,12 +38,18 @@ type ImageCacher interface {
 type imageCache struct {
 	images      map[string]imageData
 	imagesMutex *sync.RWMutex
-	fetchImage  func(string) (string, error)
+	fetchImage  func(string) (fetchResult, error)
 	keychain    authn.Keychain
+}
+
+type fetchResult struct {
+	url     string
+	version string
 }
 
 type imageData struct {
 	url         string
+	version     string
 	lastUpdated time.Time
 }
 
@@ -79,25 +88,36 @@ func (i *imageCache) getImageWithSHA(image string) (string, error) {
 	return img.url, nil
 }
 
+func (i *imageCache) GetImageVersion(image string) string {
+	i.imagesMutex.RLock()
+	defer i.imagesMutex.RUnlock()
+
+	if img, ok := i.images[image]; ok {
+		return img.version
+	}
+	return ""
+}
+
 // updateImage will make a query out to the registry and store the sha for the image
 func (i *imageCache) updateImage(image string) error {
-	imageUrl, err := i.fetchImage(image)
+	result, err := i.fetchImage(image)
 	if err != nil {
 		return err
 	}
 
 	i.images[image] = imageData{
-		url:         imageUrl,
+		url:         result.url,
+		version:     result.version,
 		lastUpdated: time.Now(),
 	}
 
 	return nil
 }
 
-func queryImageWithSHA(image string, keychain authn.Keychain) (string, error) {
+func queryImageWithSHA(image string, keychain authn.Keychain) (fetchResult, error) {
 	ref, err := name.ParseReference(image)
 	if err != nil {
-		return "", err
+		return fetchResult{}, err
 	}
 
 	// Use provided keychain if given, otherwise use cnquery's auth which supports ECR, GCR, etc.
@@ -110,20 +130,74 @@ func queryImageWithSHA(image string, keychain authn.Keychain) (string, error) {
 
 	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(kc))
 	if err != nil {
-		return "", err
+		return fetchResult{}, err
 	}
 	imgDigest := desc.Digest.String()
 	repoName := ref.Context().Name()
 	imageUrl := repoName + "@" + imgDigest
 
-	return imageUrl, nil
+	version := extractVersionLabel(ref, desc, kc)
+
+	return fetchResult{url: imageUrl, version: version}, nil
+}
+
+func extractVersionLabel(ref name.Reference, desc *remote.Descriptor, kc authn.Keychain) string {
+	cf, err := configFileFromDescriptor(ref, desc, kc)
+	if err != nil || cf == nil {
+		return ""
+	}
+	version := cf.Config.Labels["org.opencontainers.image.version"]
+	for _, suffix := range []string{"-ubi-rootless", "-rootless"} {
+		if v, ok := strings.CutSuffix(version, suffix); ok {
+			return v
+		}
+	}
+	return version
+}
+
+// configFileFromDescriptor extracts the image config, handling both single-arch
+// images and multi-arch manifest lists (picking the first child manifest).
+func configFileFromDescriptor(ref name.Reference, desc *remote.Descriptor, kc authn.Keychain) (*v1.ConfigFile, error) {
+	if desc.MediaType.IsImage() {
+		img, err := desc.Image()
+		if err != nil {
+			return nil, err
+		}
+		return img.ConfigFile()
+	}
+
+	if !desc.MediaType.IsIndex() {
+		return nil, fmt.Errorf("unexpected media type: %s", desc.MediaType)
+	}
+
+	idx, err := desc.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := idx.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	if len(manifest.Manifests) == 0 {
+		return nil, fmt.Errorf("empty image index")
+	}
+	childRef := ref.Context().Digest(manifest.Manifests[0].Digest.String())
+	childDesc, err := remote.Get(childRef, remote.WithAuthFromKeychain(kc))
+	if err != nil {
+		return nil, err
+	}
+	img, err := childDesc.Image()
+	if err != nil {
+		return nil, err
+	}
+	return img.ConfigFile()
 }
 
 func NewImageCacher() ImageCacher {
 	return &imageCache{
 		images:      map[string]imageData{},
 		imagesMutex: &sync.RWMutex{},
-		fetchImage: func(image string) (string, error) {
+		fetchImage: func(image string) (fetchResult, error) {
 			return queryImageWithSHA(image, nil)
 		},
 	}
@@ -133,7 +207,7 @@ func (i *imageCache) WithAuth(keychain authn.Keychain) ImageCacher {
 	return &imageCache{
 		images:      i.images,
 		imagesMutex: i.imagesMutex,
-		fetchImage: func(image string) (string, error) {
+		fetchImage: func(image string) (fetchResult, error) {
 			return queryImageWithSHA(image, keychain)
 		},
 		keychain: keychain,

--- a/pkg/imagecache/imagecache_test.go
+++ b/pkg/imagecache/imagecache_test.go
@@ -31,7 +31,7 @@ func TestCache(t *testing.T) {
 	tests := []struct {
 		name            string
 		imagesMap       map[string]imageData
-		fetchImageFunc  func(string) (string, error)
+		fetchImageFunc  func(string) (fetchResult, error)
 		expectedImage   string
 		extraValidation func(*testing.T, *imageCache)
 		expectError     bool
@@ -45,8 +45,8 @@ func TestCache(t *testing.T) {
 					lastUpdated: time.Now(),
 				},
 			},
-			fetchImageFunc: func(string) (string, error) {
-				return "", fmt.Errorf("should not call fetchImage")
+			fetchImageFunc: func(string) (fetchResult, error) {
+				return fetchResult{}, fmt.Errorf("should not call fetchImage")
 			},
 		},
 		{
@@ -58,22 +58,22 @@ func TestCache(t *testing.T) {
 					lastUpdated: time.Now().Add(-25 * time.Hour),
 				},
 			},
-			fetchImageFunc: func(string) (string, error) {
-				return testUpdatedImageDigest, nil
+			fetchImageFunc: func(string) (fetchResult, error) {
+				return fetchResult{url: testUpdatedImageDigest}, nil
 			},
 		},
 		{
 			name:          "image not in cache",
 			expectedImage: testCurrentImageDigest,
 			imagesMap:     map[string]imageData{},
-			fetchImageFunc: func(string) (string, error) {
-				return testCurrentImageDigest, nil
+			fetchImageFunc: func(string) (fetchResult, error) {
+				return fetchResult{url: testCurrentImageDigest}, nil
 			},
 		},
 		{
 			name: "error during image fetching",
-			fetchImageFunc: func(string) (string, error) {
-				return "", fmt.Errorf("example error while fetching image")
+			fetchImageFunc: func(string) (fetchResult, error) {
+				return fetchResult{}, fmt.Errorf("example error while fetching image")
 			},
 			expectError: true,
 		},

--- a/pkg/utils/mondoo/container_image_resolver.go
+++ b/pkg/utils/mondoo/container_image_resolver.go
@@ -40,6 +40,10 @@ type ContainerImageResolver interface {
 	// When userDigest is specified, it takes precedence over userTag.
 	CnspecImage(userImage, userTag, userDigest string, skipImageResolution bool) (string, error)
 
+	// CnspecImageVersion returns the OCI version label (org.opencontainers.image.version) from
+	// the cnspec image. Must be called after CnspecImage to populate the cache.
+	CnspecImageVersion(userImage, userTag, userDigest string) string
+
 	// MondooOperatorImage return the Mondoo operator image. If skipResolveImage is false, then the image tag is replaced
 	// by a digest. If userImage, userTag, or userDigest are empty strings, default values are used.
 	// When userDigest is specified, it takes precedence over userTag.
@@ -111,6 +115,17 @@ func (c *containerImageResolver) CnspecImage(userImage, userTag, userDigest stri
 	}
 
 	return c.resolveImage(context.Background(), image, skipImageResolution)
+}
+
+func (c *containerImageResolver) CnspecImageVersion(userImage, userTag, userDigest string) string {
+	defaultTag := CnspecTag
+	if c.resolveForOpenShift {
+		defaultTag = OpenShiftMondooClientTag
+	}
+	defaultImage := CnspecImage
+	image := userImageOrDefault(defaultImage, defaultTag, userImage, userTag, userDigest)
+	image = c.applyImageRegistry(image)
+	return c.imageCacher.GetImageVersion(image)
 }
 
 func (c *containerImageResolver) MondooOperatorImage(ctx context.Context, userImage, userTag, userDigest string, skipImageResolution bool) (string, error) {

--- a/pkg/utils/mondoo/container_image_resolver_test.go
+++ b/pkg/utils/mondoo/container_image_resolver_test.go
@@ -36,6 +36,10 @@ func (f *fakeCacher) GetImage(img string) (string, error) {
 	return f.fakeGetImage(img)
 }
 
+func (f *fakeCacher) GetImageVersion(_ string) string {
+	return ""
+}
+
 func (f *fakeCacher) WithAuth(keychain authn.Keychain) imagecache.ImageCacher {
 	return f // Return itself since we don't need auth in tests
 }

--- a/pkg/utils/mondoo/fake/container_image_resolver.go
+++ b/pkg/utils/mondoo/fake/container_image_resolver.go
@@ -18,6 +18,10 @@ func NewNoOpContainerImageResolver() mondoo.ContainerImageResolver {
 	return &noOpContainerImageResolver{}
 }
 
+func (c *noOpContainerImageResolver) CnspecImageVersion(_, _, _ string) string {
+	return ""
+}
+
 func (c *noOpContainerImageResolver) CnspecImage(userImage, userTag, userDigest string, skipResolveImage bool) (string, error) {
 	image := mondoo.CnspecImage
 	if userImage != "" {
@@ -52,6 +56,10 @@ func (c *noOpContainerImageResolver) MondooOperatorImage(ctx context.Context, us
 type ContainerImageResolverMock struct {
 	CnspecImageFunc         func(userImage, userTag, userDigest string, skipResolveImage bool) (string, error)
 	MondooOperatorImageFunc func(ctx context.Context, userImage, userTag, userDigest string, skipResolveImage bool) (string, error)
+}
+
+func (c *ContainerImageResolverMock) CnspecImageVersion(_, _, _ string) string {
+	return ""
 }
 
 func (c *ContainerImageResolverMock) CnspecImage(userImage, userTag, userDigest string, skipResolveImage bool) (string, error) {


### PR DESCRIPTION
Helps tracking cnspec image updates without digging into scanner logs