### PR TITLE
feat(nodes): warn when the node scan memory limit is too large for the node

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -20,6 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,6 +115,15 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		return err
 	}
 
+	// Collected across all nodes so the warning is emitted once per reconcile
+	// instead of once per affected node.
+	var (
+		unsafeMemoryNodes       []string
+		unsafeMemoryLimit       resource.Quantity
+		unsafeMemoryAllocatable resource.Quantity
+		haveUnsafeMemory        bool
+	)
+
 	// Create/update CronJobs for nodes
 	for _, node := range nodes.Items {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
@@ -129,7 +140,14 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			k8s.ResourcesRequirementsWithDefaults(n.Mondoo.Spec.Nodes.Resources, k8s.DefaultNodeScanningResources),
 			node,
 		); unsafe {
-			n.log().Info(nodeScanMemoryLimitWarning(limit, allocatable), "node", node.Name)
+			unsafeMemoryNodes = append(unsafeMemoryNodes, node.Name)
+			// Report the node with the least allocatable memory, which is the
+			// worst case for the configured limit.
+			if !haveUnsafeMemory || allocatable.Cmp(unsafeMemoryAllocatable) < 0 {
+				unsafeMemoryLimit = limit
+				unsafeMemoryAllocatable = allocatable
+				haveUnsafeMemory = true
+			}
 		}
 
 		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
@@ -155,6 +173,13 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 				return err
 			}
 		}
+	}
+
+	if haveUnsafeMemory {
+		n.log().Info(
+			nodeScanMemoryLimitWarning(unsafeMemoryLimit, unsafeMemoryAllocatable),
+			"nodes", strings.Join(unsafeMemoryNodes, ","),
+		)
 	}
 
 	// Delete dangling CronJobs for nodes that have been deleted from the cluster.

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -125,6 +125,13 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			return err
 		}
 
