### PR TITLE
✨ add global jobOverrides, labels, and toleration dedup

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -41,6 +41,12 @@ type MondooAuditConfigSpec struct {
 	// and filterable in the Mondoo Console.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// JobOverrides provides global defaults for all operator-generated scan Jobs.
+	// Per-scan-type overrides (e.g. spec.containers.jobOverrides) are deep-merged
+	// with this global config; per-type values take precedence on key conflicts.
+	// +optional
+	JobOverrides JobOverrides `json:"jobOverrides,omitempty"`
+
 	// Admission is DEPRECATED and ignored. Admission webhooks were removed in v12.1.0.
 	// The operator will automatically clean up any orphaned admission resources.
 	// See docs/admission-migration-guide.md for migration instructions.
@@ -77,6 +83,11 @@ type JobOverrides struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+
+	// Labels are added to the Jobs and their pod templates. Operator-managed
+	// labels take precedence and cannot be overwritten.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations are added to the Jobs and their pod templates (e.g.
 	// "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -277,6 +277,13 @@ func (in *JobOverrides) DeepCopyInto(out *JobOverrides) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -460,6 +467,7 @@ func (in *MondooAuditConfigSpec) DeepCopyInto(out *MondooAuditConfigSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.JobOverrides.DeepCopyInto(&out.JobOverrides)
 	if in.Admission != nil {
 		in, out := &in.Admission, &out.Admission
 		*out = new(DeprecatedAdmission)

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -276,6 +276,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -583,6 +590,84 @@ spec:
                           type: string
                         type: array
                     type: object
+                type: object
+              jobOverrides:
+                description: |-
+                  JobOverrides provides global defaults for all operator-generated scan Jobs.
+                  Per-scan-type overrides (e.g. spec.containers.jobOverrides) are deep-merged
+                  with this global config; per-type values take precedence on key conflicts.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are added to the Jobs and their pod templates (e.g.
+                      "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
+                      and cannot be overwritten.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are added to the Jobs and their pod templates. Operator-managed
+                      labels take precedence and cannot be overwritten.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector constrains the scan pods to nodes with matching labels. It is ignored for
+                      node scan pods because those are pinned to a specific node.
+                    type: object
+                  tolerations:
+                    description: Tolerations are appended to the tolerations of the
+                      scan pods.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished limits the lifetime of scan Jobs that have finished execution.
+                      The value is set as ttlSecondsAfterFinished on the Jobs spawned by the scan CronJobs.
+                      If unset, finished Jobs are kept according to the CronJob history limits.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               kubernetesResources:
                 properties:
@@ -1006,6 +1091,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -1326,6 +1418,13 @@ spec:
                           Annotations are added to the Jobs and their pod templates (e.g.
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
                         type: object
                       nodeSelector:
                         additionalProperties:

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -276,6 +276,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -583,6 +590,84 @@ spec:
                           type: string
                         type: array
                     type: object
+                type: object
+              jobOverrides:
+                description: |-
+                  JobOverrides provides global defaults for all operator-generated scan Jobs.
+                  Per-scan-type overrides (e.g. spec.containers.jobOverrides) are deep-merged
+                  with this global config; per-type values take precedence on key conflicts.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are added to the Jobs and their pod templates (e.g.
+                      "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
+                      and cannot be overwritten.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are added to the Jobs and their pod templates. Operator-managed
+                      labels take precedence and cannot be overwritten.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector constrains the scan pods to nodes with matching labels. It is ignored for
+                      node scan pods because those are pinned to a specific node.
+                    type: object
+                  tolerations:
+                    description: Tolerations are appended to the tolerations of the
+                      scan pods.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished limits the lifetime of scan Jobs that have finished execution.
+                      The value is set as ttlSecondsAfterFinished on the Jobs spawned by the scan CronJobs.
+                      If unset, finished Jobs are kept according to the CronJob history limits.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               kubernetesResources:
                 properties:
@@ -1006,6 +1091,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -1326,6 +1418,13 @@ spec:
                           Annotations are added to the Jobs and their pod templates (e.g.
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
                         type: object
                       nodeSelector:
                         additionalProperties:

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -276,6 +276,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -583,6 +590,84 @@ spec:
                           type: string
                         type: array
                     type: object
+                type: object
+              jobOverrides:
+                description: |-
+                  JobOverrides provides global defaults for all operator-generated scan Jobs.
+                  Per-scan-type overrides (e.g. spec.containers.jobOverrides) are deep-merged
+                  with this global config; per-type values take precedence on key conflicts.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are added to the Jobs and their pod templates (e.g.
+                      "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
+                      and cannot be overwritten.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are added to the Jobs and their pod templates. Operator-managed
+                      labels take precedence and cannot be overwritten.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector constrains the scan pods to nodes with matching labels. It is ignored for
+                      node scan pods because those are pinned to a specific node.
+                    type: object
+                  tolerations:
+                    description: Tolerations are appended to the tolerations of the
+                      scan pods.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished limits the lifetime of scan Jobs that have finished execution.
+                      The value is set as ttlSecondsAfterFinished on the Jobs spawned by the scan CronJobs.
+                      If unset, finished Jobs are kept according to the CronJob history limits.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               kubernetesResources:
                 properties:
@@ -1006,6 +1091,13 @@ spec:
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
+                        type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -1326,6 +1418,13 @@ spec:
                           Annotations are added to the Jobs and their pod templates (e.g.
                           "karpenter.sh/do-not-disrupt": "true"). Operator-managed annotations take precedence
                           and cannot be overwritten.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are added to the Jobs and their pod templates. Operator-managed
+                          labels take precedence and cannot be overwritten.
                         type: object
                       nodeSelector:
                         additionalProperties:

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -237,7 +237,7 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 		)
 	}
 
-	k8s.ApplyJobOverrides(cronjob, m.Spec.Containers.JobOverrides)
+	k8s.ApplyJobOverrides(cronjob, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.Containers.JobOverrides))
 
 	return cronjob
 }

--- a/controllers/container_image/resources_test.go
+++ b/controllers/container_image/resources_test.go
@@ -108,6 +108,7 @@ func TestCronJob_JobOverrides(t *testing.T) {
 	m := testAuditConfig()
 	m.Spec.Containers.JobOverrides = v1alpha2.JobOverrides{
 		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "security"},
 		Annotations:             map[string]string{"karpenter.sh/do-not-disrupt": "true"},
 		NodeSelector:            map[string]string{"workload-type": "mondoo-scan"},
 		Tolerations: []corev1.Toleration{
@@ -118,10 +119,32 @@ func TestCronJob_JobOverrides(t *testing.T) {
 
 	cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Labels["team"])
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Spec.Template.Labels["team"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Spec.Template.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, cj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, m.Spec.Containers.JobOverrides.Tolerations, cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations)
+}
+
+func TestCronJob_GlobalJobOverrides(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		Labels:                  map[string]string{"team": "security", "env": "prod"},
+		Annotations:             map[string]string{"global-annotation": "value"},
+	}
+	m.Spec.Containers.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "platform"},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "platform", cj.Spec.JobTemplate.Labels["team"])
+	assert.Equal(t, "prod", cj.Spec.JobTemplate.Labels["env"])
+	assert.Equal(t, "value", cj.Spec.JobTemplate.Annotations["global-annotation"])
 }
 
 func TestCronJob_WithImagePullSecrets(t *testing.T) {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -193,7 +193,7 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 		)
 	}
 
