### PR TITLE
⚡ perf(operator): trim cached Pod and Node objects

### DIFF
--- a/cmd/mondoo-operator/operator/cache.go
+++ b/cmd/mondoo-operator/operator/cache.go
@@ -1,0 +1,75 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package operator
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// cacheOptions returns the manager cache configuration. The operator watches
+// Pods and Nodes cluster wide, so the informer cache retains one copy of every
+// Pod and every Node in the cluster. The transforms below drop the fields that
+// no controller reads, which cuts the retained heap of both caches.
+func cacheOptions() cache.Options {
+	return cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}:  {Transform: transformPod},
+			&corev1.Node{}: {Transform: transformNode},
+		},
+	}
+}
+
+// transformPod strips a Pod down to the fields the operator reads.
+//
+// The operator reads:
+//   - object metadata, for names, labels, namespaces and creation timestamps,
+//   - spec.nodeName, to group node scan Pods per node,
+//   - spec.containers name, image and resources, to read the operator image and
+//     to report the memory limit of an OOM killed scan container,
+//   - status phase, conditions and container statuses, to detect OOM kills.
+//
+// Everything else (managed fields, annotations, env vars, volumes, tolerations,
+// affinity, security context) is dropped. Container order and count stay intact
+// because the condition code indexes spec.containers by container status index.
+func transformPod(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	pod.ManagedFields = nil
+	pod.Annotations = nil
+
+	containers := make([]corev1.Container, len(pod.Spec.Containers))
+	for i, c := range pod.Spec.Containers {
+		containers[i] = corev1.Container{Name: c.Name, Image: c.Image, Resources: c.Resources}
+	}
+	pod.Spec = corev1.PodSpec{NodeName: pod.Spec.NodeName, Containers: containers}
+
+	pod.Status = corev1.PodStatus{
+		Phase:             pod.Status.Phase,
+		Conditions:        pod.Status.Conditions,
+		ContainerStatuses: pod.Status.ContainerStatuses,
+	}
+
+	return pod, nil
+}
+
+// transformNode drops the Node fields that no controller reads. The operator
+// reads node names, labels, taints and the allocatable resources. The image
+// list in the status is the largest part of a Node object on a busy node and
+// nothing reads it.
+func transformNode(obj any) (any, error) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return obj, nil
+	}
+
+	node.ManagedFields = nil
+	node.Status.Images = nil
+
+	return node, nil
+}

--- a/cmd/mondoo-operator/operator/cache.go
+++ b/cmd/mondoo-operator/operator/cache.go
@@ -49,10 +49,20 @@ func transformPod(obj any) (any, error) {
 	}
 	pod.Spec = corev1.PodSpec{NodeName: pod.Spec.NodeName, Containers: containers}
 
