### PR TITLE
feat(operator): configurable image pull policy and namespace wildcards

### DIFF
--- a/api/v1alpha2/mondooauditconfig_types.go
+++ b/api/v1alpha2/mondooauditconfig_types.go
@@ -669,6 +669,21 @@ type Image struct {
 	// When specified, this takes precedence over Tag.
 	// +optional
 	Digest string `json:"digest,omitempty"`
+	// PullPolicy is the image pull policy applied to every container and init container
+	// the operator creates, including the cloud CLI and SPIFFE helper init containers.
+	// Defaults to IfNotPresent.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+}
+
+// PullPolicyOrDefault returns the configured image pull policy, falling back to
+// IfNotPresent when none is set.
+func (i Image) PullPolicyOrDefault() corev1.PullPolicy {
+	if i.PullPolicy != "" {
+		return i.PullPolicy
+	}
+	return corev1.PullIfNotPresent
 }
 
 // MondooAuditConfigStatus defines the observed state of MondooAuditConfig

--- a/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -66,6 +66,16 @@ spec:
                         type: string
                       name:
                         type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
                       tag:
                         type: string
                     type: object
@@ -1768,6 +1778,16 @@ spec:
                           When specified, this takes precedence over Tag.
                         type: string
                       name:
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
                         type: string
                       tag:
                         type: string

--- a/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/charts/mondoo-operator/files/crds/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -66,6 +66,16 @@ spec:
                         type: string
                       name:
                         type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
                       tag:
                         type: string
                     type: object
@@ -1768,6 +1778,16 @@ spec:
                           When specified, this takes precedence over Tag.
                         type: string
                       name:
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
                         type: string
                       tag:
                         type: string

--- a/cmd/mondoo-operator/resource_watcher/cmd.go
+++ b/cmd/mondoo-operator/resource_watcher/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	"go.mondoo.com/mondoo-operator/controllers/resource_watcher"
 	annot "go.mondoo.com/mondoo-operator/pkg/annotations"
+	"go.mondoo.com/mondoo-operator/pkg/utils"
 	"go.mondoo.com/mondoo-operator/pkg/utils/logger"
 )
 
@@ -153,8 +154,18 @@ func init() {
 			Scheme: scheme,
 		}
 
