### PR TITLE
⚡ perf(status): list nodes without a deep copy

### DIFF
--- a/controllers/status/status_reporter.go
+++ b/controllers/status/status_reporter.go
@@ -48,8 +48,10 @@ func (r *StatusReporter) Report(ctx context.Context, m v1alpha2.MondooAuditConfi
 		return nil
 	}
 
+	// The report only reads the node names, so skip the deep copy of every
+	// cached Node. The returned items must stay read only.
 	nodes := v1.NodeList{}
-	if err := r.kubeClient.List(ctx, &nodes); err != nil {
+	if err := r.kubeClient.List(ctx, &nodes, client.UnsafeDisableDeepCopy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What allocates

`StatusReporter.Report` runs on every reconcile of a MondooAuditConfig with console integration. It lists all Nodes from the manager cache and reads only `Name` (`ReportStatusRequestFromAuditConfig`). A cached List deep copies every Node into a fresh slice, so the whole node inventory becomes garbage on every reconcile.

## Change

Pass `client.UnsafeDisableDeepCopy` on that one List. The cache then hands back its stored objects. The items are read only, which the comment states, and the report only reads names.

## Measurement

kind cluster with 61 Nodes, each with 100 images, 3 conditions and full node info. A harness lists the NodeList from a started cache 200 times and reports `TotalAlloc` per List.

| run | per List | per node | time per List |
| --- | --- | --- | --- |
| deep copy, untrimmed Node cache | 818574 B | 13419 B | 869 us |
| deep copy, trimmed Node cache (PR #1623) | 277819 B | 4555 B | 268 us |
| no deep copy | 52423 B | 859 B | 39 us |

Two repeats each, spread below 0.1 percent. On a 500 node cluster this is about 2.3 MB of garbage per reconcile after #1623, or 6.7 MB today, against 0.43 MB.

## Correctness

* The report reads only `nodes[i].Name` and never writes to the list.
* `go test ./controllers/... ./api/... ./pkg/... ./cmd/...` passes.
