### PR TITLE
⚡ perf(nodes): sync shared ConfigMap once

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -113,15 +113,15 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		return err
 	}
 
+	if err := n.syncConfigMap(ctx, clusterUid); err != nil {
+		return err
+	}
+
 	// Create/update CronJobs for nodes
 	for _, node := range nodes.Items {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
 			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
-			return err
-		}
-
-		if err := n.syncConfigMap(ctx, clusterUid); err != nil {
 			return err
 		}
 
@@ -210,6 +210,10 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		return err
 	}
 
+	if err := n.syncConfigMap(ctx, clusterUid); err != nil {
+		return err
+	}
+
 	// Create/update Deployments for nodes
 	for _, node := range nodes.Items {
 		// Delete CronJob if it exists
@@ -224,10 +228,6 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameWithNode(n.Mondoo.Name, node.Name), Namespace: n.Mondoo.Namespace}}
 		if err := k8s.DeleteIfExists(ctx, n.KubeClient, cm); err != nil {
 			n.log().Error(err, "Failed to clean up old ConfigMap for node scanning", "namespace", cm.Namespace, "name", cm.Name)
-			return err
-		}
-
-		if err := n.syncConfigMap(ctx, clusterUid); err != nil {
 			return err
 		}
 

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -146,6 +146,40 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateConfigMap() {
 	s.Equal(cfgMapExpected.Data, cfgMap.Data)
 }
 
+func (s *DeploymentHandlerSuite) TestReconcile_CronJob_SyncsSharedConfigMapOnce() {
+	s.seedNodes()
+	countingClient := &countingClient{
+		Client:        s.fakeClientBuilder.Build(),
+		configMapGets: map[string]int{},
+	}
+	d := s.createDeploymentHandlerWithClient(countingClient)
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	s.Equal(1, countingClient.configMapGetCount(s.auditConfig.Namespace, ConfigMapName(s.auditConfig.Name)))
+}
+
+func (s *DeploymentHandlerSuite) TestReconcile_Deployment_SyncsSharedConfigMapOnce() {
+	s.seedNodes()
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+
+	countingClient := &countingClient{
+		Client:        s.fakeClientBuilder.Build(),
+		configMapGets: map[string]int{},
+	}
+	d := s.createDeploymentHandlerWithClient(countingClient)
+	s.NoError(d.KubeClient.Create(s.ctx, &s.auditConfig))
+
+	result, err := d.Reconcile(s.ctx)
+	s.NoError(err)
+	s.True(result.IsZero())
+
+	s.Equal(1, countingClient.configMapGetCount(s.auditConfig.Namespace, ConfigMapName(s.auditConfig.Name)))
+}
+
 func (s *DeploymentHandlerSuite) TestReconcile_CronJob_CleanConfigMapsForDeletedNodes() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
@@ -972,8 +1006,12 @@ func (s *DeploymentHandlerSuite) TestGarbageCollection_FailureStillUpdatesTimest
 }
 
 func (s *DeploymentHandlerSuite) createDeploymentHandler() DeploymentHandler {
+	return s.createDeploymentHandlerWithClient(s.fakeClientBuilder.Build())
+}
+
+func (s *DeploymentHandlerSuite) createDeploymentHandlerWithClient(kubeClient client.Client) DeploymentHandler {
 	return DeploymentHandler{
-		KubeClient:             s.fakeClientBuilder.Build(),
+		KubeClient:             kubeClient,
 		Mondoo:                 &s.auditConfig,
 		ContainerImageResolver: s.containerImageResolver,
 		MondooOperatorConfig:   &v1alpha2.MondooOperatorConfig{},
@@ -1019,6 +1057,26 @@ func (s *DeploymentHandlerSuite) createDeploymentHandlerWithGCMock(gcFunc func(c
 type fakeMondooClient struct {
 	mondooclient.MondooClient
 	gcFunc func(context.Context, *mondooclient.GarbageCollectAssetsRequest) error
+}
+
+type countingClient struct {
+	client.Client
+	configMapGets map[string]int
+}
+
+func (c *countingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.ConfigMap); ok {
+		c.configMapGets[c.configMapKey(key.Namespace, key.Name)]++
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *countingClient) configMapGetCount(namespace, name string) int {
+	return c.configMapGets[c.configMapKey(namespace, name)]
+}
+
+func (c *countingClient) configMapKey(namespace, name string) string {
+	return namespace + "/" + name
 }
 
 func (f *fakeMondooClient) GarbageCollectAssets(ctx context.Context, req *mondooclient.GarbageCollectAssetsRequest) error {

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -164,7 +164,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CronJob_SyncsSharedConfigMapOnce(
 
 func (s *DeploymentHandlerSuite) TestReconcile_Deployment_SyncsSharedConfigMapOnce() {
 	s.seedNodes()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 
 	countingClient := &countingClient{
 		Client:        s.fakeClientBuilder.Build(),
@@ -350,7 +350,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_Switch() {
 		s.Equal(cjExpected.Spec, cj.Spec)
 	}
 
-	mondooAuditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	mondooAuditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	result, err = d.Reconcile(s.ctx)
 	s.NoError(err)
 	s.True(result.IsZero())
@@ -451,7 +451,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
@@ -484,7 +484,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets() {
 func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_Switch() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
@@ -528,7 +528,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateDaemonSets_Switch() {
 func (s *DeploymentHandlerSuite) TestReconcile_UpdateDaemonSets() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 
@@ -871,7 +871,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CronJob_CustomSchedule() {
 func (s *DeploymentHandlerSuite) TestReconcile_Deployment_CustomInterval() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -220,7 +220,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CronJob_CleanConfigMapsForDeleted
 func (s *DeploymentHandlerSuite) TestReconcile_Deployment_CleanConfigMapsForDeletedNodes() {
 	s.seedNodes()
 	d := s.createDeploymentHandler()
-	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconsile logic)
+	s.auditConfig.Spec.Nodes.Style = v1alpha2.NodeScanStyle_Deployment // TODO: Change to DaemonSet (no effect on reconcile logic)
 	mondooAuditConfig := &s.auditConfig
 	s.NoError(d.KubeClient.Create(s.ctx, mondooAuditConfig))
 


### PR DESCRIPTION
## Summary

- Reconcile the shared node inventory ConfigMap once per node-scan reconcile.
- Remove the redundant per-node ConfigMap sync in both CronJob and DaemonSet paths.
- Add fake-client call-counting tests while preserving per-node cleanup and workload behavior.

## Rough data

- Shared ConfigMap sync work changes from once per node to once per reconcile, so a cluster with `N` nodes avoids `N-1` duplicate sync operations per pass.

## Validation

- `go test ./controllers/nodes`
- Docker/OrbStack benchmarking was unavailable because no daemon was running; fake-client API-call counting was used instead.