+		if limit, allocatable, unsafe := UnsafeNodeScanMemoryLimit(
+			k8s.ResourcesRequirementsWithDefaults(n.Mondoo.Spec.Nodes.Resources, k8s.DefaultNodeScanningResources),
+			node,
+		); unsafe {
+			n.log().Info(nodeScanMemoryLimitWarning(limit, allocatable), "node", node.Name)
+		}
+
 		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
 		cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
 		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cronJob, n.Mondoo, n.log(), func() error {

--- a/controllers/nodes/resource_validation.go
+++ b/controllers/nodes/resource_validation.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nodes
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// nodeScanMemoryLimitWarnRatio is the fraction of a node's allocatable memory above
+// which a configured node scan memory limit is reported as unsafe.
+//
+// The concern is not that the scan might be OOMKilled - that is a contained,
+// self-announcing failure. It is that node scan pods are pinned with
+// PodSpec.NodeName and therefore bypass the scheduler, so nothing validates the
+// limit against the node. Once the limit approaches the node's capacity the
+// pod's cgroup ceiling can no longer be reached before the node itself runs out
+// of memory, and the kernel switches from a contained per-cgroup OOM kill
+// (oom-kill:constraint=CONSTRAINT_MEMCG) to global reclaim, which can starve
+// kubelet and take the node NotReady. GOMEMLIMIT is derived from the same limit,
+// so cnspec is actively told to grow into that space.
+//
+// 0.7 is deliberately permissive: it is meant to catch "this limit is the size of
+// the node", not to second-guess reasonable tuning.
+const nodeScanMemoryLimitWarnRatio = 0.7
+
+// UnsafeNodeScanMemoryLimit reports whether the configured node scan memory limit is
+// large enough relative to the node's allocatable memory that the kernel may not be
+// able to contain an overrunning scan within its own cgroup. It returns the limit,
+// the node's allocatable memory and true when the limit is considered unsafe.
+//
+// Both a missing/zero limit and missing/zero allocatable memory are treated as "not
+// unsafe": there is nothing meaningful to compare.
+func UnsafeNodeScanMemoryLimit(resources corev1.ResourceRequirements, node corev1.Node) (limit, allocatable resource.Quantity, unsafe bool) {
+	memLimit := resources.Limits.Memory()
+	if memLimit == nil || memLimit.IsZero() {
+		return resource.Quantity{}, resource.Quantity{}, false
+	}
+
+	memAllocatable, ok := node.Status.Allocatable[corev1.ResourceMemory]
+	if !ok || memAllocatable.IsZero() {
+		return resource.Quantity{}, resource.Quantity{}, false
+	}
+
+	if float64(memLimit.Value()) <= nodeScanMemoryLimitWarnRatio*float64(memAllocatable.Value()) {
+		return *memLimit, memAllocatable, false
+	}
+
+	return *memLimit, memAllocatable, true
+}
+
+// nodeScanMemoryLimitWarning renders the operator-facing warning message for an
+// unsafe node scan memory limit.
+func nodeScanMemoryLimitWarning(limit, allocatable resource.Quantity) string {
+	return fmt.Sprintf(
+		"Node scan memory limit (%s) is %.0f%% of the node's allocatable memory (%s). "+
+			"Node scan pods are pinned with spec.nodeName and bypass the scheduler, so this limit is not "+
+			"validated against the node. At this size the kernel may be unable to contain an overrunning "+
+			"scan within its own cgroup and can starve kubelet instead of OOMKilling the scan. "+
+			"Consider lowering spec.nodes.resources.limits.memory to at most %d%% of the smallest node's "+
+			"allocatable memory.",
+		limit.String(),
+		100*float64(limit.Value())/float64(allocatable.Value()),
+		allocatable.String(),
+		int(nodeScanMemoryLimitWarnRatio*100),
+	)
+}

--- a/controllers/nodes/resource_validation.go
+++ b/controllers/nodes/resource_validation.go
@@ -45,7 +45,7 @@ func UnsafeNodeScanMemoryLimit(resources corev1.ResourceRequirements, node corev
 		return resource.Quantity{}, resource.Quantity{}, false
 	}
 
-	if float64(memLimit.Value()) <= nodeScanMemoryLimitWarnRatio*float64(memAllocatable.Value()) {
+	if memLimit.AsApproximateFloat64() <= nodeScanMemoryLimitWarnRatio*memAllocatable.AsApproximateFloat64() {
 		return *memLimit, memAllocatable, false
 	}
 

--- a/controllers/nodes/resource_validation_test.go
+++ b/controllers/nodes/resource_validation_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func nodeWithAllocatableMemory(mem string) corev1.Node {
+	node := corev1.Node{}
+	if mem != "" {
+		node.Status.Allocatable = corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(mem),
+		}
+	}
+	return node
+}
+
+func resourcesWithMemoryLimit(mem string) corev1.ResourceRequirements {
+	if mem == "" {
+		return corev1.ResourceRequirements{}
+	}
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(mem)},
+	}
+}
+
+func TestUnsafeNodeScanMemoryLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		limit        string
+		allocatable  string
+		expectUnsafe bool
+	}{
+		{
+			name:         "operator default on a small node is safe",
+			limit:        "250M",
+			allocatable:  "8130536Ki",
+			expectUnsafe: false,
+		},
+		{
+			name:         "limit equal to the whole node is unsafe",
+			limit:        "8G",
+			allocatable:  "8130536Ki",
+			expectUnsafe: true,
+		},
+		{
+			name:         "limit larger than the node is unsafe",
+			limit:        "16G",
+			allocatable:  "8130536Ki",
+			expectUnsafe: true,
+		},
+		{
+			name:         "the same limit on a large node is safe",
+			limit:        "8G",
+			allocatable:  "64Gi",
+			expectUnsafe: false,
+		},
+		{
+			name:         "just under the threshold is safe",
+			limit:        "5G",
+			allocatable:  "8G",
+			expectUnsafe: false,
+		},
+		{
+			name:         "just over the threshold is unsafe",
+			limit:        "6G",
+			allocatable:  "8G",
+			expectUnsafe: true,
+		},
+		{
+			name:         "no limit set is not reported",
+			limit:        "",
+			allocatable:  "8130536Ki",
+			expectUnsafe: false,
+		},
+		{
+			name:         "node without allocatable memory is not reported",
+			limit:        "8G",
+			allocatable:  "",
+			expectUnsafe: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limit, allocatable, unsafe := UnsafeNodeScanMemoryLimit(
+				resourcesWithMemoryLimit(test.limit),
+				nodeWithAllocatableMemory(test.allocatable),
+			)
+			assert.Equal(t, test.expectUnsafe, unsafe)
+
+			if !unsafe {
+				return
+			}
+
+			// The rendered warning must name both numbers so an operator can act on it
+			// without going back to the cluster.
+			msg := nodeScanMemoryLimitWarning(limit, allocatable)
+			assert.Contains(t, msg, limit.String())
+			assert.Contains(t, msg, allocatable.String())
+			assert.Contains(t, msg, "spec.nodes.resources.limits.memory")
+		})
+	}
+}
+
+func TestNodeScanMemoryLimitWarning_ReportsPercentage(t *testing.T) {
+	limit, allocatable, unsafe := UnsafeNodeScanMemoryLimit(
+		resourcesWithMemoryLimit("8G"),
+		nodeWithAllocatableMemory("8G"),
+	)
+	assert.True(t, unsafe)
+	assert.Contains(t, nodeScanMemoryLimitWarning(limit, allocatable), "100%")
+}


