### PR TITLE
🔧 configure CI jobs concurrency

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
       - "main"
     tags: ["v*.*.*"]
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,10 @@ on:
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 # Restrictive top-level default; individual jobs escalate as needed.
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 4 * * 3' # Every Wednesday at 4:00 AM
 
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: false
+
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions:
   contents: read


### PR DESCRIPTION
- QOL: Limits container publishing concurrency
- Limiting tests jobs concurrency to avoid races for Mondoo Platform resources