### PR TITLE
⚡ feat(nodes): spread node scan CronJob startup

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -563,6 +563,11 @@ type Nodes struct {
 	Schedule string `json:"schedule,omitempty"`
 	// Suspend pauses scheduled node scan CronJobs without deleting generated resources. Only applicable for CronJob style.
 	Suspend bool `json:"suspend,omitempty"`
+	// ScheduleSpread adds a deterministic startup delay to node scan CronJobs.
+	// The delay is derived from the node name and is bounded by this duration.
+	// A zero value preserves the existing behavior. Only applicable for CronJob style.
+	// +optional
+	ScheduleSpread metav1.Duration `json:"scheduleSpread,omitempty"`
 	// IntervalTimer is the interval (in minutes) for the node scanning. The default is "60". Only applicable for Deployment
 	// style.
 	// +kubebuilder:default=60

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -723,6 +723,7 @@ func (in *MondooOperatorConfigStatus) DeepCopy() *MondooOperatorConfigStatus {
 func (in *Nodes) DeepCopyInto(out *Nodes) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	out.ScheduleSpread = in.ScheduleSpread
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1592,6 +1592,12 @@ spec:
                       Schedule specifies a custom crontab schedule for the node scanning job. If not specified, the default schedule is
                       used. Only applicable for CronJob style
                     type: string
+                  scheduleSpread:
+                    description: |-
+                      ScheduleSpread adds a deterministic startup delay to node scan CronJobs.
+                      The delay is derived from the node name and is bounded by this duration.
+                      A zero value preserves the existing behavior. Only applicable for CronJob style.
+                    type: string
                   style:
                     default: cronjob
                     description: Style specifies how node scanning is deployed. The

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1592,6 +1592,12 @@ spec:
                       Schedule specifies a custom crontab schedule for the node scanning job. If not specified, the default schedule is
                       used. Only applicable for CronJob style
                     type: string
+                  scheduleSpread:
+                    description: |-
+                      ScheduleSpread adds a deterministic startup delay to node scan CronJobs.
+                      The delay is derived from the node name and is bounded by this duration.
+                      A zero value preserves the existing behavior. Only applicable for CronJob style.
+                    type: string
                   style:
                     default: cronjob
                     description: Style specifies how node scanning is deployed. The

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -1592,6 +1592,12 @@ spec:
                       Schedule specifies a custom crontab schedule for the node scanning job. If not specified, the default schedule is
                       used. Only applicable for CronJob style
                     type: string
+                  scheduleSpread:
+                    description: |-
+                      ScheduleSpread adds a deterministic startup delay to node scan CronJobs.
+                      The delay is derived from the node name and is bounded by this duration.
+                      A zero value preserves the existing behavior. Only applicable for CronJob style.
+                    type: string
                   style:
                     default: cronjob
                     description: Style specifies how node scanning is deployed. The

--- a/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
@@ -169,6 +169,8 @@ spec:
     # schedule: "0 * * * *"
     # Pause scheduled node scan CronJobs without deleting them.
     # suspend: true
+    # Optional deterministic startup spread for node scan CronJobs
+    # scheduleSpread: 30m
     # Interval in minutes (only for deployment style)
     # intervalTimer: 60
     resources:

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -62,6 +62,10 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 
 	containerResources := k8s.ResourcesRequirementsWithDefaults(m.Spec.Nodes.Resources, k8s.DefaultNodeScanningResources)
 	gcLimit := gomemlimit.CalculateGoMemLimit(containerResources)
+	scanCommand, scanArgs := nodeScanCommand(
+		cmd,
+		nodeScanStartDelay(node.Name, m.Spec.Nodes.ScheduleSpread.Duration),
+	)
 
 	cj := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +110,8 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 								{
 									Image:     image,
 									Name:      "cnspec",
-									Command:   cmd,
+									Command:   scanCommand,
+									Args:      scanArgs,
 									Resources: containerResources,
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: ptr.To(isOpenshift),

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,6 +137,81 @@ func TestCronJob_HasReportTypeNone(t *testing.T) {
 
 	cmd := strings.Join(container.Command, " ")
 	assert.Contains(t, cmd, "--report-type none")
+}
+
+func TestNodeScanStartDelay(t *testing.T) {
+	const nodeName = "test-node"
+	spread := 10 * time.Minute
+
+	delay := nodeScanStartDelay(nodeName, spread)
+	assert.GreaterOrEqual(t, delay, time.Duration(0))
+	assert.LessOrEqual(t, delay, spread)
+	assert.Equal(t, delay, nodeScanStartDelay(nodeName, spread))
+	assert.Zero(t, nodeScanStartDelay(nodeName, 0))
+	assert.Zero(t, nodeScanStartDelay(nodeName, -time.Minute))
+}
+
+func TestCronJob_ScheduleSpreadDelaysScanner(t *testing.T) {
+	m := testMondooAuditConfig()
+	m.Spec.Nodes.ScheduleSpread = metav1.Duration{Duration: time.Minute}
+	nodeName := firstNodeNameWithDelay(t, m.Spec.Nodes.ScheduleSpread.Duration)
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", node, m, false, cfg)
+	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	delay := nodeScanStartDelay(node.Name, m.Spec.Nodes.ScheduleSpread.Duration)
+
+	assert.Equal(t, []string{"/bin/sh", "-c", nodeScanDelayScript}, container.Command)
+	assert.Equal(t, fmt.Sprintf("%d", int64(delay/time.Second)), container.Args[0])
+	assert.Equal(t, []string{
+		"cnspec", "scan", "local",
+		"--config", "/etc/opt/mondoo/mondoo.yml",
+		"--inventory-template", "/etc/opt/mondoo/inventory_template.yml",
+		"--report-type", "none",
+	}, container.Args[1:])
+}
+
+func TestCronJob_ScheduleSpreadDisabledKeepsDirectCommand(t *testing.T) {
+	m := testMondooAuditConfig()
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := CronJob("test-image:latest", node, m, false, cfg)
+	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+	assert.Equal(t, "cnspec", container.Command[0])
+	assert.Empty(t, container.Args)
+}
+
+func TestCronJob_ScheduleSpreadKeepsProxyArgSafe(t *testing.T) {
+	m := testMondooAuditConfig()
+	m.Spec.Nodes.ScheduleSpread = metav1.Duration{Duration: 10 * time.Minute}
+	nodeName := firstNodeNameWithDelay(t, m.Spec.Nodes.ScheduleSpread.Duration)
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	const proxyValue = "https://proxy.example:8443; echo injected"
+	cfg := v1alpha2.MondooOperatorConfig{
+		Spec: v1alpha2.MondooOperatorConfigSpec{
+			HttpsProxy: ptr.To(proxyValue),
+		},
+	}
+
+	cj := CronJob("test-image:latest", node, m, false, cfg)
+	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+	require.Equal(t, []string{"/bin/sh", "-c", nodeScanDelayScript}, container.Command)
+	require.GreaterOrEqual(t, len(container.Args), 2)
+
+	proxyFlagIndex := -1
+	for i, arg := range container.Args {
+		if arg == "--api-proxy" {
+			proxyFlagIndex = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, proxyFlagIndex, "expected --api-proxy argument")
+	require.Greater(t, len(container.Args), proxyFlagIndex+1, "expected proxy value after --api-proxy")
+	assert.Equal(t, proxyValue, container.Args[proxyFlagIndex+1])
 }
 
 func TestResources_GOMEMLIMIT(t *testing.T) {
@@ -611,6 +687,18 @@ func envToMap(envVars []corev1.EnvVar) map[string]string {
 		m[e.Name] = e.Value
 	}
 	return m
+}
+
+func firstNodeNameWithDelay(t *testing.T, spread time.Duration) string {
+	t.Helper()
+	for i := 0; i < 1024; i++ {
+		nodeName := fmt.Sprintf("test-node-%d", i)
+		if nodeScanStartDelay(nodeName, spread) > 0 {
+			return nodeName
+		}
+	}
+	t.Fatalf("could not find node name with non-zero delay for spread %s", spread)
+	return ""
 }
 
 func testMondooAuditConfig() *v1alpha2.MondooAuditConfig {

--- a/controllers/nodes/schedule.go
+++ b/controllers/nodes/schedule.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nodes
+
+import (
+	"hash/fnv"
+	"strconv"
+	"time"
+)
+
+const nodeScanDelayScript = `sleep "$0"; exec "$@"`
+
+// nodeScanStartDelay returns a stable delay for a node within the configured
+// spread window. A zero or sub-second window disables the delay.
+func nodeScanStartDelay(nodeName string, spread time.Duration) time.Duration {
+	maxSeconds := int64(spread / time.Second)
+	if nodeName == "" || maxSeconds <= 0 {
+		return 0
+	}
+
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(nodeName))
+	return time.Duration(int64(hash.Sum32())%(maxSeconds+1)) * time.Second
+}
+
+// nodeScanCommand wraps a node scan command with a startup delay while keeping
+// the actual cnspec arguments as separate shell arguments.
+func nodeScanCommand(command []string, delay time.Duration) ([]string, []string) {
+	if delay <= 0 {
+		return command, nil
+	}
+
+	args := make([]string, 1, len(command)+1)
+	args[0] = strconv.FormatInt(int64(delay/time.Second), 10)
+	args = append(args, command...)
+	return []string{"/bin/sh", "-c", nodeScanDelayScript}, args
+}

--- a/controllers/nodes/schedule_test.go
+++ b/controllers/nodes/schedule_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nodes
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeScanStartDelay_DeterministicMultiNodeExamples(t *testing.T) {
+	spread := 30 * time.Minute
+	tests := map[string]time.Duration{
+		"node-a":                            1084 * time.Second,
+		"node-b":                            587 * time.Second,
+		"node-c":                            90 * time.Second,
+		"ip-10-0-1-1":                       1143 * time.Second,
+		"ip-10-0-1-2":                       646 * time.Second,
+		"worker-0":                          1296 * time.Second,
+		"worker-1":                          799 * time.Second,
+		"aks-nodepool1-12345678-vmss000001": 79 * time.Second,
+	}
+
+	for nodeName, expectedDelay := range tests {
+		assert.Equal(t, expectedDelay, nodeScanStartDelay(nodeName, spread), nodeName)
+		assert.Equal(t, expectedDelay, nodeScanStartDelay(nodeName, spread), "repeat check: %s", nodeName)
+	}
+}
+
+func TestNodeScanStartDelay_FlattensClusterWidePeak(t *testing.T) {
+	const totalNodes = 500
+	spread := 30 * time.Minute
+
+	concurrentPeak := totalNodes
+	bucketCounts := map[time.Duration]int{}
+	for i := 0; i < totalNodes; i++ {
+		nodeName := fmt.Sprintf("node-%03d", i)
+		delay := nodeScanStartDelay(nodeName, spread)
+		bucketCounts[delay]++
+	}
+
+	staggeredPeak := 0
+	for _, count := range bucketCounts {
+		if count > staggeredPeak {
+			staggeredPeak = count
+		}
+	}
+
+	t.Logf("cluster-wide startup peak (500 nodes): concurrent=%d, staggered=%d, spread=%s, populated-buckets=%d",
+		concurrentPeak, staggeredPeak, spread, len(bucketCounts))
+
+	require.Greater(t, len(bucketCounts), 1)
+	assert.Less(t, staggeredPeak, concurrentPeak)
+	assert.LessOrEqual(t, staggeredPeak, 5)
+}
+
+func TestNodeScanDelayScript_PreservesArgumentBoundaries(t *testing.T) {
+	proxyValue := "https://proxy.example:8443; echo injected"
+	cmd := exec.Command("/bin/sh", "-c", nodeScanDelayScript, "0", "/bin/echo", proxyValue)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	require.NoError(t, cmd.Run(), out.String())
+	assert.Equal(t, proxyValue+"\n", out.String())
+}

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -969,6 +969,23 @@ kubectl -n mondoo-operator edit mondooauditconfigs.k8s.mondoo.com mondoo-client
     schedule: 41 * * * *
 ```
 
+Node scan CronJobs can be spread across a bounded startup window to avoid
+starting every node scan at the same time:
+
+```yaml
+spec:
+  nodes:
+    enable: true
+    style: cronjob
+    schedule: "0 */3 * * *"
+    scheduleSpread: 30m
+```
+
+`scheduleSpread` derives a stable delay from each node name, so reconciles do
+not reshuffle the schedule. It defaults to `0s` and applies only to CronJob
+style node scanning. The CronJob schedule itself is unchanged; the scanner
+waits before starting its scan.
+
 You can adjust the schedule for the following components:
 - Kubernetes Resources Scanning
 - Container Image Scanning
@@ -1357,6 +1374,8 @@ Search for the `nodes:` section and specify the new limits there. It should look
 spec:
   nodes:
     enable: true
+    # Optional: spread node CronJob startup within this window
+    scheduleSpread: 30m
     resources:
       limits:
         cpu: 200m

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -984,7 +984,8 @@ spec:
 `scheduleSpread` derives a stable delay from each node name, so reconciles do
 not reshuffle the schedule. It defaults to `0s` and applies only to CronJob
 style node scanning. The CronJob schedule itself is unchanged; the scanner
-waits before starting its scan.
+waits before starting its scan. This smooths cluster-wide concurrent starts
+(and aggregate memory/IO peaks); it does not reduce per-pod scan memory.
 
 You can adjust the schedule for the following components:
 - Kubernetes Resources Scanning

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -986,6 +986,9 @@ not reshuffle the schedule. It defaults to `0s` and applies only to CronJob
 style node scanning. The CronJob schedule itself is unchanged; the scanner
 waits before starting its scan. This smooths cluster-wide concurrent starts
 (and aggregate memory/IO peaks); it does not reduce per-pod scan memory.
+Keep `scheduleSpread` shorter than the cron interval. With
+`ConcurrencyPolicy: Forbid`, a delayed scan that is still running when the
+next cron trigger fires can cause that run to be skipped.
 
 You can adjust the schedule for the following components:
 - Kubernetes Resources Scanning


### PR DESCRIPTION
## Summary

- Add optional `spec.nodes.scheduleSpread` for deterministic per-node startup delays.
- Preserve existing behavior at `0s`; DaemonSet and Deployment styles are unchanged.
- Add tests showing a 500-node startup bucket dropping from 500 concurrent starts to 3.

## Validation

- `go test ./controllers/nodes/...`
- `go test ./controllers/...`
- `make lint` and `make lint/actions`
- Docker/OrbStack benchmarking was unavailable because no daemon was running; shell simulation and deterministic tests were used instead.

Addresses #1599.