### PR TITLE
🐛 fix(status): report the memory limit of the OOM killed container

### DIFF
--- a/cmd/mondoo-operator/operator/operator_status.go
+++ b/cmd/mondoo-operator/operator/operator_status.go
@@ -102,12 +102,12 @@ func updateOperatorConditions(config *k8sv1alpha2.MondooAuditConfig, degradedSta
 	memoryLimit := ""
 	if degradedStatus {
 		msg = "Mondoo Operator controller is unavailable"
-		for i, containerStatus := range pod.Status.ContainerStatuses {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
 			if (containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode == 137) ||
 				(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 				msg = "Mondoo Operator controller is unavailable due to OOM"
 				affectedPods = append(affectedPods, pod.Name)
-				memoryLimit = pod.Spec.Containers[i].Resources.Limits.Memory().String()
+				memoryLimit = k8s.ContainerMemoryLimit(pod, containerStatus.Name)
 				break
 			}
 		}

--- a/controllers/container_image/conditions.go
+++ b/controllers/container_image/conditions.go
@@ -36,7 +36,7 @@ func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedS
 	}
 
 	currentPod := k8s.GetNewestPodFromList(pods.Items)
-	for i, containerStatus := range currentPod.Status.ContainerStatuses {
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
 		if containerStatus.Name != "mondoo-containers-scan" {
 			continue
 		}
@@ -44,7 +44,7 @@ func updateImageScanningConditions(config *v1alpha2.MondooAuditConfig, degradedS
 			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 			msg = oomMessage
 			affectedPods = append(affectedPods, currentPod.Name)
-			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+			memoryLimit = k8s.ContainerMemoryLimit(&currentPod, containerStatus.Name)
 			reason = "KubernetesContainerImageScanningUnavailable"
 			status = corev1.ConditionTrue
 		}

--- a/controllers/container_image/conditions_test.go
+++ b/controllers/container_image/conditions_test.go
@@ -163,3 +163,29 @@ func oomPodList() *corev1.PodList {
 		},
 	}
 }
+
+func TestConditions_OOM_ReportsTheScanContainerLimit(t *testing.T) {
+	config := &v1alpha2.MondooAuditConfig{
+		Spec: v1alpha2.MondooAuditConfigSpec{
+			Containers: v1alpha2.Containers{Enable: true},
+		},
+	}
+
+	// The kubelet sorts container statuses by name, a sidecar can therefore sit
+	// at a different index in the spec than in the status.
+	podList := oomPodList()
+	pod := &podList.Items[0]
+	pod.Spec.Containers = append([]corev1.Container{{
+		Name: "zzz-sidecar",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+		},
+	}}, pod.Spec.Containers...)
+	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{Name: "zzz-sidecar"})
+
+	updateImageScanningConditions(config, true, podList)
+
+	cond := config.Status.Conditions[0]
+	assert.Equal(t, oomMessage, cond.Message)
+	assert.Equal(t, "1Gi", cond.MemoryLimit)
+}

--- a/controllers/k8s_scan/conditions.go
+++ b/controllers/k8s_scan/conditions.go
@@ -36,7 +36,7 @@ func updateWorkloadsConditions(config *v1alpha2.MondooAuditConfig, degradedStatu
 	}
 
 	currentPod := k8s.GetNewestPodFromList(pods.Items)
