### PR TITLE
feat: apply jobOverrides to resource watcher Deployment and node scanner DaemonSet

### DIFF
--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -313,6 +313,8 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 			cfg.Spec.ImagePullSecrets...)
 	}
 
+	k8s.ApplyDaemonSetOverrides(ds, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.Nodes.JobOverrides))
+
 	return ds
 }
 

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -483,6 +483,45 @@ func TestDaemonSet_WithImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
 }
 
+func TestDaemonSet_WithJobOverrides(t *testing.T) {
+	mac := *testMondooAuditConfig()
+	mac.Spec.JobOverrides = v1alpha2.JobOverrides{
+		NodeSelector: map[string]string{"workload-type": "mondoo-scan"},
+		Tolerations: []corev1.Toleration{
+			{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule},
+		},
+		Labels:      map[string]string{"team": "security"},
+		Annotations: map[string]string{"karpenter.sh/do-not-disrupt": "true"},
+	}
+
+	existingTolerations := []corev1.Toleration{
+		{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists},
+	}
+
+	ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, existingTolerations)
+
+	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, ds.Spec.Template.Spec.NodeSelector)
+	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
+	assert.Equal(t, "security", ds.Spec.Template.Labels["team"])
+	assert.Equal(t, "true", ds.Spec.Template.Annotations["karpenter.sh/do-not-disrupt"])
+	// Operator-managed labels must survive
+	assert.Equal(t, "mondoo", ds.Spec.Template.Labels["app"])
+}
+
+func TestDaemonSet_PerTypeJobOverridesOverrideGlobal(t *testing.T) {
+	mac := *testMondooAuditConfig()
+	mac.Spec.JobOverrides = v1alpha2.JobOverrides{
+		NodeSelector: map[string]string{"workload-type": "global"},
+	}
+	mac.Spec.Nodes.JobOverrides = v1alpha2.JobOverrides{
+		NodeSelector: map[string]string{"workload-type": "node-scan"},
+	}
+
+	ds := DaemonSet(mac, false, "test123", v1alpha2.MondooOperatorConfig{}, nil)
+
+	assert.Equal(t, map[string]string{"workload-type": "node-scan"}, ds.Spec.Template.Spec.NodeSelector)
+}
+
 // envToMap converts a slice of EnvVar to a map for easy lookup.
 func envToMap(envVars []corev1.EnvVar) map[string]string {
 	m := make(map[string]string, len(envVars))

--- a/controllers/resource_watcher/resources.go
+++ b/controllers/resource_watcher/resources.go
@@ -202,5 +202,7 @@ func Deployment(image, integrationMRN, clusterUID string, m *v1alpha2.MondooAudi
 			cfg.Spec.ImagePullSecrets...)
 	}
 
+	k8s.ApplyDeploymentOverrides(deployment, k8s.MergeJobOverrides(m.Spec.JobOverrides, m.Spec.KubernetesResources.JobOverrides))
+
 	return deployment
 }

--- a/controllers/resource_watcher/resources_test.go
+++ b/controllers/resource_watcher/resources_test.go
@@ -501,6 +501,71 @@ func TestDeployment_WithImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
 }
 