-	k8s.ApplyJobOverrides(cronjob, m.Spec.KubernetesResources.JobOverrides)
+	k8s.ApplyJobOverrides(cronjob, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.KubernetesResources.JobOverrides))
 
 	return cronjob
 }
@@ -599,7 +599,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 		}
 	}
 
-	k8s.ApplyJobOverrides(cronjob, m.Spec.KubernetesResources.JobOverrides)
+	k8s.ApplyJobOverrides(cronjob, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.KubernetesResources.JobOverrides))
 
 	return cronjob
 }

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -338,6 +338,7 @@ func TestCronJob_JobOverrides(t *testing.T) {
 	m := testAuditConfig()
 	m.Spec.KubernetesResources.JobOverrides = v1alpha2.JobOverrides{
 		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "security"},
 		Annotations:             map[string]string{"karpenter.sh/do-not-disrupt": "true"},
 		NodeSelector:            map[string]string{"workload-type": "mondoo-scan"},
 		Tolerations: []corev1.Toleration{
@@ -348,16 +349,36 @@ func TestCronJob_JobOverrides(t *testing.T) {
 
 	cj := CronJob("test-image:latest", m, cfg)
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Labels["team"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Spec.Template.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, cj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, m.Spec.KubernetesResources.JobOverrides.Tolerations, cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations)
 }
 
+func TestCronJob_GlobalJobOverrides(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		Labels:                  map[string]string{"team": "security", "env": "prod"},
+	}
+	m.Spec.KubernetesResources.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "platform"},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", m, cfg)
+	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "platform", cj.Spec.JobTemplate.Labels["team"])
+	assert.Equal(t, "prod", cj.Spec.JobTemplate.Labels["env"])
+}
+
 func TestExternalClusterCronJob_JobOverrides(t *testing.T) {
 	m := testAuditConfig()
 	m.Spec.KubernetesResources.JobOverrides = v1alpha2.JobOverrides{
 		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "security"},
 		Annotations:             map[string]string{"karpenter.sh/do-not-disrupt": "true"},
 		NodeSelector:            map[string]string{"workload-type": "mondoo-scan"},
 		Tolerations: []corev1.Toleration{
@@ -372,6 +393,7 @@ func TestExternalClusterCronJob_JobOverrides(t *testing.T) {
 
 	cj := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Labels["team"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Spec.Template.Annotations["karpenter.sh/do-not-disrupt"])
 	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, cj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector)

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -182,7 +182,7 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 			cfg.Spec.ImagePullSecrets...)
 	}
 