-	for i, containerStatus := range currentPod.Status.ContainerStatuses {
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
 		if containerStatus.Name != "mondoo-k8s-scan" {
 			continue
 		}
@@ -44,7 +44,7 @@ func updateWorkloadsConditions(config *v1alpha2.MondooAuditConfig, degradedStatu
 			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 			msg = oomMessage
 			affectedPods = append(affectedPods, currentPod.Name)
-			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+			memoryLimit = k8s.ContainerMemoryLimit(&currentPod, containerStatus.Name)
 			reason = "KubernetesResourcesScanningUnavailable"
 			status = corev1.ConditionTrue
 		}

--- a/controllers/nodes/conditions.go
+++ b/controllers/nodes/conditions.go
@@ -45,7 +45,7 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 	for _, pods := range podsPerNode {
 		currentPod := k8s.GetNewestPodFromList(pods)
 		isOOM := false
-		for i, containerStatus := range currentPod.Status.ContainerStatuses {
+		for _, containerStatus := range currentPod.Status.ContainerStatuses {
 			if containerStatus.Name != "cnspec" {
 				continue
 			}
@@ -54,7 +54,7 @@ func updateNodeConditions(config *v1alpha2.MondooAuditConfig, degradedStatus boo
 				isOOM = true
 				msg = oomMessage
 				affectedPods = append(affectedPods, currentPod.Name)
-				memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+				memoryLimit = k8s.ContainerMemoryLimit(&currentPod, containerStatus.Name)
 				reason = "NodeScanningUnavailable"
 				status = corev1.ConditionTrue
 				break

--- a/controllers/resource_watcher/conditions.go
+++ b/controllers/resource_watcher/conditions.go
@@ -37,7 +37,7 @@ func updateResourceWatcherConditions(config *v1alpha2.MondooAuditConfig, degrade
 	}
 
 	currentPod := k8s.GetNewestPodFromList(pods.Items)
-	for i, containerStatus := range currentPod.Status.ContainerStatuses {
+	for _, containerStatus := range currentPod.Status.ContainerStatuses {
 		if containerStatus.Name != "mondoo-resource-watcher" {
 			continue
 		}
@@ -45,7 +45,7 @@ func updateResourceWatcherConditions(config *v1alpha2.MondooAuditConfig, degrade
 			(containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 137) {
 			msg = oomMessage
 			affectedPods = append(affectedPods, currentPod.Name)
-			memoryLimit = currentPod.Spec.Containers[i].Resources.Limits.Memory().String()
+			memoryLimit = k8s.ContainerMemoryLimit(&currentPod, containerStatus.Name)
 			reason = "ResourceWatcherUnavailable"
 			status = corev1.ConditionTrue
 		}

--- a/pkg/utils/k8s/pods.go
+++ b/pkg/utils/k8s/pods.go
@@ -9,6 +9,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// ContainerMemoryLimit returns the memory limit of the named container as a
+// string. It returns an empty string if the Pod has no such container.
+//
+// The kubelet sorts status.containerStatuses by name, while spec.containers
+// keeps the order of the manifest. The two lists must therefore be matched by
+// name, not by index.
+func ContainerMemoryLimit(pod *corev1.Pod, containerName string) string {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == containerName {
+			return pod.Spec.Containers[i].Resources.Limits.Memory().String()
+		}
+	}
+	return ""
+}
+
 // GetNewestPodFromList returns the most recent pod from a pod list
 // This is determined by the creation timestamp of the pod
 func GetNewestPodFromList(pods []corev1.Pod) corev1.Pod {

--- a/pkg/utils/k8s/pods_test.go
+++ b/pkg/utils/k8s/pods_test.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestContainerMemoryLimit(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "sidecar",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+					},
+				},
+				{
+					Name: "cnspec",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("300Mi")},
+					},
+				},
+				{
+					Name: "no-limits",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "300Mi", ContainerMemoryLimit(pod, "cnspec"))
+	assert.Equal(t, "64Mi", ContainerMemoryLimit(pod, "sidecar"))
+	assert.Equal(t, "0", ContainerMemoryLimit(pod, "no-limits"))
+	assert.Equal(t, "", ContainerMemoryLimit(pod, "missing"))
+	assert.Equal(t, "", ContainerMemoryLimit(&corev1.Pod{}, "cnspec"))
+}


### PR DESCRIPTION
## Defect

The OOM conditions walk `status.containerStatuses` and use the loop index to read `spec.containers[i].Resources.Limits`. The kubelet sorts container statuses by name, while `spec.containers` keeps the order of the manifest. As soon as a scan Pod has more than one container, for example a sidecar added through `jobOverrides`, the two lists no longer line up and the condition reports the memory limit of the wrong container.

The same pattern exists in five places:

* `controllers/nodes/conditions.go`
* `controllers/container_image/conditions.go`
* `controllers/k8s_scan/conditions.go`
* `controllers/resource_watcher/conditions.go`
* `cmd/mondoo-operator/operator/operator_status.go`

## Change

Add `k8s.ContainerMemoryLimit(pod, containerName)` and match the container by name in all five places. The helper returns an empty string when the Pod has no such container, which also removes the out of range risk of the index based lookup.

## Verification

A new regression test in `controllers/container_image/conditions_test.go` puts a sidecar before the scan container in the spec, and appends the sidecar status after the scan container status.

Before the change:

```
$ go test ./controllers/container_image/... -run TestConditions_OOM_ReportsTheScanContainerLimit
    Expected: 1Gi
    Actual:   64Mi
FAIL
```

After the change the test passes. `go test ./controllers/... ./api/... ./pkg/... ./cmd/...` passes.

New unit tests in `pkg/utils/k8s/pods_test.go` cover the named container, a container without limits, a missing container and an empty Pod.
