### PR TITLE
⚡ perf(container-image): reuse CronJob listing during GC

### DIFF
--- a/controllers/container_image/deployment_handler.go
+++ b/controllers/container_image/deployment_handler.go
@@ -77,39 +77,40 @@ func (n *DeploymentHandler) Reconcile(ctx context.Context) (ctrl.Result, error) 
 		return ctrl.Result{}, err
 	}
 
-	if err := n.syncCronJob(ctx, clusterUid); err != nil {
+	cronJobs, err := n.syncCronJob(ctx, clusterUid)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	n.garbageCollectIfNeeded(ctx, clusterUid)
+	n.garbageCollectIfNeeded(ctx, clusterUid, cronJobs)
 
 	return ctrl.Result{}, nil
 }
 
-func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) error {
+func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) ([]batchv1.CronJob, error) {
 	mondooClientImage, err := n.ContainerImageResolver.CnspecImage(
 		n.Mondoo.Spec.Scanner.Image.Name, n.Mondoo.Spec.Scanner.Image.Tag, n.Mondoo.Spec.Scanner.Image.Digest, n.MondooOperatorConfig.Spec.SkipContainerResolution)
 	if err != nil {
 		n.log().Error(err, "Failed to resolve mondoo-client container image")
-		return err
+		return nil, err
 	}
 
 	integrationMrn, err := k8s.TryGetIntegrationMrnForAuditConfig(ctx, n.KubeClient, *n.Mondoo)
 	if err != nil {
 		n.log().Error(err,
 			"failed to retrieve integration-mrn for MondooAuditConfig", "namespace", n.Mondoo.Namespace, "name", n.Mondoo.Name)
-		return err
+		return nil, err
 	}
 
 	if err := n.syncConfigMap(ctx, clusterUid); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Reconcile private registry secrets (merges multiple secrets if needed)
 	privateRegistrySecretName, err := k8s.ReconcilePrivateRegistriesSecret(ctx, n.KubeClient, n.Mondoo)
 	if err != nil {
 		n.log().Error(err, "Failed to reconcile private registry secrets")
-		return err
+		return nil, err
 	}
 
 	desired := CronJob(mondooClientImage, integrationMrn, clusterUid, privateRegistrySecretName, n.Mondoo, *n.MondooOperatorConfig)
@@ -119,20 +120,20 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// When a CronJob is updated, remove completed Jobs so they don't linger with stale config
 	if op == controllerutil.OperationResultUpdated {
 		if err := k8s.DeleteCompletedJobs(ctx, n.KubeClient, n.Mondoo.Namespace, CronJobLabels(*n.Mondoo), n.log()); err != nil {
 			n.log().Error(err, "Failed to clean up completed Jobs after CronJob update")
-			return err
+			return nil, err
 		}
 	}
 
 	cronJobs, err := n.getCronJobsForAuditConfig(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get Pods for this CronJob
@@ -142,7 +143,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 		selector, err := metav1.LabelSelectorAsSelector(lSelector)
 		if err != nil {
 			n.log().Error(err, "Failed to create label selector for Kubernetes Container Image Scanning")
-			return err
+			return nil, err
 		}
 		opts := []client.ListOption{
 			client.InNamespace(n.Mondoo.Namespace),
@@ -151,13 +152,13 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context, clusterUid string) 
 		err = n.KubeClient.List(ctx, pods, opts...)
 		if err != nil {
 			n.log().Error(err, "Failed to list Pods for Kubernetes Container Image Scanning")
-			return err
+			return nil, err
 		}
 	}
 
 	updateImageScanningConditions(n.Mondoo, !k8s.AreCronJobsSuccessful(cronJobs), pods)
 	n.updateScanStatus(cronJobs)
-	return nil
+	return cronJobs, nil
 }
 
 func (n *DeploymentHandler) updateScanStatus(cronJobs []batchv1.CronJob) {
@@ -228,13 +229,7 @@ func (n *DeploymentHandler) getCronJobsForAuditConfig(ctx context.Context) ([]ba
 
 // garbageCollectIfNeeded checks whether a new successful container image scan has completed
 // since the last GC run, and if so, performs garbage collection of stale assets via the Mondoo API.
-func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterUid string) {
-	cronJobs, err := n.getCronJobsForAuditConfig(ctx)
-	if err != nil {
-		logger.Error(err, "Failed to list CronJobs for container image garbage collection")
-		return
-	}
-
+func (n *DeploymentHandler) garbageCollectIfNeeded(ctx context.Context, clusterUid string, cronJobs []batchv1.CronJob) {
 	var latestSuccess *metav1.Time
 	for i := range cronJobs {
 		t := cronJobs[i].Status.LastSuccessfulTime

--- a/controllers/container_image/deployment_handler_test.go
+++ b/controllers/container_image/deployment_handler_test.go
@@ -574,3 +574,40 @@ func (s *DeploymentHandlerSuite) createDeploymentHandler() DeploymentHandler {
 func TestDeploymentHandlerSuite(t *testing.T) {
 	suite.Run(t, new(DeploymentHandlerSuite))
 }
+
+func BenchmarkReconcile_CronJobListsPerOperation(b *testing.B) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		b.Fatal(err)
+	}
+	if err := mondoov1alpha2.AddToScheme(scheme); err != nil {
+		b.Fatal(err)
+	}
+
+	auditConfig := utils.DefaultAuditConfig("mondoo-operator", false, true, false)
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(test.TestKubeSystemNamespace(), &auditConfig).
+		Build()
+	countingKubeClient := &countingClient{Client: baseClient}
+
+	d := DeploymentHandler{
+		KubeClient:             countingKubeClient,
+		Mondoo:                 &auditConfig,
+		ContainerImageResolver: fakeMondoo.NewNoOpContainerImageResolver(),
+		MondooOperatorConfig:   &mondoov1alpha2.MondooOperatorConfig{},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.Reconcile(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(countingKubeClient.cronJobListCalls)/float64(b.N), "cronjob-lists/op")
+}

--- a/controllers/container_image/deployment_handler_test.go
+++ b/controllers/container_image/deployment_handler_test.go
@@ -36,6 +36,18 @@ type DeploymentHandlerSuite struct {
 	fakeClientBuilder *fake.ClientBuilder
 }
 
+type countingClient struct {
+	client.Client
+	cronJobListCalls int
+}
+
+func (c *countingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*batchv1.CronJobList); ok {
+		c.cronJobListCalls++
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
 func (s *DeploymentHandlerSuite) SetupSuite() {
 	s.ctx = context.Background()
 	s.scheme = clientgoscheme.Scheme
@@ -527,6 +539,27 @@ func (s *DeploymentHandlerSuite) TestReconcile_WIF_InvalidConfig() {
 
 	_, err := d.Reconcile(s.ctx)
 	s.Error(err, "should fail validation when provider-specific config is missing")
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_AvoidsRedundantCronJobListings() {
+	baseClient := s.fakeClientBuilder.Build()
+	countingKubeClient := &countingClient{Client: baseClient}
+
+	d := DeploymentHandler{
+		KubeClient:             countingKubeClient,
+		Mondoo:                 &s.auditConfig,
+		ContainerImageResolver: s.containerImageResolver,
+		MondooOperatorConfig:   &mondoov1alpha2.MondooOperatorConfig{},
+	}
+
+	s.NoError(countingKubeClient.Create(s.ctx, &s.auditConfig))
+
+	_, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+
+	// One list during stale CronJob cleanup + one list for status/conditions update.
+	// GC now reuses the already-listed CronJobs.
+	s.Equal(2, countingKubeClient.cronJobListCalls)
 }
 
 func (s *DeploymentHandlerSuite) createDeploymentHandler() DeploymentHandler {


### PR DESCRIPTION
## Summary

- Reuse the CronJob list already fetched during container-image reconciliation for garbage-collection decisions.
- Remove one redundant CronJob list/allocation per reconcile while preserving scan status and GC behavior.
- Add an API-call-counting test and benchmark.

## Rough data

- CronJob list calls: `3 -> 2` per reconcile (~33% fewer).
- Synthetic benchmark: `2.000 cronjob-lists/op`, ~245 KB/op, ~2,013 allocs/op after the change.

## Validation

- `go test ./controllers/container_image -count=1`
- Focused benchmark passed.
- Docker/OrbStack benchmarking was unavailable because no daemon was running.

Complements #1537 and #1578; does not duplicate them.