+func TestDeployment_WithJobOverrides(t *testing.T) {
+	config := &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-config",
+			Namespace: "mondoo-operator",
+		},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			KubernetesResources: v1alpha2.KubernetesResources{
+				Enable: true,
+				ResourceWatcher: v1alpha2.ResourceWatcherSpec{
+					Enable: true,
+				},
+			},
+			JobOverrides: v1alpha2.JobOverrides{
+				NodeSelector: map[string]string{"workload-type": "mondoo-scan"},
+				Tolerations: []corev1.Toleration{
+					{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule},
+				},
+				Labels:      map[string]string{"team": "security"},
+				Annotations: map[string]string{"karpenter.sh/do-not-disrupt": "true"},
+			},
+		},
+	}
+
+	operatorConfig := v1alpha2.MondooOperatorConfig{}
+	deployment := Deployment("ghcr.io/mondoohq/cnspec:latest", "", "", config, operatorConfig)
+
+	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, deployment.Spec.Template.Spec.NodeSelector)
+	assert.Len(t, deployment.Spec.Template.Spec.Tolerations, 1)
+	assert.Equal(t, "dedicated", deployment.Spec.Template.Spec.Tolerations[0].Key)
+	assert.Equal(t, "security", deployment.Spec.Template.Labels["team"])
+	assert.Equal(t, "true", deployment.Spec.Template.Annotations["karpenter.sh/do-not-disrupt"])
+	// Operator-managed labels must survive
+	assert.Equal(t, "mondoo-resource-watcher", deployment.Spec.Template.Labels["app"])
+	assert.Equal(t, "my-config", deployment.Spec.Template.Labels["mondoo_cr"])
+}
+
+func TestDeployment_PerTypeJobOverridesOverrideGlobal(t *testing.T) {
+	config := &v1alpha2.MondooAuditConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-config",
+			Namespace: "mondoo-operator",
+		},
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			KubernetesResources: v1alpha2.KubernetesResources{
+				Enable: true,
+				ResourceWatcher: v1alpha2.ResourceWatcherSpec{
+					Enable: true,
+				},
+				JobOverrides: v1alpha2.JobOverrides{
+					NodeSelector: map[string]string{"workload-type": "k8s-scan"},
+				},
+			},
+			JobOverrides: v1alpha2.JobOverrides{
+				NodeSelector: map[string]string{"workload-type": "global"},
+			},
+		},
+	}
+
+	operatorConfig := v1alpha2.MondooOperatorConfig{}
+	deployment := Deployment("ghcr.io/mondoohq/cnspec:latest", "", "", config, operatorConfig)
+
+	assert.Equal(t, map[string]string{"workload-type": "k8s-scan"}, deployment.Spec.Template.Spec.NodeSelector)
+}
+
 // envToMap converts a slice of EnvVar to a map for easy lookup.
 func envToMap(envVars []corev1.EnvVar) map[string]string {
 	m := make(map[string]string, len(envVars))

--- a/pkg/utils/k8s/job_overrides.go
+++ b/pkg/utils/k8s/job_overrides.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"maps"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -111,6 +112,42 @@ func ApplyJobOverrides(cj *batchv1.CronJob, o v1alpha2.JobOverrides) {
 	// nodeSelector doesn't match the node, so the selector is only applied to pods
 	// that go through the scheduler.
 	if len(o.NodeSelector) > 0 && podSpec.NodeName == "" {
+		podSpec.NodeSelector = o.NodeSelector
+	}
+
+	podSpec.Tolerations = MergeTolerations(podSpec.Tolerations, o.Tolerations)
+}
+
+// ApplyDeploymentOverrides applies user-configured overrides to a generated Deployment.
+func ApplyDeploymentOverrides(d *appsv1.Deployment, o v1alpha2.JobOverrides) {
+	if len(o.Labels) > 0 {
+		d.Spec.Template.Labels = mergeUserMetadata(d.Spec.Template.Labels, o.Labels)
+	}
+
+	if len(o.Annotations) > 0 {
+		d.Spec.Template.Annotations = mergeUserMetadata(d.Spec.Template.Annotations, o.Annotations)
+	}
+
+	podSpec := &d.Spec.Template.Spec
+	if len(o.NodeSelector) > 0 {
+		podSpec.NodeSelector = o.NodeSelector
+	}
+
+	podSpec.Tolerations = MergeTolerations(podSpec.Tolerations, o.Tolerations)
+}
+
+// ApplyDaemonSetOverrides applies user-configured overrides to a generated DaemonSet.
+func ApplyDaemonSetOverrides(ds *appsv1.DaemonSet, o v1alpha2.JobOverrides) {
+	if len(o.Labels) > 0 {
+		ds.Spec.Template.Labels = mergeUserMetadata(ds.Spec.Template.Labels, o.Labels)
+	}
+
+	if len(o.Annotations) > 0 {
+		ds.Spec.Template.Annotations = mergeUserMetadata(ds.Spec.Template.Annotations, o.Annotations)
+	}
+
+	podSpec := &ds.Spec.Template.Spec
+	if len(o.NodeSelector) > 0 {
 		podSpec.NodeSelector = o.NodeSelector
 	}
 

--- a/pkg/utils/k8s/job_overrides_test.go
+++ b/pkg/utils/k8s/job_overrides_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"go.mondoo.com/mondoo-operator/api/v1alpha2"
@@ -234,4 +236,151 @@ func TestMergeJobOverrides_PerTypeOnlyTTL(t *testing.T) {
 
 	result := MergeJobOverrides(global, perType)
 	assert.Equal(t, ptr.To(int32(0)), result.TTLSecondsAfterFinished)
+}
+
+// ApplyDeploymentOverrides tests
+
+func TestApplyDeploymentOverrides_Empty(t *testing.T) {
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+			},
+		},
+	}
+	ApplyDeploymentOverrides(d, v1alpha2.JobOverrides{})
+
+	assert.Equal(t, map[string]string{"app": "test"}, d.Spec.Template.Labels)
+	assert.Nil(t, d.Spec.Template.Annotations)
+	assert.Nil(t, d.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, d.Spec.Template.Spec.Tolerations)
+}
+
+func TestApplyDeploymentOverrides_AllFields(t *testing.T) {
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+			},
+		},
+	}
+	overrides := v1alpha2.JobOverrides{
+		Labels:       map[string]string{"team": "security"},
+		Annotations:  map[string]string{"karpenter.sh/do-not-disrupt": "true"},
+		NodeSelector: map[string]string{"workload-type": "mondoo-scan"},
+		Tolerations: []corev1.Toleration{
+			{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule},
+		},
+	}
+	ApplyDeploymentOverrides(d, overrides)
+
+	assert.Equal(t, map[string]string{"app": "test", "team": "security"}, d.Spec.Template.Labels)
+	assert.Equal(t, map[string]string{"karpenter.sh/do-not-disrupt": "true"}, d.Spec.Template.Annotations)
+	assert.Equal(t, map[string]string{"workload-type": "mondoo-scan"}, d.Spec.Template.Spec.NodeSelector)
+	assert.Len(t, d.Spec.Template.Spec.Tolerations, 1)
+}
+
+func TestApplyDeploymentOverrides_OperatorLabelsPreserved(t *testing.T) {
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "mondoo-resource-watcher", "mondoo_cr": "config"},
+				},
+			},
+		},
+	}
+	ApplyDeploymentOverrides(d, v1alpha2.JobOverrides{
+		Labels: map[string]string{"app": "overwritten", "team": "security"},
+	})
+
+	assert.Equal(t, "mondoo-resource-watcher", d.Spec.Template.Labels["app"])
+	assert.Equal(t, "security", d.Spec.Template.Labels["team"])
+}
+
+func TestApplyDeploymentOverrides_TolerationsMerged(t *testing.T) {
+	existing := corev1.Toleration{Key: "existing", Operator: corev1.TolerationOpExists}
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{existing},
+				},
+			},
+		},
+	}
+	additional := corev1.Toleration{Key: "new", Operator: corev1.TolerationOpExists}
+	ApplyDeploymentOverrides(d, v1alpha2.JobOverrides{
+		Tolerations: []corev1.Toleration{additional},
+	})
+
+	assert.Len(t, d.Spec.Template.Spec.Tolerations, 2)
+}
+
+// ApplyDaemonSetOverrides tests
+
+func TestApplyDaemonSetOverrides_Empty(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "mondoo"},
+				},
+			},
+		},
+	}
+	ApplyDaemonSetOverrides(ds, v1alpha2.JobOverrides{})
+
+	assert.Equal(t, map[string]string{"app": "mondoo"}, ds.Spec.Template.Labels)
+	assert.Nil(t, ds.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, ds.Spec.Template.Spec.Tolerations)
+}
+
+func TestApplyDaemonSetOverrides_AllFields(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "mondoo"},
+				},
+			},
+		},
+	}
+	overrides := v1alpha2.JobOverrides{
+		Labels:       map[string]string{"team": "security"},
+		Annotations:  map[string]string{"karpenter.sh/do-not-disrupt": "true"},
+		NodeSelector: map[string]string{"node-role": "scan"},
+		Tolerations: []corev1.Toleration{
+			{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule},
+		},
+	}
+	ApplyDaemonSetOverrides(ds, overrides)
+
+	assert.Equal(t, map[string]string{"app": "mondoo", "team": "security"}, ds.Spec.Template.Labels)
+	assert.Equal(t, map[string]string{"karpenter.sh/do-not-disrupt": "true"}, ds.Spec.Template.Annotations)
+	assert.Equal(t, map[string]string{"node-role": "scan"}, ds.Spec.Template.Spec.NodeSelector)
+	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 1)
+}
+
+func TestApplyDaemonSetOverrides_TolerationsMergedWithExisting(t *testing.T) {
+	existing := corev1.Toleration{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists}
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{existing},
+				},
+			},
+		},
+	}
+	additional := corev1.Toleration{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule}
+	ApplyDaemonSetOverrides(ds, v1alpha2.JobOverrides{
+		Tolerations: []corev1.Toleration{additional, existing},
+	})
+
+	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
 }