+	statuses := make([]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
+	for i, status := range pod.Status.ContainerStatuses {
+		statuses[i] = corev1.ContainerStatus{
+			Name:                 status.Name,
+			State:                status.State,
+			LastTerminationState: status.LastTerminationState,
+			RestartCount:         status.RestartCount,
+		}
+	}
+
 	pod.Status = corev1.PodStatus{
 		Phase:             pod.Status.Phase,
 		Conditions:        pod.Status.Conditions,
-		ContainerStatuses: pod.Status.ContainerStatuses,
+		ContainerStatuses: statuses,
 	}
 
 	return pod, nil

--- a/cmd/mondoo-operator/operator/cache_test.go
+++ b/cmd/mondoo-operator/operator/cache_test.go
@@ -1,0 +1,158 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTransformPod_KeepsFieldsTheOperatorReads(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "mondoo-client-node-scan",
+			Namespace:     "mondoo-operator",
+			Labels:        map[string]string{"mondoo_cr": "mondoo-client"},
+			Annotations:   map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{
+				{
+					Name:  "cnspec",
+					Image: "docker.io/mondoo/cnspec:latest",
+					Env:   []corev1.EnvVar{{Name: "DEBUG", Value: "true"}},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("300Mi")},
+					},
+				},
+			},
+			Volumes:     []corev1.Volume{{Name: "root"}},
+			Tolerations: []corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodFailed,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:                 "cnspec",
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137}},
+				},
+			},
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	out, err := transformPod(pod)
+	require.NoError(t, err)
+
+	got, ok := out.(*corev1.Pod)
+	require.True(t, ok)
+
+	// Kept.
+	assert.Equal(t, "mondoo-client-node-scan", got.Name)
+	assert.Equal(t, "mondoo-operator", got.Namespace)
+	assert.Equal(t, map[string]string{"mondoo_cr": "mondoo-client"}, got.Labels)
+	assert.Equal(t, "node-1", got.Spec.NodeName)
+	require.Len(t, got.Spec.Containers, 1)
+	assert.Equal(t, "cnspec", got.Spec.Containers[0].Name)
+	assert.Equal(t, "docker.io/mondoo/cnspec:latest", got.Spec.Containers[0].Image)
+	assert.Equal(t, "300Mi", got.Spec.Containers[0].Resources.Limits.Memory().String())
+	assert.Equal(t, corev1.PodFailed, got.Status.Phase)
+	assert.Len(t, got.Status.Conditions, 1)
+	require.Len(t, got.Status.ContainerStatuses, 1)
+	assert.Equal(t, int32(137), got.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode)
+
+	// Dropped.
+	assert.Nil(t, got.ManagedFields)
+	assert.Nil(t, got.Annotations)
+	assert.Nil(t, got.Spec.Containers[0].Env)
+	assert.Nil(t, got.Spec.Volumes)
+	assert.Nil(t, got.Spec.Tolerations)
+	assert.Empty(t, got.Status.PodIP)
+}
+
+func TestTransformPod_KeepsContainerIndexes(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "sidecar"}, {Name: "cnspec"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "sidecar"}, {Name: "cnspec"}},
+		},
+	}
+
+	out, err := transformPod(pod)
+	require.NoError(t, err)
+
+	got := out.(*corev1.Pod)
+	require.Len(t, got.Spec.Containers, 2)
+	for i, status := range got.Status.ContainerStatuses {
+		assert.Equal(t, status.Name, got.Spec.Containers[i].Name)
+	}
+}
+
+func TestTransformPod_IgnoresOtherTypes(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+
+	out, err := transformPod(node)
+	require.NoError(t, err)
+	assert.Same(t, node, out)
+}
+
+func TestTransformNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "node-1",
+			Labels:        map[string]string{"kubernetes.io/hostname": "node-1"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{{Key: "dedicated", Value: "mondoo", Effect: corev1.TaintEffectNoSchedule}},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+			Capacity:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+			Images:      []corev1.ContainerImage{{Names: []string{"docker.io/library/nginx:latest"}, SizeBytes: 1000}},
+		},
+	}
+
+	out, err := transformNode(node)
+	require.NoError(t, err)
+
+	got, ok := out.(*corev1.Node)
+	require.True(t, ok)
+
+	assert.Equal(t, "node-1", got.Name)
+	assert.Equal(t, map[string]string{"kubernetes.io/hostname": "node-1"}, got.Labels)
+	assert.Equal(t, []corev1.Taint{{Key: "dedicated", Value: "mondoo", Effect: corev1.TaintEffectNoSchedule}}, got.Spec.Taints)
+	assert.Equal(t, "4Gi", got.Status.Allocatable.Memory().String())
+	assert.Equal(t, "8Gi", got.Status.Capacity.Memory().String())
+
+	assert.Nil(t, got.ManagedFields)
+	assert.Nil(t, got.Status.Images)
+}
+
+func TestTransformNode_IgnoresOtherTypes(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}
+
+	out, err := transformNode(pod)
+	require.NoError(t, err)
+	assert.Same(t, pod, out)
+}
+
+func TestCacheOptions(t *testing.T) {
+	opts := cacheOptions()
+	require.Len(t, opts.ByObject, 2)
+
+	for obj, byObject := range opts.ByObject {
+		assert.NotNil(t, byObject.Transform, "missing transform for %T", obj)
+	}
+}

--- a/cmd/mondoo-operator/operator/cache_test.go
+++ b/cmd/mondoo-operator/operator/cache_test.go
@@ -43,6 +43,11 @@ func TestTransformPod_KeepsFieldsTheOperatorReads(t *testing.T) {
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
 					Name:                 "cnspec",
+					RestartCount:         3,
+					State:                corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+					Image:                "docker.io/mondoo/cnspec:latest",
+					ImageID:              "sha256:unused",
+					ContainerID:          "containerd://unused",
 					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137}},
 				},
 			},
