### PR TITLE
⚡ perf(resource-watcher): dedupe normalized resource types

### DIFF
--- a/controllers/resource_watcher/watcher.go
+++ b/controllers/resource_watcher/watcher.go
@@ -77,6 +77,7 @@ func NewResourceWatcher(c cache.Cache, debouncer *Debouncer, config WatcherConfi
 			config.ResourceTypes = HighPriorityResourceTypes
 		}
 	}
+	config.ResourceTypes = normalizeResourceTypes(config.ResourceTypes)
 	return &ResourceWatcher{
 		cache:     c,
 		debouncer: debouncer,
@@ -127,35 +128,86 @@ func (w *ResourceWatcher) Start(ctx context.Context) error {
 
 // getObjectForResourceType returns the client.Object for a resource type string.
 func (w *ResourceWatcher) getObjectForResourceType(resourceType string) (client.Object, error) {
-	switch strings.ToLower(resourceType) {
-	case "pods", "pod":
+	switch normalizeResourceType(resourceType) {
+	case "pods":
 		return &corev1.Pod{}, nil
-	case "deployments", "deployment":
+	case "deployments":
 		return &appsv1.Deployment{}, nil
-	case "daemonsets", "daemonset":
+	case "daemonsets":
 		return &appsv1.DaemonSet{}, nil
-	case "statefulsets", "statefulset":
+	case "statefulsets":
 		return &appsv1.StatefulSet{}, nil
-	case "replicasets", "replicaset":
+	case "replicasets":
 		return &appsv1.ReplicaSet{}, nil
-	case "jobs", "job":
+	case "jobs":
 		return &batchv1.Job{}, nil
-	case "cronjobs", "cronjob":
+	case "cronjobs":
 		return &batchv1.CronJob{}, nil
-	case "services", "service":
+	case "services":
 		return &corev1.Service{}, nil
-	case "ingresses", "ingress":
+	case "ingresses":
 		return &networkingv1.Ingress{}, nil
-	case "namespaces", "namespace":
+	case "namespaces":
 		return &corev1.Namespace{}, nil
-	case "configmaps", "configmap":
+	case "configmaps":
 		return &corev1.ConfigMap{}, nil
-	case "secrets", "secret":
+	case "secrets":
 		return &corev1.Secret{}, nil
-	case "serviceaccounts", "serviceaccount":
+	case "serviceaccounts":
 		return &corev1.ServiceAccount{}, nil
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", resourceType)
+	}
+}
+
+func normalizeResourceTypes(resourceTypes []string) []string {
+	normalized := make([]string, 0, len(resourceTypes))
+	seen := make(map[string]struct{}, len(resourceTypes))
+	for _, resourceType := range resourceTypes {
+		canonical := normalizeResourceType(resourceType)
+		if canonical == "" {
+			continue
+		}
+		if _, exists := seen[canonical]; exists {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+	return normalized
+}
+
+func normalizeResourceType(resourceType string) string {
+	canonical := strings.ToLower(strings.TrimSpace(resourceType))
+	switch canonical {
+	case "pod":
+		return "pods"
+	case "deployment":
+		return "deployments"
+	case "daemonset":
+		return "daemonsets"
+	case "statefulset":
+		return "statefulsets"
+	case "replicaset":
+		return "replicasets"
+	case "job":
+		return "jobs"
+	case "cronjob":
+		return "cronjobs"
+	case "service":
+		return "services"
+	case "ingress":
+		return "ingresses"
+	case "namespace":
+		return "namespaces"
+	case "configmap":
+		return "configmaps"
+	case "secret":
+		return "secrets"
+	case "serviceaccount":
+		return "serviceaccounts"
+	default:
+		return canonical
 	}
 }
 

--- a/controllers/resource_watcher/watcher_test.go
+++ b/controllers/resource_watcher/watcher_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource_watcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+func TestNewResourceWatcher_NormalizesAndDeduplicatesResourceTypes(t *testing.T) {
+	w := NewResourceWatcher(nil, nil, WatcherConfig{
+		ResourceTypes: []string{"Deployment", "deployments", " pod ", "pods", "CronJob", "cronjobs"},
+	})
+
+	assert.Equal(t, []string{"deployments", "pods", "cronjobs"}, w.config.ResourceTypes)
+}
+
+func TestNewResourceWatcher_DefaultHighPriorityResourceTypes(t *testing.T) {
+	w := NewResourceWatcher(nil, nil, WatcherConfig{})
+
+	assert.Equal(t, HighPriorityResourceTypes, w.config.ResourceTypes)
+}
+
+func TestGetObjectForResourceType_AcceptsSingularAndPlural(t *testing.T) {
+	w := &ResourceWatcher{}
+
+	deploymentObj, err := w.getObjectForResourceType("deployment")
+	assert.NoError(t, err)
+	assert.IsType(t, &appsv1.Deployment{}, deploymentObj)
+
+	cronjobObj, err := w.getObjectForResourceType("cronjobs")
+	assert.NoError(t, err)
+	assert.IsType(t, &batchv1.CronJob{}, cronjobObj)
+}
+
+func BenchmarkNormalizeResourceTypes_WithDuplicates(b *testing.B) {
+	resourceTypes := make([]string, 0, 12000)
+	for i := 0; i < 2000; i++ {
+		resourceTypes = append(resourceTypes, "deployment", "deployments", "pod", "pods", "CronJob", "cronjobs")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = normalizeResourceTypes(resourceTypes)
+	}
+}


### PR DESCRIPTION
## Summary

- Normalize singular/plural and case variants in `resourceTypes`.
- Deduplicate equivalent watcher entries before informer creation, preventing duplicate watches and scans.
- Preserve existing defaults and add focused tests/benchmark coverage.

## Rough data

- A 12,000-entry list containing six repeated aliases is reduced to the canonical unique set before informer setup.
- Benchmark: ~380 us/op, ~649 KB/op, 2,034 allocs/op for normalization.

## Validation

- `go test ./controllers/resource_watcher`
- Focused benchmark passed.
- Docker/OrbStack benchmarking was unavailable because no daemon was running.