--- a/pkg/utils/k8s/update_fields.go
+++ b/pkg/utils/k8s/update_fields.go
@@ -57,6 +57,8 @@ func UpdateDeploymentFields(obj, desired *appsv1.Deployment) {
 	ps := &obj.Spec.Template.Spec
 	dps := &desired.Spec.Template.Spec
 	ps.ServiceAccountName = dps.ServiceAccountName
+	ps.NodeSelector = dps.NodeSelector
+	ps.Tolerations = dps.Tolerations
 	ps.Containers = dps.Containers
 	ps.Volumes = dps.Volumes
 	ps.ImagePullSecrets = dps.ImagePullSecrets
@@ -76,6 +78,7 @@ func UpdateDaemonSetFields(obj, desired *appsv1.DaemonSet) {
 	dps := &desired.Spec.Template.Spec
 	ps.PriorityClassName = dps.PriorityClassName
 	ps.AutomountServiceAccountToken = dps.AutomountServiceAccountToken
+	ps.NodeSelector = dps.NodeSelector
 	ps.Tolerations = dps.Tolerations
 	ps.Containers = dps.Containers
 	ps.Volumes = dps.Volumes

--- a/pkg/utils/k8s/update_fields_test.go
+++ b/pkg/utils/k8s/update_fields_test.go
@@ -139,6 +139,27 @@ func TestUpdateDeploymentFields_ImagePullSecrets(t *testing.T) {
 	assert.Equal(t, desired.Spec.Template.Spec.Containers, obj.Spec.Template.Spec.Containers)
 }
 
+func TestUpdateDeploymentFields_NodeSelectorAndTolerations(t *testing.T) {
+	desired := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{"workload-type": "mondoo-scan"},
+					Tolerations: []corev1.Toleration{
+						{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "mondoo", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+		},
+	}
+
+	obj := &appsv1.Deployment{}
+	UpdateDeploymentFields(obj, desired)
+
+	assert.Equal(t, desired.Spec.Template.Spec.NodeSelector, obj.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, desired.Spec.Template.Spec.Tolerations, obj.Spec.Template.Spec.Tolerations)
+}
+
 func TestUpdateDaemonSetFields_ImagePullSecrets(t *testing.T) {
 	desired := &appsv1.DaemonSet{
 		Spec: appsv1.DaemonSetSpec{
@@ -158,4 +179,21 @@ func TestUpdateDaemonSetFields_ImagePullSecrets(t *testing.T) {
 
 	assert.Equal(t, desired.Spec.Template.Spec.ImagePullSecrets, obj.Spec.Template.Spec.ImagePullSecrets)
 	assert.Equal(t, desired.Spec.Template.Spec.Containers, obj.Spec.Template.Spec.Containers)
+}
+
+func TestUpdateDaemonSetFields_NodeSelector(t *testing.T) {
+	desired := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{"workload-type": "mondoo-scan"},
+				},
+			},
+		},
+	}
+
+	obj := &appsv1.DaemonSet{}
+	UpdateDaemonSetFields(obj, desired)
+
+	assert.Equal(t, desired.Spec.Template.Spec.NodeSelector, obj.Spec.Template.Spec.NodeSelector)
 }


### PR DESCRIPTION
## Summary

- Apply `jobOverrides` (nodeSelector, tolerations, labels, annotations) to the resource watcher Deployment and node scanner DaemonSet
- Add `ApplyDeploymentOverrides` and `ApplyDaemonSetOverrides` utilities following the existing `ApplyJobOverrides` pattern
- Fix `UpdateDeploymentFields` and `UpdateDaemonSetFields` to propagate nodeSelector (and tolerations for Deployment) on reconcile updates

Follow-up to #1598 — closes the gap noted in https://github.com/mondoohq/mondoo-operator/pull/1522#issuecomment-5169688992 where the resource watcher and node scanner DaemonSet were the only workloads not receiving `jobOverrides`.

## Tests

- `go test ./pkg/utils/k8s/... ./controllers/resource_watcher/... ./controllers/nodes/... -count=1`