### PR DESCRIPTION
Draft, for discussion — happy to change the shape, the threshold, or drop it entirely if you'd rather solve this differently.

Addresses #1600.

### Why

Node scan pods are pinned with `PodSpec.NodeName`, so they bypass the scheduler and nothing validates `spec.nodes.resources.limits.memory` against the node the pod will actually run on. That matters more than it might sound, because of how the failure degrades:

* **Limit comfortably below node capacity** → an overrunning scan is killed by its own cgroup (`oom-kill:constraint=CONSTRAINT_MEMCG`). The scan fails loudly, the node is fine. This is the good case and it is self-announcing.
* **Limit at or above node capacity** → the pod's cgroup ceiling can never be reached before the *node* runs out of memory, so the kernel does global reclaim instead. kubelet gets starved, stops renewing its node lease, and the node goes `Ready=Unknown` / `NodeStatusUnknown` some time later. `GOMEMLIMIT` is derived from the same limit, so `cnspec` is actively instructed to grow into that space.

The second case is nasty precisely because it does *not* look like a scanner problem: there is no OOMKilled pod to notice, just a node that quietly stops posting status. We spent a day attributing it to a node image and a control-plane rollout before the cron boundary correlation pointed back at the scan.

The operator already lists `Node` objects to build these CronJobs, so `status.allocatable` is sitting right there at exactly the moment the decision is made — it seemed a shame not to use it.

### What this does

Adds `UnsafeNodeScanMemoryLimit()` plus a rendered warning, and logs it from the node CronJob reconcile loop when the configured limit exceeds **70%** of a node's allocatable memory. The message names the node, the configured limit and the node's allocatable memory, so it is actionable without going back to the cluster:

```
Node scan memory limit (8G) is 103% of the node's allocatable memory (8028136Ki).
Node scan pods are pinned with spec.nodeName and bypass the scheduler, so this limit is not
validated against the node. At this size the kernel may be unable to contain an overrunning
scan within its own cgroup and can starve kubelet instead of OOMKilling the scan.
Consider lowering spec.nodes.resources.limits.memory to at most 70% of the smallest node's
allocatable memory.
```

Deliberately minimal:

* **No API change** and **no behaviour change** — advisory only.
* `DefaultNodeScanningResources` (250M) never trips it, so out-of-the-box users see nothing.
* Missing/zero limit and missing/zero `allocatable` are both treated as "nothing to say" rather than as errors.
* 70% is intentionally permissive: it is meant to catch *"this limit is the size of the node"*, not to second-guess reasonable tuning.

### Tests

`controllers/nodes/resource_validation_test.go`, table-driven, covering the operator default on a small node, limit == node, limit > node, the same limit on a large node, either side of the threshold, and both "nothing to compare" cases. Also asserts the rendered message contains both quantities and the field name.

```
$ go test ./controllers/nodes/...
ok  	go.mondoo.com/mondoo-operator/controllers/nodes
```

`go build ./...` is clean and `gofmt` reports nothing.

### Open questions for you

1. **Log spam.** This currently logs once per node per reconcile. That is fine at `Info` for a condition that should be rare, but if you would prefer it deduplicated, hoisted out of the per-node loop, or emitted once per `MondooAuditConfig` rather than per node, say the word.
2. **Event or condition instead?** #1600 lists emitting a Kubernetes `Event` or a `MondooAuditConfig` status condition as alternatives. Both are more discoverable than a log line, but they touch your status API surface, so I did not want to choose that for you. Happy to switch.
3. **Threshold.** 70% is a judgement call. Anything from 50% to 80% would be defensible.
4. **Clamping.** The stronger version — capping the effective limit (and therefore `GOMEMLIMIT`) at a fraction of allocatable so the bad configuration becomes impossible rather than merely visible — would need to be opt-in. Out of scope here, but I am glad to follow up if you want it.

### Note

I have not signed the Mondoo CLA yet; I will sign it via the CLA Assistant bot when it comes round. Also worth flagging that our own misconfigured 8G limit was **our** mistake, not a bad default on your side — `DefaultNodeScanningResources` is conservative and sensible. This is about making that class of mistake visible, not about changing your defaults.
