### PR TITLE
feat: add Vault namespace support for external cluster auth

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -390,6 +390,13 @@ type VaultAuthConfig struct {
 	// +kubebuilder:validation:Required
 	VaultAddr string `json:"vaultAddr"`
 
+	// VaultNamespace is the Vault Enterprise / HCP Vault namespace to use for all
+	// requests (sets the X-Vault-Namespace header). Leave empty for Vault OSS or
+	// the root namespace.
+	// Example: "admin/team-a"
+	// +optional
+	VaultNamespace string `json:"vaultNamespace,omitempty"`
+
 	// AuthPath is the Vault Kubernetes auth method mount path.
 	// +optional
 	// +kubebuilder:default="auth/kubernetes"

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -720,6 +720,13 @@ spec:
                                 VaultAddr is the address of the Vault server.
                                 Example: "https://vault.example.com:8200"
                               type: string
+                            vaultNamespace:
+                              description: |-
+                                VaultNamespace is the Vault Enterprise / HCP Vault namespace to use for all
+                                requests (sets the X-Vault-Namespace header). Leave empty for Vault OSS or
+                                the root namespace.
+                                Example: "admin/team-a"
+                              type: string
                           required:
                           - authRole
                           - credsRole

--- a/controllers/k8s_scan/vault.go
+++ b/controllers/k8s_scan/vault.go
@@ -42,6 +42,14 @@ func DefaultVaultTokenFetcher(ctx context.Context, saToken string, config v1alph
 		return "", fmt.Errorf("failed to create Vault client: %w", err)
 	}
 
+	// Scope all requests to the configured Vault Enterprise / HCP namespace, if any.
+	// This applies to both the Kubernetes auth login and the credential generation below.
+	if config.VaultNamespace != "" {
+		if err := client.SetNamespace(config.VaultNamespace); err != nil {
+			return "", fmt.Errorf("failed to set Vault namespace: %w", err)
+		}
+	}
+
 	// Authenticate to Vault using Kubernetes auth
 	authPath := config.AuthPath
 	if authPath == "" {

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -552,6 +552,7 @@ externalClusters:
       authRole: mondoo-scanner        # Vault K8s auth role
       credsRole: target-cluster-creds  # Vault K8s secrets engine role
       # Optional fields:
+      # vaultNamespace: "admin/team-a" # Vault Enterprise / HCP Vault namespace
       # authPath: "auth/kubernetes"    # Vault K8s auth mount path (default)
       # secretsPath: "kubernetes"      # Vault K8s secrets engine mount (default)
       # kubernetesNamespace: scanning  # Target namespace for generated token


### PR DESCRIPTION
Add an optional `vaultNamespace` field to VaultAuthConfig so the operator can fetch dynamic Kubernetes credentials from a Vault Enterprise / HCP Vault namespace. When set, DefaultVaultTokenFetcher scopes all requests to that namespace (X-Vault-Namespace header) via client.SetNamespace, covering both the Kubernetes auth login and the credential generation.

The field is optional; an empty value targets Vault OSS or the root namespace, so no new validation is required.

- api/v1alpha2: add VaultNamespace field to VaultAuthConfig
- controllers/k8s_scan/vault.go: set the namespace on the Vault client
- config/crd: regenerate CRD manifest
- docs/user-manual.md: document the vaultNamespace option