### PR TITLE
⚡ perf(resource-watcher): cache metadata only

### DIFF
--- a/cmd/mondoo-operator/resource_watcher/cmd.go
+++ b/cmd/mondoo-operator/resource_watcher/cmd.go
@@ -151,6 +151,9 @@ func init() {
 		// Create cache
 		cacheOpts := cache.Options{
 			Scheme: scheme,
+			// The cache only feeds change events, so keep metadata and drop
+			// the specs and statuses that dominate the retained heap.
+			DefaultTransform: resource_watcher.CacheTransform,
 		}
 
 		// If specific namespaces are provided, configure cache to only watch those

--- a/controllers/resource_watcher/transform.go
+++ b/controllers/resource_watcher/transform.go
@@ -20,6 +20,9 @@ import (
 // statuses in the cache are therefore never read, but they dominate the
 // retained heap, in particular for ReplicaSets and Deployments which carry a
 // full pod template each.
+//
+// Labels stay. They are small next to a spec, and label based filtering of the
+// watched resources is in review in #1518.
 func CacheTransform(obj any) (any, error) {
 	switch o := obj.(type) {
 	case *appsv1.Deployment:

--- a/controllers/resource_watcher/transform.go
+++ b/controllers/resource_watcher/transform.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource_watcher
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// CacheTransform strips a watched object down to its metadata before the
+// informer stores it.
+//
+// The resource watcher cache exists to deliver change events. The event
+// handler reads the namespace, the name and the labels of an object, then
+// hands a type, namespace and name triple to the scanner. cnspec reads the
+// object itself from the API server during the scan. The specs and the
+// statuses in the cache are therefore never read, but they dominate the
+// retained heap, in particular for ReplicaSets and Deployments which carry a
+// full pod template each.
+func CacheTransform(obj any) (any, error) {
+	switch o := obj.(type) {
+	case *appsv1.Deployment:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = appsv1.DeploymentSpec{}, appsv1.DeploymentStatus{}
+	case *appsv1.DaemonSet:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = appsv1.DaemonSetSpec{}, appsv1.DaemonSetStatus{}
+	case *appsv1.StatefulSet:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = appsv1.StatefulSetSpec{}, appsv1.StatefulSetStatus{}
+	case *appsv1.ReplicaSet:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = appsv1.ReplicaSetSpec{}, appsv1.ReplicaSetStatus{}
+	case *corev1.Pod:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = corev1.PodSpec{}, corev1.PodStatus{}
+	case *batchv1.Job:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = batchv1.JobSpec{}, batchv1.JobStatus{}
+	case *batchv1.CronJob:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = batchv1.CronJobSpec{}, batchv1.CronJobStatus{}
+	case *corev1.Service:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = corev1.ServiceSpec{}, corev1.ServiceStatus{}
+	case *networkingv1.Ingress:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = networkingv1.IngressSpec{}, networkingv1.IngressStatus{}
+	case *corev1.Namespace:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Spec, o.Status = corev1.NamespaceSpec{}, corev1.NamespaceStatus{}
+	case *corev1.ConfigMap:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Data, o.BinaryData = nil, nil
+	case *corev1.Secret:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Data, o.StringData = nil, nil
+	case *corev1.ServiceAccount:
+		o.ManagedFields, o.Annotations = nil, nil
+		o.Secrets, o.ImagePullSecrets = nil, nil
+	}
+	return obj, nil
+}

--- a/controllers/resource_watcher/transform_test.go
+++ b/controllers/resource_watcher/transform_test.go
@@ -1,0 +1,135 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resource_watcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func testMeta() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:          "test-resource",
+		Namespace:     "test-namespace",
+		Labels:        map[string]string{"app": "test"},
+		Annotations:   map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"},
+		ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kube-controller-manager"}},
+	}
+}
+
+func TestCacheTransform_KeepsIdentity(t *testing.T) {
+	podTemplate := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "nginx:latest"}}},
+	}
+
+	objects := []client.Object{
+		&appsv1.Deployment{ObjectMeta: testMeta(), Spec: appsv1.DeploymentSpec{Replicas: ptr.To(int32(3)), Template: podTemplate}},
+		&appsv1.DaemonSet{ObjectMeta: testMeta(), Spec: appsv1.DaemonSetSpec{Template: podTemplate}},
+		&appsv1.StatefulSet{ObjectMeta: testMeta(), Spec: appsv1.StatefulSetSpec{Template: podTemplate}},
+		&appsv1.ReplicaSet{ObjectMeta: testMeta(), Spec: appsv1.ReplicaSetSpec{Template: podTemplate}},
+		&corev1.Pod{ObjectMeta: testMeta(), Spec: podTemplate.Spec},
+		&batchv1.Job{ObjectMeta: testMeta(), Spec: batchv1.JobSpec{Template: podTemplate}},
+		&batchv1.CronJob{ObjectMeta: testMeta(), Spec: batchv1.CronJobSpec{Schedule: "* * * * *"}},
+		&corev1.Service{ObjectMeta: testMeta(), Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"}},
+		&networkingv1.Ingress{ObjectMeta: testMeta(), Spec: networkingv1.IngressSpec{DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{Name: "test", Port: networkingv1.ServiceBackendPort{Number: 80}},
+		}}},
+		&corev1.Namespace{ObjectMeta: testMeta(), Spec: corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{"kubernetes"}}},
+		&corev1.ConfigMap{ObjectMeta: testMeta(), Data: map[string]string{"key": "value"}},
+		&corev1.Secret{ObjectMeta: testMeta(), Data: map[string][]byte{"key": []byte("value")}},
+		&corev1.ServiceAccount{ObjectMeta: testMeta(), Secrets: []corev1.ObjectReference{{Name: "token"}}},
+	}
+
+	for _, obj := range objects {
+		out, err := CacheTransform(obj)
+		require.NoError(t, err)
+
+		got, ok := out.(client.Object)
+		require.True(t, ok)
+
+		assert.Equal(t, "test-resource", got.GetName())
+		assert.Equal(t, "test-namespace", got.GetNamespace())
+		assert.Equal(t, map[string]string{"app": "test"}, got.GetLabels())
+		assert.Nil(t, got.GetAnnotations())
+		assert.Nil(t, got.GetManagedFields())
+	}
+}
+
+func TestCacheTransform_DropsPayload(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: testMeta(),
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr.To(int32(3))},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 3},
+	}
+	out, err := CacheTransform(deployment)
+	require.NoError(t, err)
+	assert.Equal(t, appsv1.DeploymentSpec{}, out.(*appsv1.Deployment).Spec)
+	assert.Equal(t, appsv1.DeploymentStatus{}, out.(*appsv1.Deployment).Status)
+
+	replicaSet := &appsv1.ReplicaSet{
+		ObjectMeta: testMeta(),
+		Spec: appsv1.ReplicaSetSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "nginx:latest"}}},
+		}},
+	}
+	out, err = CacheTransform(replicaSet)
+	require.NoError(t, err)
+	assert.Empty(t, out.(*appsv1.ReplicaSet).Spec.Template.Spec.Containers)
+
+	configMap := &corev1.ConfigMap{ObjectMeta: testMeta(), Data: map[string]string{"key": "value"}, BinaryData: map[string][]byte{"bin": {1}}}
+	out, err = CacheTransform(configMap)
+	require.NoError(t, err)
+	assert.Nil(t, out.(*corev1.ConfigMap).Data)
+	assert.Nil(t, out.(*corev1.ConfigMap).BinaryData)
+
+	secret := &corev1.Secret{ObjectMeta: testMeta(), Data: map[string][]byte{"key": []byte("value")}, StringData: map[string]string{"key": "value"}}
+	out, err = CacheTransform(secret)
+	require.NoError(t, err)
+	assert.Nil(t, out.(*corev1.Secret).Data)
+	assert.Nil(t, out.(*corev1.Secret).StringData)
+
+	ingress := &networkingv1.Ingress{ObjectMeta: testMeta(), Spec: networkingv1.IngressSpec{Rules: []networkingv1.IngressRule{{Host: "example.com"}}}}
+	out, err = CacheTransform(ingress)
+	require.NoError(t, err)
+	assert.Empty(t, out.(*networkingv1.Ingress).Spec.Rules)
+}
+
+func TestCacheTransform_PassesUnknownTypesThrough(t *testing.T) {
+	obj := &corev1.Endpoints{ObjectMeta: testMeta()}
+
+	out, err := CacheTransform(obj)
+	require.NoError(t, err)
+	assert.Same(t, obj, out)
+	assert.NotNil(t, obj.GetAnnotations())
+}
+
+func TestCacheTransform_HandlesEveryWatchedResourceType(t *testing.T) {
+	watcher := NewResourceWatcher(nil, nil, WatcherConfig{})
+	types := append([]string{}, DefaultResourceTypes...)
+	types = append(types, "configmaps", "secrets", "serviceaccounts")
+
+	for _, resourceType := range types {
+		obj, err := watcher.getObjectForResourceType(resourceType)
+		require.NoError(t, err)
+
+		obj.SetAnnotations(map[string]string{"test": "value"})
+		obj.SetManagedFields([]metav1.ManagedFieldsEntry{{Manager: "test"}})
+
+		out, err := CacheTransform(obj)
+		require.NoError(t, err)
+
+		got := out.(client.Object)
+		assert.Nil(t, got.GetAnnotations(), "annotations kept for %s", resourceType)
+		assert.Nil(t, got.GetManagedFields(), "managed fields kept for %s", resourceType)
+	}
+}