-	k8s.ApplyJobOverrides(cj, m.Spec.Nodes.JobOverrides)
+	k8s.ApplyJobOverrides(cj, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.Nodes.JobOverrides))
 
 	return cj
 }

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -257,6 +257,7 @@ func TestCronJob_JobOverrides(t *testing.T) {
 	mac := testMondooAuditConfig()
 	mac.Spec.Nodes.JobOverrides = v1alpha2.JobOverrides{
 		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "security"},
 		Annotations:             map[string]string{"karpenter.sh/do-not-disrupt": "true"},
 		NodeSelector:            map[string]string{"workload-type": "mondoo-scan"},
 		Tolerations: []corev1.Toleration{
@@ -266,6 +267,10 @@ func TestCronJob_JobOverrides(t *testing.T) {
 
 	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+
+	// User labels are applied
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Labels["team"])
+	assert.Equal(t, "security", cj.Spec.JobTemplate.Spec.Template.Labels["team"])
 
 	// User annotations are merged; operator-managed annotations are kept
 	assert.Equal(t, "true", cj.Spec.JobTemplate.Annotations["karpenter.sh/do-not-disrupt"])
@@ -281,6 +286,26 @@ func TestCronJob_JobOverrides(t *testing.T) {
 	require.Len(t, tolerations, 2)
 	assert.Equal(t, "node-taint", tolerations[0].Key)
 	assert.Equal(t, mac.Spec.Nodes.JobOverrides.Tolerations[0], tolerations[1])
+}
+
+func TestCronJob_GlobalJobOverrides(t *testing.T) {
+	testNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node-name"},
+	}
+	mac := testMondooAuditConfig()
+	mac.Spec.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		Labels:                  map[string]string{"team": "security", "env": "prod"},
+	}
+	mac.Spec.Nodes.JobOverrides = v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(300)),
+		Labels:                  map[string]string{"team": "platform"},
+	}
+
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, "platform", cj.Spec.JobTemplate.Labels["team"])
+	assert.Equal(t, "prod", cj.Spec.JobTemplate.Labels["env"])
 }
 
 func TestDaemonSet_Capabilities(t *testing.T) {

--- a/pkg/utils/k8s/job_overrides.go
+++ b/pkg/utils/k8s/job_overrides.go
@@ -4,10 +4,91 @@
 package k8s
 
 import (
+	"maps"
+
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
 )
+
+// MergeJobOverrides deep-merges a global JobOverrides with a per-scan-type
+// override. Per-type values take precedence on key conflicts for maps; for
+// scalar pointers, per-type wins if non-nil; tolerations are union-merged
+// with dedup.
+func MergeJobOverrides(global, perType v1alpha2.JobOverrides) v1alpha2.JobOverrides {
+	merged := v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: global.TTLSecondsAfterFinished,
+		Labels:                  mergeMaps(global.Labels, perType.Labels),
+		Annotations:             mergeMaps(global.Annotations, perType.Annotations),
+		NodeSelector:            mergeMaps(global.NodeSelector, perType.NodeSelector),
+		Tolerations:             MergeTolerations(global.Tolerations, perType.Tolerations),
+	}
+	if perType.TTLSecondsAfterFinished != nil {
+		merged.TTLSecondsAfterFinished = perType.TTLSecondsAfterFinished
+	}
+	return merged
+}
+
+// mergeMaps deep-merges two string maps. Values in the override map take
+// precedence on key conflicts. Returns nil when both inputs are nil.
+func mergeMaps(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(override))
+	maps.Copy(merged, base)
+	maps.Copy(merged, override)
+	return merged
+}
+
+// MergeTolerations returns the union of two toleration slices, deduplicating
+// by (Key, Operator, Value, Effect, TolerationSeconds). The first slice's
+// entries take precedence when duplicates exist.
+func MergeTolerations(existing, additional []corev1.Toleration) []corev1.Toleration {
+	if len(existing) == 0 && len(additional) == 0 {
+		return nil
+	}
+
+	type tolerationKey struct {
+		Key                  string
+		Operator             corev1.TolerationOperator
+		Value                string
+		Effect               corev1.TaintEffect
+		TolerationSecondsSet bool
+		TolerationSeconds    int64
+	}
+
+	keyFor := func(t corev1.Toleration) tolerationKey {
+		k := tolerationKey{
+			Key:      t.Key,
+			Operator: t.Operator,
+			Value:    t.Value,
+			Effect:   t.Effect,
+		}
+		if t.TolerationSeconds != nil {
+			k.TolerationSecondsSet = true
+			k.TolerationSeconds = *t.TolerationSeconds
+		}
+		return k
+	}
+
+	seen := make(map[tolerationKey]struct{}, len(existing))
+	result := make([]corev1.Toleration, 0, len(existing)+len(additional))
+
+	for _, t := range existing {
+		seen[keyFor(t)] = struct{}{}
+		result = append(result, *t.DeepCopy())
+	}
+	for _, t := range additional {
+		if _, ok := seen[keyFor(t)]; ok {
+			continue
+		}
+		seen[keyFor(t)] = struct{}{}
+		result = append(result, *t.DeepCopy())
+	}
+	return result
+}
 
 // ApplyJobOverrides applies user-configured overrides to a generated scan CronJob.
 func ApplyJobOverrides(cj *batchv1.CronJob, o v1alpha2.JobOverrides) {
@@ -15,9 +96,14 @@ func ApplyJobOverrides(cj *batchv1.CronJob, o v1alpha2.JobOverrides) {
 		cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished = o.TTLSecondsAfterFinished
 	}
 
+	if len(o.Labels) > 0 {
+		cj.Spec.JobTemplate.Labels = mergeUserMetadata(cj.Spec.JobTemplate.Labels, o.Labels)
+		cj.Spec.JobTemplate.Spec.Template.Labels = mergeUserMetadata(cj.Spec.JobTemplate.Spec.Template.Labels, o.Labels)
+	}
+
 	if len(o.Annotations) > 0 {
-		cj.Spec.JobTemplate.Annotations = mergeUserAnnotations(cj.Spec.JobTemplate.Annotations, o.Annotations)
-		cj.Spec.JobTemplate.Spec.Template.Annotations = mergeUserAnnotations(cj.Spec.JobTemplate.Spec.Template.Annotations, o.Annotations)
+		cj.Spec.JobTemplate.Annotations = mergeUserMetadata(cj.Spec.JobTemplate.Annotations, o.Annotations)
+		cj.Spec.JobTemplate.Spec.Template.Annotations = mergeUserMetadata(cj.Spec.JobTemplate.Spec.Template.Annotations, o.Annotations)
 	}
 
 	podSpec := &cj.Spec.JobTemplate.Spec.Template.Spec
@@ -28,18 +114,14 @@ func ApplyJobOverrides(cj *batchv1.CronJob, o v1alpha2.JobOverrides) {
 		podSpec.NodeSelector = o.NodeSelector
 	}
 
-	podSpec.Tolerations = append(podSpec.Tolerations, o.Tolerations...)
+	podSpec.Tolerations = MergeTolerations(podSpec.Tolerations, o.Tolerations)
 }
 
