### PR TITLE
fix(node-scanning): sort aggregated tolerations for deterministic DaemonSet diffs

### DIFF
--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -246,7 +246,11 @@ func (n *DeploymentHandler) syncDaemonSet(ctx context.Context) error {
 		}
 	}
 
-	desired := DaemonSet(*n.Mondoo, n.IsOpenshift, mondooClientImage, *n.MondooOperatorConfig, slices.Collect(maps.Keys(tolerations)))
+	// maps.Keys iterates in random order, so sort to avoid a spurious update on every reconcile.
+	tolerationList := slices.Collect(maps.Keys(tolerations))
+	k8s.SortTolerations(tolerationList)
+
+	desired := DaemonSet(*n.Mondoo, n.IsOpenshift, mondooClientImage, *n.MondooOperatorConfig, tolerationList)
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
 	op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, ds, n.Mondoo, n.log(), func() error {
 		k8s.UpdateDaemonSetFields(ds, desired)

--- a/pkg/utils/k8s/taints.go
+++ b/pkg/utils/k8s/taints.go
@@ -3,7 +3,12 @@
 
 package k8s
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"cmp"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func TaintsToTolerations(taints []corev1.Taint) []corev1.Toleration {
 	var tolerations []corev1.Toleration
@@ -11,6 +16,33 @@ func TaintsToTolerations(taints []corev1.Taint) []corev1.Toleration {
 		tolerations = append(tolerations, TaintToToleration(t))
 	}
 	return tolerations
+}
+
+// SortTolerations sorts tolerations in place into a deterministic order, since a slice built from a map has none.
+func SortTolerations(tolerations []corev1.Toleration) {
+	slices.SortFunc(tolerations, func(a, b corev1.Toleration) int {
+		return cmp.Or(
+			cmp.Compare(a.Key, b.Key),
+			cmp.Compare(a.Operator, b.Operator),
+			cmp.Compare(a.Value, b.Value),
+			cmp.Compare(a.Effect, b.Effect),
+			compareTolerationSeconds(a.TolerationSeconds, b.TolerationSeconds),
+		)
+	})
+}
+
+// compareTolerationSeconds treats unset (nil) as less than any set value.
+func compareTolerationSeconds(a, b *int64) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return cmp.Compare(*a, *b)
+	}
 }
 
 func TaintToToleration(t corev1.Taint) corev1.Toleration {

--- a/pkg/utils/k8s/taints_test.go
+++ b/pkg/utils/k8s/taints_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestTaintsToTolerations(t *testing.T) {
@@ -45,4 +46,25 @@ func TestTaintToToleration(t *testing.T) {
 	assert.Equal(t, taint.Key, toleration.Key)
 	assert.Equal(t, taint.Value, toleration.Value)
 	assert.Equal(t, taint.Effect, toleration.Effect)
+}
+
+func TestSortTolerations_Deterministic(t *testing.T) {
+	a := corev1.Toleration{Key: "a", Operator: corev1.TolerationOpEqual, Value: "1", Effect: corev1.TaintEffectNoSchedule}
+	b := corev1.Toleration{Key: "b", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+	c := corev1.Toleration{Key: "b", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}
+	d := corev1.Toleration{Key: "b", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To(int64(30))}
+
+	want := []corev1.Toleration{a, c, d, b}
+
+	// Every permutation must converge on the same sorted result.
+	for _, input := range [][]corev1.Toleration{
+		{a, b, c, d},
+		{d, c, b, a},
+		{b, a, d, c},
+		{c, d, a, b},
+	} {
+		got := append([]corev1.Toleration{}, input...)
+		SortTolerations(got)
+		assert.Equal(t, want, got)
+	}
 }


### PR DESCRIPTION
## What
`syncDaemonSet` builds the node-scanning DaemonSet's tolerations from the union of
every distinct taint across all cluster nodes, deduplicated via a `map` and collected
with `slices.Collect(maps.Keys(...))`.

## Bug
Go randomizes map iteration order, so the resulting slice order differs across
reconciles even when the underlying taint set hasn't changed. Since
`equality.Semantic.DeepEqual` compares slices order-sensitively, `CreateOrUpdate` saw
a spurious diff on (almost) every reconcile, triggering a DaemonSet update and a full
rolling restart of every node-scanning pod, cluster-wide, on every reconcile. This gets
worse the more distinct taint keys exist in the cluster (observed via a DaemonSet
`.metadata.generation` in the tens of thousands after just a few days).

## Fix
Sort the collected tolerations (`SortTolerations`, `pkg/utils/k8s/taints.go`) before
building the desired DaemonSet, so an unchanged taint set always produces an
identical, order-independent slice.

## Testing
- `TestSortTolerations_Deterministic` feeds 4 permutations of the same toleration set
  and asserts they all converge on the same sorted output.
- `go build`, `go vet`, `go test ./pkg/utils/k8s/... ./controllers/nodes/...` all pass.