@@ -69,6 +74,8 @@ func TestTransformPod_KeepsFieldsTheOperatorReads(t *testing.T) {
 	assert.Len(t, got.Status.Conditions, 1)
 	require.Len(t, got.Status.ContainerStatuses, 1)
 	assert.Equal(t, int32(137), got.Status.ContainerStatuses[0].LastTerminationState.Terminated.ExitCode)
+	assert.Equal(t, int32(3), got.Status.ContainerStatuses[0].RestartCount)
+	assert.Equal(t, "OOMKilled", got.Status.ContainerStatuses[0].State.Terminated.Reason)
 
 	// Dropped.
 	assert.Nil(t, got.ManagedFields)
@@ -77,6 +84,9 @@ func TestTransformPod_KeepsFieldsTheOperatorReads(t *testing.T) {
 	assert.Nil(t, got.Spec.Volumes)
 	assert.Nil(t, got.Spec.Tolerations)
 	assert.Empty(t, got.Status.PodIP)
+	assert.Empty(t, got.Status.ContainerStatuses[0].Image)
+	assert.Empty(t, got.Status.ContainerStatuses[0].ImageID)
+	assert.Empty(t, got.Status.ContainerStatuses[0].ContainerID)
 }
 
 func TestTransformPod_KeepsContainerIndexes(t *testing.T) {

--- a/cmd/mondoo-operator/operator/cmd.go
+++ b/cmd/mondoo-operator/operator/cmd.go
@@ -88,6 +88,7 @@ func init() {
 			LeaderElectionID:       "60679458.mondoo.com",
 			LeaseDuration:          ptr.To(30 * time.Second),
 			RenewDeadline:          ptr.To(20 * time.Second),
+			Cache:                  cacheOptions(),
 			Client: client.Options{
 				Cache: &client.CacheOptions{
 					DisableFor: []client.Object{


### PR DESCRIPTION
## What allocates

The operator watches Pods and Nodes cluster wide (`SetupWithManager` in `controllers/mondooauditconfig_controller.go`). The controller-runtime cache therefore retains one full copy of every Pod and every Node in the cluster, for the lifetime of the process.

The controllers read very little of that:

* Pods: metadata, `spec.nodeName`, container name, image and resources, and the status fields used for OOM detection (`controllers/*/conditions.go`, `pkg/utils/mondoo/container_image_resolver.go`, `pkg/utils/k8s/pods.go`).
* Nodes: name, labels, taints and `status.allocatable` (`controllers/nodes/*`, `controllers/status/operator_status.go`).

Env vars, volumes, tolerations, annotations, managed fields and the node image list are retained but never read.

## Change

Two `cache.ByObject` transforms, applied before an object enters the informer store. Container order and count stay intact, because the condition code indexes `spec.containers` by container status index.

No behaviour change, no extra API calls, no feature gate.

## Measurement

kind cluster (1 node image, populated with synthetic objects): 1517 Pods across 31 namespaces (2 containers, 20 env vars, 2 KiB annotation each), 61 Nodes (100 images each), 644 ConfigMaps, 452 Deployments, 452 ReplicaSets.

A harness starts the same informers the operator starts (Pod, Node, CronJob, Deployment, DaemonSet, ConfigMap), waits for sync, runs `runtime.GC()` three times, then reads `runtime.MemStats`.

| run | heap_alloc | heap_inuse |
| --- | --- | --- |
| before | 45.09 MiB | 48.62 MiB |
| after | 23.68 MiB | 32.14 MiB |

Three repeats each, spread below 0.1 MiB. Retained heap drops by 47.5 percent.

`go tool pprof -inuse_space` before the change, top sites:

```
   11.01MB 21.76%  k8s.io/apimachinery/pkg/apis/meta/v1.(*ObjectMeta).Unmarshal
    8.02MB 15.85%  bytes.Clone
    4.50MB  8.90%  k8s.io/api/core/v1.(*Container).Unmarshal
    4.50MB  8.90%  k8s.io/api/core/v1.(*PodSpec).Unmarshal
    4.50MB  8.90%  k8s.io/api/core/v1.(*ResourceRequirements).Unmarshal
    2.50MB  4.94%  k8s.io/api/core/v1.(*EnvVar).Unmarshal
```

After the change `PodSpec`, `EnvVar` and most of `ObjectMeta` leave the profile.

The Node part alone saves about 28 KiB per node, so the saving grows with cluster size.

## Correctness

* New unit tests cover the kept fields, the dropped fields, the container index mapping and the type guards.
* `go test ./controllers/... ./api/... ./pkg/... ./cmd/...` passes.
* The transforms were also run against the kind cluster above. Cached Pods and Nodes still serve every field the controllers read.


## Review clarification

The production Pod cache transform intentionally excludes init-container specifications and statuses: current cached Pod consumers inspect regular containers only. It is not an init-container OOM detection feature. Any future cached consumer of init-container data must extend the transform and its regression tests first.

The latest feedback fix preserves regular-container Name, State, LastTerminationState and RestartCount while dropping unused status metadata. Current-head upstream workflow approval is still required; earlier test/measurement results above are not a claim that the latest head has completed CI.