-// mergeUserAnnotations merges user-defined annotations with operator-managed ones.
-// Operator-managed annotations take precedence and cannot be overwritten.
-func mergeUserAnnotations(operator, user map[string]string) map[string]string {
+// mergeUserMetadata merges user-defined labels or annotations with operator-managed ones.
+// Operator-managed values take precedence and cannot be overwritten.
+func mergeUserMetadata(operator, user map[string]string) map[string]string {
 	merged := make(map[string]string, len(operator)+len(user))
-	for k, v := range user {
-		merged[k] = v
-	}
-	for k, v := range operator {
-		merged[k] = v
-	}
+	maps.Copy(merged, user)
+	maps.Copy(merged, operator)
 	return merged
 }

--- a/pkg/utils/k8s/job_overrides_test.go
+++ b/pkg/utils/k8s/job_overrides_test.go
@@ -19,7 +19,9 @@ func TestApplyJobOverrides_Empty(t *testing.T) {
 	ApplyJobOverrides(cj, v1alpha2.JobOverrides{})
 
 	assert.Nil(t, cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+	assert.Nil(t, cj.Spec.JobTemplate.Labels)
 	assert.Nil(t, cj.Spec.JobTemplate.Annotations)
+	assert.Nil(t, cj.Spec.JobTemplate.Spec.Template.Labels)
 	assert.Nil(t, cj.Spec.JobTemplate.Spec.Template.Annotations)
 	assert.Nil(t, cj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector)
 	assert.Nil(t, cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations)
@@ -30,6 +32,38 @@ func TestApplyJobOverrides_TTLSecondsAfterFinished(t *testing.T) {
 	ApplyJobOverrides(cj, v1alpha2.JobOverrides{TTLSecondsAfterFinished: ptr.To(int32(300))})
 
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
+}
+
+func TestApplyJobOverrides_Labels(t *testing.T) {
+	cj := &batchv1.CronJob{}
+	cj.Spec.JobTemplate.Labels = map[string]string{"operator-managed": "job"}
+	cj.Spec.JobTemplate.Spec.Template.Labels = map[string]string{"operator-managed": "pod"}
+
+	ApplyJobOverrides(cj, v1alpha2.JobOverrides{
+		Labels: map[string]string{
+			"team":             "security",
+			"operator-managed": "overwritten",
+		},
+	})
+
+	assert.Equal(t, map[string]string{
+		"team":             "security",
+		"operator-managed": "job",
+	}, cj.Spec.JobTemplate.Labels)
+	assert.Equal(t, map[string]string{
+		"team":             "security",
+		"operator-managed": "pod",
+	}, cj.Spec.JobTemplate.Spec.Template.Labels)
+}
+
+func TestApplyJobOverrides_LabelsNilMaps(t *testing.T) {
+	cj := &batchv1.CronJob{}
+	ApplyJobOverrides(cj, v1alpha2.JobOverrides{
+		Labels: map[string]string{"team": "security"},
+	})
+
+	assert.Equal(t, map[string]string{"team": "security"}, cj.Spec.JobTemplate.Labels)
+	assert.Equal(t, map[string]string{"team": "security"}, cj.Spec.JobTemplate.Spec.Template.Labels)
 }
 
 func TestApplyJobOverrides_Annotations(t *testing.T) {
@@ -89,4 +123,115 @@ func TestApplyJobOverrides_Tolerations(t *testing.T) {
 	ApplyJobOverrides(cj, v1alpha2.JobOverrides{Tolerations: []corev1.Toleration{user}})
 
 	assert.Equal(t, []corev1.Toleration{existing, user}, cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations)
+}
+
+func TestApplyJobOverrides_TolerationsDeduplicated(t *testing.T) {
+	toleration := corev1.Toleration{Key: "workload-type", Operator: corev1.TolerationOpEqual, Value: "mondoo-scan", Effect: corev1.TaintEffectNoSchedule}
+
+	cj := &batchv1.CronJob{}
+	cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations = []corev1.Toleration{toleration}
+	ApplyJobOverrides(cj, v1alpha2.JobOverrides{Tolerations: []corev1.Toleration{toleration}})
+
+	assert.Len(t, cj.Spec.JobTemplate.Spec.Template.Spec.Tolerations, 1)
+}
+
+// MergeTolerations tests
+
+func TestMergeTolerations_BothEmpty(t *testing.T) {
+	assert.Nil(t, MergeTolerations(nil, nil))
+}
+
+func TestMergeTolerations_Dedup(t *testing.T) {
+	t1 := corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule}
+	t2 := corev1.Toleration{Key: "key2", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}
+
+	result := MergeTolerations([]corev1.Toleration{t1, t2}, []corev1.Toleration{t1})
+	assert.Equal(t, []corev1.Toleration{t1, t2}, result)
+}
+
+func TestMergeTolerations_DifferentTolerationSeconds(t *testing.T) {
+	t1 := corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpExists, TolerationSeconds: ptr.To(int64(300))}
+	t2 := corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpExists, TolerationSeconds: ptr.To(int64(600))}
+
+	result := MergeTolerations([]corev1.Toleration{t1}, []corev1.Toleration{t2})
+	assert.Len(t, result, 2)
+}
+
+func TestMergeTolerations_DeepCopyTolerationSeconds(t *testing.T) {
+	seconds := int64(300)
+	t1 := corev1.Toleration{Key: "key1", TolerationSeconds: &seconds}
+
+	result := MergeTolerations(nil, []corev1.Toleration{t1})
+	assert.Equal(t, int64(300), *result[0].TolerationSeconds)
+
+	seconds = 999
+	assert.Equal(t, int64(300), *result[0].TolerationSeconds, "should not alias the original pointer")
+}
+
+// MergeJobOverrides tests
+
+func TestMergeJobOverrides_BothEmpty(t *testing.T) {
+	result := MergeJobOverrides(v1alpha2.JobOverrides{}, v1alpha2.JobOverrides{})
+	assert.Equal(t, v1alpha2.JobOverrides{}, result)
+}
+
+func TestMergeJobOverrides_GlobalOnly(t *testing.T) {
+	global := v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		Labels:                  map[string]string{"team": "security"},
+		Annotations:             map[string]string{"a": "1"},
+		NodeSelector:            map[string]string{"node": "infra"},
+		Tolerations: []corev1.Toleration{
+			{Key: "key1", Operator: corev1.TolerationOpExists},
+		},
+	}
+
+	result := MergeJobOverrides(global, v1alpha2.JobOverrides{})
+	assert.Equal(t, ptr.To(int32(3600)), result.TTLSecondsAfterFinished)
+	assert.Equal(t, map[string]string{"team": "security"}, result.Labels)
+	assert.Equal(t, map[string]string{"a": "1"}, result.Annotations)
+	assert.Equal(t, map[string]string{"node": "infra"}, result.NodeSelector)
+	assert.Len(t, result.Tolerations, 1)
+}
+
+func TestMergeJobOverrides_PerTypeOverridesGlobal(t *testing.T) {
+	global := v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		Labels:                  map[string]string{"team": "security", "env": "prod"},
+		Annotations:             map[string]string{"a": "1", "b": "2"},
+		NodeSelector:            map[string]string{"node": "infra"},
+	}
+	perType := v1alpha2.JobOverrides{
+		TTLSecondsAfterFinished: ptr.To(int32(7200)),
+		Labels:                  map[string]string{"team": "platform"},
+		Annotations:             map[string]string{"b": "3", "c": "4"},
+		NodeSelector:            map[string]string{"node": "scan"},
+	}
+
+	result := MergeJobOverrides(global, perType)
+	assert.Equal(t, ptr.To(int32(7200)), result.TTLSecondsAfterFinished)
+	assert.Equal(t, map[string]string{"team": "platform", "env": "prod"}, result.Labels)
+	assert.Equal(t, map[string]string{"a": "1", "b": "3", "c": "4"}, result.Annotations)
+	assert.Equal(t, map[string]string{"node": "scan"}, result.NodeSelector)
+}
+
+func TestMergeJobOverrides_TolerationsUnionMerged(t *testing.T) {
+	t1 := corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpExists}
+	t2 := corev1.Toleration{Key: "key2", Operator: corev1.TolerationOpExists}
+
+	global := v1alpha2.JobOverrides{Tolerations: []corev1.Toleration{t1}}
+	perType := v1alpha2.JobOverrides{Tolerations: []corev1.Toleration{t1, t2}}
+
+	result := MergeJobOverrides(global, perType)
+	assert.Len(t, result.Tolerations, 2)
+	assert.Equal(t, t1.Key, result.Tolerations[0].Key)
+	assert.Equal(t, t2.Key, result.Tolerations[1].Key)
+}
+
+func TestMergeJobOverrides_PerTypeOnlyTTL(t *testing.T) {
+	global := v1alpha2.JobOverrides{TTLSecondsAfterFinished: ptr.To(int32(3600))}
+	perType := v1alpha2.JobOverrides{TTLSecondsAfterFinished: ptr.To(int32(0))}
+
+	result := MergeJobOverrides(global, perType)
+	assert.Equal(t, ptr.To(int32(0)), result.TTLSecondsAfterFinished)
 }


### PR DESCRIPTION
Follows-up on #1594 by extending it and porting MergeTolerations from #1522

- Add spec.jobOverrides as a global default for all scan types; per-type overrides deep-merge with global (per-type wins on conflict)
- Add labels field to JobOverrides (same operator-wins semantics as annotations)
- Port MergeTolerations from #1522 to deduplicate tolerations by composite key instead of blindly appending