--- a/controllers/resource_watcher/transform_test.go
+++ b/controllers/resource_watcher/transform_test.go
@@ -105,12 +105,16 @@ func TestCacheTransform_DropsPayload(t *testing.T) {
 }
 
 func TestCacheTransform_PassesUnknownTypesThrough(t *testing.T) {
-	obj := &corev1.Endpoints{ObjectMeta: testMeta()}
+	obj := &corev1.Endpoints{
+		ObjectMeta: testMeta(),
+		Subsets:    []corev1.EndpointSubset{{Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}}}},
+	}
+	want := obj.DeepCopy()
 
 	out, err := CacheTransform(obj)
 	require.NoError(t, err)
 	assert.Same(t, obj, out)
-	assert.NotNil(t, obj.GetAnnotations())
+	assert.Equal(t, want, out, "unknown types must pass through unmodified")
 }
 
 func TestCacheTransform_HandlesEveryWatchedResourceType(t *testing.T) {


### PR DESCRIPTION
## What retains

The resource watcher starts an informer per watched resource type (`controllers/resource_watcher/watcher.go`). By default that is Deployments, DaemonSets, StatefulSets and ReplicaSets, cluster wide. The informer store keeps a full copy of every object for the lifetime of the process.

The cache is only used to deliver change events. `handleEvent` reads namespace, name and labels, then hands a type, namespace and name triple to the debouncer. cnspec reads the object from the API server during the scan. Nothing reads a cached spec or status, but a ReplicaSet or a Deployment carries a full pod template, which is the bulk of the object.

## Change

A `DefaultTransform` on the watcher cache clears spec, status, payload maps (ConfigMap and Secret data, ServiceAccount secrets), annotations and managed fields of every watched type. Metadata identity, labels and owner references stay.

No behaviour change, no extra API calls, no feature gate.

## Measurement

kind cluster with 452 Deployments and 452 ReplicaSets, each with a pod template of 2 containers, 20 env vars, 2 volumes and a 2 KiB annotation.

A harness starts the same four informers the watcher starts by default, waits for sync, updates one Deployment to prove events still arrive, runs `runtime.GC()` three times, then reads `runtime.MemStats`.

| run | heap_alloc | heap_inuse |
| --- | --- | --- |
| before | 20.16 MiB | 23.20 MiB |
| after | 4.52 MiB | 9.80 MiB |

Three repeats each, spread below 0.02 MiB on heap_alloc. Retained heap drops by 77.6 percent, about 17 KiB per workload object.

## Correctness

* The same harness run confirms the informer still delivers the update event with the correct namespace, name and labels after the transform, and that all 904 cached objects keep namespace and name.
* New unit tests cover identity retention, payload clearing, unknown type pass through, and that every type in `getObjectForResourceType` is handled.
* `go test ./controllers/... ./api/... ./pkg/... ./cmd/...` passes.