-		// If specific namespaces are provided, configure cache to only watch those
-		if len(namespacesList) > 0 {
+		// If specific namespaces are provided, configure cache to only watch those.
+		// Cache keys must be literal namespace names, so this is only possible when
+		// every include entry is a literal. A glob such as "prod-*" cannot be
+		// expanded up front: namespaces matching it may be created after startup.
+		// In that case watch cluster-wide and let the watcher's namespace filter
+		// drop events from namespaces that are out of scope.
+		switch {
+		case len(namespacesList) == 0:
+		case utils.HasGlobPattern(namespacesList):
+			logger.Info("Namespace include list contains glob patterns; watching all namespaces and filtering events per namespace",
+				"namespaces", namespacesList)
+		default:
 			byNamespace := make(map[string]cache.Config)
 			for _, ns := range namespacesList {
 				byNamespace[ns] = cache.Config{}
@@ -183,12 +194,15 @@ func init() {
 		debouncer := resource_watcher.NewDebouncer(*debounceInterval, *minimumScanInterval, scanner.ScanResourcesFunc())
 
 		// Create watcher
-		watcher := resource_watcher.NewResourceWatcher(c, debouncer, resource_watcher.WatcherConfig{
+		watcher, err := resource_watcher.NewResourceWatcher(c, debouncer, resource_watcher.WatcherConfig{
 			Namespaces:        namespacesList,
 			NamespacesExclude: namespacesExcludeList,
 			ResourceTypes:     resourceTypesList,
 			WatchAllResources: *watchAllResources,
 		})
+		if err != nil {
+			return fmt.Errorf("failed to create resource watcher: %w", err)
+		}
 
 		// Start components
 		errChan := make(chan error, 3)

--- a/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
+++ b/config/crd/bases/k8s.mondoo.com_mondooauditconfigs.yaml
@@ -66,6 +66,16 @@ spec:
                         type: string
                       name:
                         type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
                       tag:
                         type: string
                     type: object
@@ -1768,6 +1778,16 @@ spec:
                           When specified, this takes precedence over Tag.
                         type: string
                       name:
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the image pull policy applied to every container and init container
+                          the operator creates, including the cloud CLI and SPIFFE helper init containers.
+                          Defaults to IfNotPresent.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
                         type: string
                       tag:
                         type: string

--- a/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
+++ b/config/samples/k8s_v1alpha2_mondooauditconfig.yaml
@@ -32,6 +32,9 @@ spec:
     image:
       name: ghcr.io/mondoohq/mondoo-operator
       tag: latest
+      # Pull policy for every container the operator creates.
+      # One of Always, IfNotPresent (default), or Never.
+      # pullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
@@ -171,7 +174,9 @@ spec:
         cpu: 500m
         memory: 500Mi
 
-  # Namespace filtering (applies to K8s resources and container scanning)
+  # Namespace filtering (applies to K8s resources and container scanning).
+  # Entries may be literal namespace names or glob patterns, e.g. "prod-*",
+  # "*-canary", "team-?", "{frontend,backend}".
   filtering:
     namespaces:
       # Exclude specific namespaces
@@ -181,3 +186,4 @@ spec:
       # include:
       #   - default
       #   - production
+      #   - 'prod-*'

--- a/controllers/container_image/resources.go
+++ b/controllers/container_image/resources.go
@@ -98,7 +98,7 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 							Containers: []corev1.Container{
 								{
 									Image:           image,
-									ImagePullPolicy: corev1.PullIfNotPresent,
+									ImagePullPolicy: m.Spec.Scanner.Image.PullPolicyOrDefault(),
 									Name:            "mondoo-containers-scan",
 									Command:         cmd,
 									Resources:       containerResources,
@@ -214,7 +214,7 @@ func CronJob(image, integrationMrn, clusterUid, privateRegistrySecretName string
 		)
 
 		// Add init container for registry credential generation
-		podSpec.InitContainers = append(podSpec.InitContainers, k8s.RegistryWIFInitContainer(wif))
+		podSpec.InitContainers = append(podSpec.InitContainers, k8s.RegistryWIFInitContainer(wif, m.Spec.Scanner.Image.PullPolicyOrDefault()))
 
 		// AKS Workload Identity webhook requires this label on the pod template only.
 		// Copy labels so we don't mutate the CronJob/Job metadata.

--- a/controllers/container_image/resources_test.go
+++ b/controllers/container_image/resources_test.go
@@ -163,6 +163,23 @@ func TestCronJob_WithImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
 }
 
+func TestCronJob_ImagePullPolicy(t *testing.T) {
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("defaults to IfNotPresent", func(t *testing.T) {
+		cj := CronJob("test-image:latest", "", testClusterUID, "", testAuditConfig(), cfg)
+		assert.Equal(t, corev1.PullIfNotPresent, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+
+	t.Run("honors the configured policy", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.Scanner.Image.PullPolicy = corev1.PullAlways
+
+		cj := CronJob("test-image:latest", "", testClusterUID, "", m, cfg)
+		assert.Equal(t, corev1.PullAlways, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+}
+
 func TestCronJob_ImagePullSecrets_AppendsMultiple(t *testing.T) {
 	m := testAuditConfig()
 	cfg := v1alpha2.MondooOperatorConfig{

--- a/controllers/k8s_scan/deployment_handler_test.go
+++ b/controllers/k8s_scan/deployment_handler_test.go
@@ -1425,7 +1425,7 @@ func TestWIFInitContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			container := wifInitContainer(tt.cluster)
+			container := wifInitContainer(tt.cluster, corev1.PullIfNotPresent)
 
 			// Verify container name
 			if container.Name != "generate-kubeconfig" {
@@ -1512,7 +1512,7 @@ func TestSpiffeInitContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			container := spiffeInitContainer(tt.cluster)
+			container := spiffeInitContainer(tt.cluster, corev1.PullIfNotPresent)
 
 			// Verify container name
 			if container.Name != "fetch-spiffe-certs" {

--- a/controllers/k8s_scan/resources.go
+++ b/controllers/k8s_scan/resources.go
@@ -101,7 +101,7 @@ func CronJob(image string, m *v1alpha2.MondooAuditConfig, cfg v1alpha2.MondooOpe
 							Containers: []corev1.Container{
 								{
 									Image:           image,
-									ImagePullPolicy: corev1.PullIfNotPresent,
+									ImagePullPolicy: m.Spec.Scanner.Image.PullPolicyOrDefault(),
 									Name:            "mondoo-k8s-scan",
 									Command:         cmd,
 									Resources:       containerResources,
@@ -359,7 +359,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 			}
 		}
 
-		initContainers = append(initContainers, wifInitContainer(cluster))
+		initContainers = append(initContainers, wifInitContainer(cluster, m.Spec.Scanner.Image.PullPolicyOrDefault()))
 
 		// AKS Workload Identity webhook uses a pod-level objectSelector matching
 		// the label "azure.workload.identity/use: true" to inject federated token
@@ -432,7 +432,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 			}
 		}
 
-		initContainers = append(initContainers, spiffeInitContainer(cluster))
+		initContainers = append(initContainers, spiffeInitContainer(cluster, m.Spec.Scanner.Image.PullPolicyOrDefault()))
 
 	case cluster.VaultAuth != nil:
 		// Vault auth: operator fetches credentials and writes a kubeconfig Secret
@@ -473,7 +473,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 							Containers: []corev1.Container{
 								{
 									Image:           image,
-									ImagePullPolicy: corev1.PullIfNotPresent,
+									ImagePullPolicy: m.Spec.Scanner.Image.PullPolicyOrDefault(),
 									Name:            "mondoo-k8s-scan",
 									Command:         cmd,
 									Resources:       extContainerResources,
@@ -589,7 +589,7 @@ func ExternalClusterCronJob(image string, cluster v1alpha2.ExternalCluster, m *v
 			corev1.EnvVar{Name: "DOCKER_CONFIG", Value: "/etc/opt/mondoo/docker"},
 		)
 
-		podSpec.InitContainers = append(podSpec.InitContainers, k8s.RegistryWIFInitContainer(m.Spec.Containers.WorkloadIdentity))
+		podSpec.InitContainers = append(podSpec.InitContainers, k8s.RegistryWIFInitContainer(m.Spec.Containers.WorkloadIdentity, m.Spec.Scanner.Image.PullPolicyOrDefault()))
 
 		// AKS Workload Identity webhook requires this label
 		if m.Spec.Containers.WorkloadIdentity.Provider == v1alpha2.CloudProviderAKS {
@@ -720,7 +720,7 @@ func WIFServiceAccount(cluster v1alpha2.ExternalCluster, m *v1alpha2.MondooAudit
 }
 
 // wifInitContainer creates an init container that generates kubeconfig using cloud CLI tools
-func wifInitContainer(cluster v1alpha2.ExternalCluster) corev1.Container {
+func wifInitContainer(cluster v1alpha2.ExternalCluster, pullPolicy corev1.PullPolicy) corev1.Container {
 	var image, shell, script string
 	var env []corev1.EnvVar
 
@@ -856,7 +856,7 @@ fi
 	return corev1.Container{
 		Name:            "generate-kubeconfig",
 		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: pullPolicy,
 		Command:         []string{shell, "-c", script},
 		Env:             env,
 		VolumeMounts: []corev1.VolumeMount{
@@ -897,7 +897,7 @@ fi
 // If scans consistently exceed your SVID TTL, consider:
 // - Increasing the SVID TTL in your SPIRE server configuration
 // - Using a different authentication method (kubeconfig, service account token)
-func spiffeInitContainer(cluster v1alpha2.ExternalCluster) corev1.Container {
+func spiffeInitContainer(cluster v1alpha2.ExternalCluster, pullPolicy corev1.PullPolicy) corev1.Container {
 	socketPath := cluster.SPIFFEAuth.SocketPath
 	if socketPath == "" {
 		socketPath = "/run/spire/sockets/agent.sock"
@@ -979,7 +979,7 @@ kill $HELPER_PID 2>/dev/null || true
 	return corev1.Container{
 		Name:            "fetch-spiffe-certs",
 		Image:           constants.SPIFFEHelperImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: pullPolicy,
 		Command:         []string{"/bin/sh", "-c", script},
 		Env: []corev1.EnvVar{
 			{Name: "SOCKET_FILE", Value: socketFile},

--- a/controllers/k8s_scan/resources_test.go
+++ b/controllers/k8s_scan/resources_test.go
@@ -233,6 +233,54 @@ func TestCronJob_WithImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
 }
 
+func TestCronJob_ImagePullPolicy(t *testing.T) {
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("defaults to IfNotPresent", func(t *testing.T) {
+		cj := CronJob("test-image:latest", testAuditConfig(), cfg)
+		container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+		assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	})
+
+	t.Run("honors the configured policy", func(t *testing.T) {
+		m := testAuditConfig()
+		m.Spec.Scanner.Image.PullPolicy = corev1.PullAlways
+
+		cj := CronJob("test-image:latest", m, cfg)
+		container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+		assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
+	})
+}
+
+func TestExternalClusterCronJob_ImagePullPolicyAppliesToInitContainers(t *testing.T) {
+	m := testAuditConfig()
+	m.Spec.Scanner.Image.PullPolicy = corev1.PullAlways
+	cluster := v1alpha2.ExternalCluster{
+		Name: "remote",
+		WorkloadIdentity: &v1alpha2.WorkloadIdentityConfig{
+			Provider: "gke",
+			GKE: &v1alpha2.GKEWorkloadIdentity{
+				ProjectID:            "my-project",
+				ClusterName:          "remote-cluster",
+				ClusterLocation:      "us-central1",
+				GoogleServiceAccount: "scanner@my-project.iam.gserviceaccount.com",
+			},
+		},
+	}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	cj := ExternalClusterCronJob("test-image:latest", cluster, m, cfg)
+	podSpec := cj.Spec.JobTemplate.Spec.Template.Spec
+
+	require.NotEmpty(t, podSpec.InitContainers, "expected a kubeconfig-generating init container")
+	for _, c := range podSpec.InitContainers {
+		assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy, "init container %q", c.Name)
+	}
+	for _, c := range podSpec.Containers {
+		assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy, "container %q", c.Name)
+	}
+}
+
 func TestCronJob_HasReportTypeNone(t *testing.T) {
 	m := testAuditConfig()
 	cfg := v1alpha2.MondooOperatorConfig{}

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -131,7 +131,7 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 									}, proxyEnvVars...), m.Spec.Nodes.Env),
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-									ImagePullPolicy:          corev1.PullIfNotPresent,
+									ImagePullPolicy:          m.Spec.Scanner.Image.PullPolicyOrDefault(),
 								},
 							},
 							Volumes: []corev1.Volume{
@@ -252,7 +252,7 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 							},
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-							ImagePullPolicy:          corev1.PullIfNotPresent,
+							ImagePullPolicy:          m.Spec.Scanner.Image.PullPolicyOrDefault(),
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "root", ReadOnly: true, MountPath: "/mnt/host/"},
 								{Name: "config", ReadOnly: true, MountPath: "/etc/opt/"},

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -426,6 +426,41 @@ func TestCronJob_WithImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)
 }
 
+func TestCronJob_ImagePullPolicy(t *testing.T) {
+	testNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-name"}}
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("defaults to IfNotPresent", func(t *testing.T) {
+		cj := CronJob("test123", testNode, testMondooAuditConfig(), false, cfg)
+		assert.Equal(t, corev1.PullIfNotPresent, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+
+	t.Run("honors the configured policy", func(t *testing.T) {
+		mac := testMondooAuditConfig()
+		mac.Spec.Scanner.Image.PullPolicy = corev1.PullNever
+
+		cj := CronJob("test123", testNode, mac, false, cfg)
+		assert.Equal(t, corev1.PullNever, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+}
+
+func TestDaemonSet_ImagePullPolicy(t *testing.T) {
+	cfg := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("defaults to IfNotPresent", func(t *testing.T) {
+		ds := DaemonSet(*testMondooAuditConfig(), false, "test123", cfg, nil)
+		assert.Equal(t, corev1.PullIfNotPresent, ds.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+
+	t.Run("honors the configured policy", func(t *testing.T) {
+		mac := *testMondooAuditConfig()
+		mac.Spec.Scanner.Image.PullPolicy = corev1.PullAlways
+
+		ds := DaemonSet(mac, false, "test123", cfg, nil)
+		assert.Equal(t, corev1.PullAlways, ds.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+}
+
 func TestDaemonSet_WithProxy(t *testing.T) {
 	mac := *testMondooAuditConfig()
 	cfg := v1alpha2.MondooOperatorConfig{

--- a/controllers/resource_watcher/resources.go
+++ b/controllers/resource_watcher/resources.go
@@ -133,7 +133,7 @@ func Deployment(image, integrationMRN, clusterUID string, m *v1alpha2.MondooAudi
 						{
 							Name:            "mondoo-resource-watcher",
 							Image:           image,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: m.Spec.Scanner.Image.PullPolicyOrDefault(),
 							Command:         cmd,
 							Resources:       k8s.ResourcesRequirementsWithDefaults(m.Spec.Scanner.Resources, k8s.DefaultK8sResourceScanningResources),
 							SecurityContext: &corev1.SecurityContext{

--- a/controllers/resource_watcher/resources_test.go
+++ b/controllers/resource_watcher/resources_test.go
@@ -471,6 +471,39 @@ func TestDeployment_ProxyEnvVars(t *testing.T) {
 	assert.Equal(t, "localhost,10.0.0.0/8", envMap["no_proxy"])
 }
 
+func TestDeployment_ImagePullPolicy(t *testing.T) {
+	newConfig := func() *v1alpha2.MondooAuditConfig {
+		return &v1alpha2.MondooAuditConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-config",
+				Namespace: "mondoo-operator",
+			},
+			Spec: v1alpha2.MondooAuditConfigSpec{
+				KubernetesResources: v1alpha2.KubernetesResources{
+					Enable: true,
+					ResourceWatcher: v1alpha2.ResourceWatcherSpec{
+						Enable: true,
+					},
+				},
+			},
+		}
+	}
+	operatorConfig := v1alpha2.MondooOperatorConfig{}
+
+	t.Run("defaults to IfNotPresent", func(t *testing.T) {
+		d := Deployment("test-image:latest", "", "", newConfig(), operatorConfig)
+		assert.Equal(t, corev1.PullIfNotPresent, d.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+
+	t.Run("honors the configured policy", func(t *testing.T) {
+		config := newConfig()
+		config.Spec.Scanner.Image.PullPolicy = corev1.PullAlways
+
+		d := Deployment("test-image:latest", "", "", config, operatorConfig)
+		assert.Equal(t, corev1.PullAlways, d.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	})
+}
+
 func TestDeployment_WithImagePullSecrets(t *testing.T) {
 	config := &v1alpha2.MondooAuditConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/resource_watcher/watcher.go
+++ b/controllers/resource_watcher/watcher.go
@@ -6,9 +6,9 @@ package resource_watcher
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
+	"go.mondoo.com/mondoo-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -64,10 +64,12 @@ type ResourceWatcher struct {
 	cache     cache.Cache
 	debouncer *Debouncer
 	config    WatcherConfig
+	nsFilter  *utils.NamespaceFilter
 }
 
-// NewResourceWatcher creates a new ResourceWatcher.
-func NewResourceWatcher(c cache.Cache, debouncer *Debouncer, config WatcherConfig) *ResourceWatcher {
+// NewResourceWatcher creates a new ResourceWatcher. It returns an error if the
+// configured namespace include/exclude patterns are not valid glob syntax.
+func NewResourceWatcher(c cache.Cache, debouncer *Debouncer, config WatcherConfig) (*ResourceWatcher, error) {
 	if len(config.ResourceTypes) == 0 {
 		// Use high-priority resources by default (stable workload resources).
 		// Only use all resources if explicitly requested via WatchAllResources.
@@ -77,11 +79,18 @@ func NewResourceWatcher(c cache.Cache, debouncer *Debouncer, config WatcherConfi
 			config.ResourceTypes = HighPriorityResourceTypes
 		}
 	}
+
+	nsFilter, err := utils.NewNamespaceFilter(config.Namespaces, config.NamespacesExclude)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ResourceWatcher{
 		cache:     c,
 		debouncer: debouncer,
 		config:    config,
-	}
+		nsFilter:  nsFilter,
+	}, nil
 }
 
 // Start begins watching resources and processing events.
@@ -159,15 +168,10 @@ func (w *ResourceWatcher) getObjectForResourceType(resourceType string) (client.
 	}
 }
 
-// shouldWatchNamespace returns true if the namespace should be watched.
+// shouldWatchNamespace returns true if the namespace should be watched. Include
+// and exclude entries may be literal names or glob patterns such as "prod-*".
 func (w *ResourceWatcher) shouldWatchNamespace(namespace string) bool {
-	// If include list is specified, only watch those namespaces
-	if len(w.config.Namespaces) > 0 {
-		return slices.Contains(w.config.Namespaces, namespace)
-	}
-
-	// Check exclude list
-	return !slices.Contains(w.config.NamespacesExclude, namespace)
+	return w.nsFilter.Allow(namespace)
 }
 
 // resourceEventHandler handles resource events from informers.

--- a/controllers/resource_watcher/watcher_test.go
+++ b/controllers/resource_watcher/watcher_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource_watcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldWatchNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		include   []string
+		exclude   []string
+		namespace string
+		expected  bool
+	}{
+		{
+			name:      "no filtering watches everything",
+			namespace: "any-namespace",
+			expected:  true,
+		},
+		{
+			name:      "literal include matches",
+			include:   []string{"default", "prod"},
+			namespace: "prod",
+			expected:  true,
+		},
+		{
+			name:      "literal include does not match",
+			include:   []string{"default", "prod"},
+			namespace: "staging",
+			expected:  false,
+		},
+		{
+			name:      "literal exclude matches",
+			exclude:   []string{"kube-system"},
+			namespace: "kube-system",
+			expected:  false,
+		},
+		{
+			name:      "literal exclude does not match",
+			exclude:   []string{"kube-system"},
+			namespace: "prod",
+			expected:  true,
+		},
+		{
+			name:      "glob include matches",
+			include:   []string{"prod-*"},
+			namespace: "prod-api",
+			expected:  true,
+		},
+		{
+			name:      "glob include does not match",
+			include:   []string{"prod-*"},
+			namespace: "staging-api",
+			expected:  false,
+		},
+		{
+			name:      "glob exclude matches",
+			exclude:   []string{"kube-*"},
+			namespace: "kube-public",
+			expected:  false,
+		},
+		{
+			name:      "glob exclude does not match",
+			exclude:   []string{"kube-*"},
+			namespace: "prod-api",
+			expected:  true,
+		},
+		{
+			name:      "glob mixed with literals in include",
+			include:   []string{"default", "team-*"},
+			namespace: "team-payments",
+			expected:  true,
+		},
+		{
+			name:      "include takes precedence over exclude",
+			include:   []string{"prod-*"},
+			exclude:   []string{"prod-canary"},
+			namespace: "prod-canary",
+			expected:  true,
+		},
+		{
+			name:      "suffix glob exclude",
+			exclude:   []string{"*-canary"},
+			namespace: "api-canary",
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w, err := NewResourceWatcher(nil, nil, WatcherConfig{
+				Namespaces:        test.include,
+				NamespacesExclude: test.exclude,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, w.shouldWatchNamespace(test.namespace))
+		})
+	}
+}
+
+func TestNewResourceWatcherRejectsInvalidNamespacePattern(t *testing.T) {
+	t.Run("include", func(t *testing.T) {
+		_, err := NewResourceWatcher(nil, nil, WatcherConfig{Namespaces: []string{"[bad"}})
+		require.Error(t, err)
+	})
+
+	t.Run("exclude", func(t *testing.T) {
+		_, err := NewResourceWatcher(nil, nil, WatcherConfig{NamespacesExclude: []string{"[bad"}})
+		require.Error(t, err)
+	})
+}
+
+func TestNewResourceWatcherDefaultResourceTypes(t *testing.T) {
+	w, err := NewResourceWatcher(nil, nil, WatcherConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, HighPriorityResourceTypes, w.config.ResourceTypes)
+
+	w, err = NewResourceWatcher(nil, nil, WatcherConfig{WatchAllResources: true})
+	require.NoError(t, err)
+	assert.Equal(t, DefaultResourceTypes, w.config.ResourceTypes)
+}

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -12,6 +12,7 @@ This user manual describes how to install and use the Mondoo Operator.
   - [Configuring the Mondoo Secret](#configuring-the-mondoo-secret)
   - [Creating a MondooAuditConfig](#creating-a-mondooauditconfig)
     - [Filter Kubernetes objects based on namespace](#filter-kubernetes-objects-based-on-namespace)
+      - [Wildcards](#wildcards)
   - [Scanning External Clusters](#scanning-external-clusters)
     - [Creating a kubeconfig Secret](#creating-a-kubeconfig-secret)
     - [Configuring external cluster scanning](#configuring-external-cluster-scanning)
@@ -23,6 +24,7 @@ This user manual describes how to install and use the Mondoo Operator.
   - [Installing Mondoo into multiple namespaces](#installing-mondoo-into-multiple-namespaces)
   - [Adjust the scan interval](#adjust-the-scan-interval)
   - [Customize the generated scan Jobs](#customize-the-generated-scan-jobs)
+  - [Set the image pull policy](#set-the-image-pull-policy)
   - [Real-time Resource Watcher (Opt-in)](#real-time-resource-watcher-opt-in)
   - [Configure resources for the operator and its components](#configure-resources-for-the-operator-and-its-components)
     - [Configure resources for the operator-controller](#configure-resources-for-the-operator-controller)
@@ -223,6 +225,35 @@ spec:
         - backend2
         - ...
 ```
+
+`include` takes precedence over `exclude`: when `include` is non-empty only the namespaces it matches are scanned, and `exclude` is not consulted at all.
+
+#### Wildcards
+
+Both lists accept glob patterns as well as literal namespace names:
+
+```
+...
+spec:
+...
+  filtering:
+    namespaces:
+      exclude:
+        - kube-*        # kube-system, kube-public, kube-node-lease
+        - '*-canary'    # any namespace ending in -canary
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `prod-*` | `prod-api`, `prod-web`, but not `staging-api` |
+| `*-canary` | `api-canary`, `web-canary` |
+| `team-?` | `team-a`, `team-b`, but not `team-payments` |
+| `{frontend,backend}` | `frontend`, `backend` |
+| `*` | every namespace |
+
+Quote any pattern that starts with `*`, otherwise YAML parses it as an alias.
+
+> **Note:** When `include` contains a wildcard, the resource watcher watches all namespaces and filters events as they arrive, because the set of matching namespaces can change while it is running. This needs cluster-wide list/watch permission on the resource types being watched, which the operator's default RBAC already grants. With only literal names, the watch is scoped to those namespaces.
 
 ## GitOps installs: let the operator create its Console integration
 
@@ -1024,6 +1055,45 @@ Notes:
   the operator take precedence and cannot be overwritten.
 - `nodeSelector` is ignored for node scan pods because they are pinned to a specific node.
 - `nodes.jobOverrides` only applies to the `cronjob` node scanning style.
+
+## Set the image pull policy
+
+By default every container the operator creates uses `IfNotPresent`. Set
+`spec.scanner.image.pullPolicy` to change it:
+
+```yaml
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-client
+  namespace: mondoo-operator
+spec:
+  scanner:
+    image:
+      pullPolicy: Always
+```
+
+Valid values are `Always`, `IfNotPresent`, and `Never`.
+
+The policy applies to every container and init container the operator generates:
+
+- the Kubernetes resource scan CronJobs, including those for [external clusters](#scanning-external-clusters)
+- the container image scan CronJob
+- the node scan CronJobs and DaemonSet
+- the [resource watcher](#real-time-resource-watcher-opt-in) Deployment
+- the cloud CLI (`gcloud`/`aws`/`az`), SPIFFE helper, and registry credential init containers
+
+Two cases where this matters:
+
+- **`Always`** — you publish a moving tag such as `13-rootless` and want each scan to pick up the
+  newest push. Prefer pinning `spec.scanner.image.digest` when you need reproducibility instead.
+- **`Never`** — an air-gapped cluster where images are preloaded onto the nodes and any registry
+  round trip would fail. Note that the third-party init container images
+  (`gcloud`, `aws`, `az`, the SPIFFE helper, `busybox`) are not rewritten by
+  `imageRegistry`/`registryMirrors`, so preload those under their original names.
+
+This setting does not affect the operator's own Deployment. Configure that through the Helm value
+`controllerManager.manager.imagePullPolicy`.
 
 ## Real-time Resource Watcher (Opt-in)
 

--- a/pkg/utils/k8s/registry_wif.go
+++ b/pkg/utils/k8s/registry_wif.go
@@ -13,7 +13,7 @@ import (
 
 // RegistryWIFInitContainer creates an init container that generates docker config credentials
 // using cloud-native Workload Identity Federation for container registry authentication.
-func RegistryWIFInitContainer(wif *v1alpha2.WorkloadIdentityConfig) corev1.Container {
+func RegistryWIFInitContainer(wif *v1alpha2.WorkloadIdentityConfig, pullPolicy corev1.PullPolicy) corev1.Container {
 	var image, shell, script string
 	var env []corev1.EnvVar
 
@@ -151,7 +151,7 @@ echo "Docker config generated for ACR: ${ACR_LOGIN_SERVER}"
 	return corev1.Container{
 		Name:            "generate-registry-creds",
 		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: pullPolicy,
 		Command:         []string{shell, "-c", script},
 		Env:             env,
 		VolumeMounts: []corev1.VolumeMount{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,31 +4,112 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gobwas/glob"
 )
 
-func AllowNamespace(namespace string, includeNamespaces, excludeNamespaces []string) (bool, error) {
-	if len(includeNamespaces) > 0 {
-		for _, ns := range includeNamespaces {
-			g, err := glob.Compile(ns)
-			if err != nil {
-				return false, err
-			}
-			if g.Match(namespace) {
-				return true, nil
-			}
+// globMetaChars are the characters gobwas/glob interprets as pattern syntax. A
+// Kubernetes namespace name is a DNS-1123 label, so it can never contain any of
+// them: their presence unambiguously marks an entry as a pattern rather than a
+// literal name.
+const globMetaChars = `*?[]{}!\`
+
+// IsGlobPattern reports whether s uses glob syntax, i.e. whether it can match a
+// name other than itself.
+func IsGlobPattern(s string) bool {
+	return strings.ContainsAny(s, globMetaChars)
+}
+
+// HasGlobPattern reports whether any entry in patterns uses glob syntax.
+func HasGlobPattern(patterns []string) bool {
+	for _, p := range patterns {
+		if IsGlobPattern(p) {
+			return true
 		}
-		return false, nil
+	}
+	return false
+}
+
+// NamespaceFilter decides whether a namespace is in scope for watching or
+// scanning. Entries may be literal namespace names or glob patterns such as
+// "prod-*".
+//
+// Include takes precedence over Exclude: when the include list is non-empty only
+// namespaces matching it are allowed, and the exclude list is not consulted at
+// all. When both lists are empty every namespace is allowed.
+//
+// These are the same semantics the cnspec Kubernetes provider applies to the
+// "namespaces" and "namespaces-exclude" inventory options, so a given
+// MondooAuditConfig selects the same namespaces whether it is evaluated here or
+// inside a scan job.
+type NamespaceFilter struct {
+	include []glob.Glob
+	exclude []glob.Glob
+}
+
+// NewNamespaceFilter compiles the include and exclude patterns. It returns an
+// error if any pattern is not valid glob syntax, so a typo surfaces at startup
+// instead of silently matching nothing.
+func NewNamespaceFilter(includeNamespaces, excludeNamespaces []string) (*NamespaceFilter, error) {
+	include, err := compileGlobs(includeNamespaces)
+	if err != nil {
+		return nil, fmt.Errorf("invalid namespace include pattern: %w", err)
 	}
 
-	for _, ns := range excludeNamespaces {
-		g, err := glob.Compile(ns)
+	exclude, err := compileGlobs(excludeNamespaces)
+	if err != nil {
+		return nil, fmt.Errorf("invalid namespace exclude pattern: %w", err)
+	}
+
+	return &NamespaceFilter{include: include, exclude: exclude}, nil
+}
+
+// Allow reports whether the namespace is in scope.
+func (f *NamespaceFilter) Allow(namespace string) bool {
+	// Anything on the include list means accept only from that list.
+	if len(f.include) > 0 {
+		return matchesAny(f.include, namespace)
+	}
+
+	// Nothing was explicitly included, so the namespace is in scope unless it is
+	// explicitly excluded.
+	return !matchesAny(f.exclude, namespace)
+}
+
+func compileGlobs(patterns []string) ([]glob.Glob, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	compiled := make([]glob.Glob, 0, len(patterns))
+	for _, p := range patterns {
+		g, err := glob.Compile(p)
 		if err != nil {
-			return false, nil
+			return nil, fmt.Errorf("%q: %w", p, err)
 		}
-		if g.Match(namespace) {
-			return false, nil
+		compiled = append(compiled, g)
+	}
+	return compiled, nil
+}
+
+func matchesAny(globs []glob.Glob, s string) bool {
+	for _, g := range globs {
+		if g.Match(s) {
+			return true
 		}
 	}
-	return true, nil
+	return false
+}
+
+// AllowNamespace reports whether the namespace is in scope for the given include
+// and exclude lists. Prefer NewNamespaceFilter when the same lists are evaluated
+// repeatedly, since this recompiles the patterns on every call.
+func AllowNamespace(namespace string, includeNamespaces, excludeNamespaces []string) (bool, error) {
+	f, err := NewNamespaceFilter(includeNamespaces, excludeNamespaces)
+	if err != nil {
+		return false, err
+	}
+	return f.Allow(namespace), nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -66,6 +66,67 @@ func TestFiltering(t *testing.T) {
 			excludedList:   []string{"test*"},
 			expectedResult: false,
 		},
+		{
+			name:           "include glob prefix matches",
+			input:          "prod-api",
+			includedList:   []string{"prod-*"},
+			expectedResult: true,
+		},
+		{
+			name:           "include glob prefix does not match",
+			input:          "staging-api",
+			includedList:   []string{"prod-*"},
+			expectedResult: false,
+		},
+		{
+			name:           "include glob among literals",
+			input:          "dev-web",
+			includedList:   []string{"default", "dev-*"},
+			expectedResult: true,
+		},
+		{
+			name:           "exclude glob suffix",
+			input:          "api-canary",
+			excludedList:   []string{"*-canary"},
+			expectedResult: false,
+		},
+		{
+			name:           "exclude glob among literals leaves others allowed",
+			input:          "prod-api",
+			excludedList:   []string{"kube-system", "*-canary"},
+			expectedResult: true,
+		},
+		{
+			name:           "include glob wins over overlapping exclude glob",
+			input:          "prod-api",
+			includedList:   []string{"prod-*"},
+			excludedList:   []string{"prod-*"},
+			expectedResult: true,
+		},
+		{
+			name:           "single char wildcard",
+			input:          "team-a",
+			includedList:   []string{"team-?"},
+			expectedResult: true,
+		},
+		{
+			name:           "alternation",
+			input:          "backend",
+			includedList:   []string{"{frontend,backend}"},
+			expectedResult: true,
+		},
+		{
+			name:           "match everything",
+			input:          "anything-at-all",
+			includedList:   []string{"*"},
+			expectedResult: true,
+		},
+		{
+			name:           "exclude everything",
+			input:          "anything-at-all",
+			excludedList:   []string{"*"},
+			expectedResult: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -77,4 +138,62 @@ func TestFiltering(t *testing.T) {
 			assert.Equal(t, test.expectedResult, result, "unexpected result when checking namespace filtering")
 		})
 	}
+}
+
+func TestAllowNamespaceInvalidPattern(t *testing.T) {
+	// An unterminated character class is not valid glob syntax. Both branches must
+	// surface the error rather than silently allowing or denying the namespace.
+	t.Run("include", func(t *testing.T) {
+		_, err := AllowNamespace("test-namespace", []string{"[bad"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "include")
+	})
+
+	t.Run("exclude", func(t *testing.T) {
+		_, err := AllowNamespace("test-namespace", nil, []string{"[bad"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exclude")
+	})
+}
+
+func TestNewNamespaceFilterCompilesOnce(t *testing.T) {
+	f, err := NewNamespaceFilter([]string{"prod-*", "shared"}, []string{"prod-canary"})
+	require.NoError(t, err)
+
+	// Include is non-empty, so exclude is not consulted at all.
+	assert.True(t, f.Allow("prod-api"))
+	assert.True(t, f.Allow("prod-canary"))
+	assert.True(t, f.Allow("shared"))
+	assert.False(t, f.Allow("staging-api"))
+}
+
+func TestIsGlobPattern(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"default", false},
+		{"kube-system", false},
+		{"mondoo-operator", false},
+		{"prod-*", true},
+		{"*", true},
+		{"team-?", true},
+		{"{a,b}", true},
+		{"[abc]-ns", true},
+		{`esc\-aped`, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			assert.Equal(t, test.expected, IsGlobPattern(test.input))
+		})
+	}
+}
+
+func TestHasGlobPattern(t *testing.T) {
+	assert.False(t, HasGlobPattern(nil))
+	assert.False(t, HasGlobPattern([]string{}))
+	assert.False(t, HasGlobPattern([]string{"default", "kube-system"}))
+	assert.True(t, HasGlobPattern([]string{"default", "prod-*"}))
+	assert.True(t, HasGlobPattern([]string{"prod-*"}))
 }


### PR DESCRIPTION
Add spec.scanner.image.pullPolicy to MondooAuditConfig, and make the resource watcher honor namespace glob patterns.

**Image pull policy**

Every container the operator generated hardcoded PullIfNotPresent. The new enum field (Always|IfNotPresent|Never) defaults to IfNotPresent, so existing behavior is unchanged. It applies to the k8s scan, external cluster, container image and node scan CronJobs, the node scan DaemonSet, the resource watcher Deployment, and the generate-kubeconfig, fetch-spiffe-certs and generate-registry-creds init containers. The three init container helpers took no config, so they gained a pullPolicy parameter.

The operator's own Deployment is unaffected; it stays configurable through the Helm value controllerManager.manager.imagePullPolicy.

**Namespace wildcards**

Glob patterns already worked for the CronJob scan paths, which pass namespaces/namespaces-exclude through to the cnspec Kubernetes provider. The resource watcher silently ignored them, for two independent reasons:

  - shouldWatchNamespace matched with slices.Contains, so an include list of ["prod-*"] watched nothing.
  - The include list was used verbatim as controller-runtime cache namespace keys, opening a literal watch on a namespace named "prod-*". Fixing the matcher alone would still have delivered no events.

Both paths now share a pre-compiled NamespaceFilter in pkg/utils, so the watcher and the scan jobs select the same namespaces. When the include list contains a glob the watcher caches cluster-wide and filters per event, because matching namespaces can be created after startup; literal-only lists keep the scoped watch. Invalid patterns now fail at startup instead of silently matching nothing, which also fixes AllowNamespace swallowing glob compile errors on the exclude branch and returning deny.

shouldWatchNamespace had no test coverage. Adds watcher_test.go, plus pull policy tests across all four controllers.