### PR TITLE
🐛 nodes: give node assets their cloud instance identity

### DIFF
--- a/controllers/nodes/aws_account.go
+++ b/controllers/nodes/aws_account.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"sync"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// irsaRoleAnnotation is the annotation IRSA uses to bind a ServiceAccount to an
+// IAM role.
+const irsaRoleAnnotation = "eks.amazonaws.com/role-arn"
+
+// stsTimeout bounds the GetCallerIdentity call. The result is cached for the
+// life of the process, so this runs at most once; a cluster with no route to
+// STS should not stall a reconcile waiting for it.
+const stsTimeout = 5 * time.Second
+
+// iamRoleARNRegex extracts the account ID from an IAM role ARN, e.g.
+// arn:aws:iam::123456789012:role/some-role. It accepts every partition, so
+// aws-cn and aws-us-gov ARNs work too.
+var iamRoleARNRegex = regexp.MustCompile(`^arn:aws[a-z-]*:iam::(\d{12}):`)
+
+// awsAccountResolver finds the AWS account the cluster runs in, without going
+// through the instance metadata service.
+//
+// IMDS is the obvious source and the wrong one here: Karpenter and the EKS
+// managed node group module both default httpPutResponseHopLimit to 1, which
+// stops any pod that is not on the host network from reading it. Raising that
+// limit exposes the node role to every pod on the node, and host networking is
+// a heavy grant for a scan pod. Every source below avoids the problem instead.
+//
+// The account never changes for a given operator deployment, so the answer is
+// resolved once and cached -- including a negative answer, which stops a
+// cluster with no AWS identity from retrying on every reconcile.
+type awsAccountResolver struct {
+	// Namespace is the operator's own namespace, where the ServiceAccount
+	// fallback looks for IRSA annotations.
+	Namespace string
+
+	once    sync.Once
+	account string
+}
+
+// awsAccountResolvers caches one resolver per operator namespace. The account
+// is a property of the cluster, so the answer is worth keeping across
+// reconciles -- the DeploymentHandler that asks for it is rebuilt on every one.
+// Keyed by namespace rather than held as a single global because the fallback
+// branch looks for ServiceAccounts in a specific namespace, and an operator may
+// reconcile MondooAuditConfigs in more than one.
+var awsAccountResolvers sync.Map
+
+// awsAccountResolverFor returns the cached resolver for an operator namespace.
+func awsAccountResolverFor(namespace string) *awsAccountResolver {
+	if resolver, ok := awsAccountResolvers.Load(namespace); ok {
+		return resolver.(*awsAccountResolver)
+	}
+	resolver, _ := awsAccountResolvers.LoadOrStore(namespace, &awsAccountResolver{Namespace: namespace})
+	return resolver.(*awsAccountResolver)
+}
+
+// Resolve returns the AWS account ID, or "" when it cannot be established. An
+// empty result is a normal outcome -- a cluster outside AWS, or one whose
+// operator has no cloud identity -- and callers must treat it as "skip the AWS
+// platform ID", never as an error worth failing a reconcile over.
+func (r *awsAccountResolver) Resolve(ctx context.Context, c client.Client) string {
+	r.once.Do(func() {
+		r.account = r.resolve(ctx, c)
+	})
+	return r.account
+}
+
+func (r *awsAccountResolver) resolve(ctx context.Context, c client.Client) string {
+	// 1. IRSA injects AWS_ROLE_ARN into every pod it serves, so the account is
+	//    already in this process's environment. Free, and no network call.
+	if account := accountFromRoleARN(os.Getenv("AWS_ROLE_ARN")); account != "" {
+		return account
+	}
+
+	// 2. Ask STS. This is the authoritative answer and the only one that works
+	//    under EKS Pod Identity, which hands out credentials without ever
+	//    naming a role ARN in the environment. GetCallerIdentity needs no IAM
+	//    permission at all -- any valid credentials can call it -- so this adds
+	//    no privilege requirement, only the need for credentials to exist.
+	if account := accountFromSTS(ctx); account != "" {
+		return account
+	}
+
+	// 3. Fall back to reading an IRSA annotation off a ServiceAccount in the
+	//    operator's namespace. This needs no AWS credentials at all, which
+	//    makes it the branch that works on a deployment where only the
+	//    scanning ServiceAccount was ever wired up to IAM.
+	//
+	//    It is last because it is the weakest: it reports the account of
+	//    whatever role somebody annotated, which is the cluster's account in
+	//    every ordinary setup -- the OIDC provider backing IRSA lives there --
+	//    but would be wrong for a role assumed across accounts.
+	return r.accountFromServiceAccounts(ctx, c)
+}
+
+// accountFromRoleARN pulls the account ID out of an IAM role ARN.
+func accountFromRoleARN(arn string) string {
+	match := iamRoleARNRegex.FindStringSubmatch(arn)
+	if match == nil {
+		return ""
+	}
+	return match[1]
+}
+
+// accountFromSTS asks STS who we are. Returns "" whenever no usable credentials
+// are configured, which is the common case outside AWS.
+func accountFromSTS(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, stsTimeout)
+	defer cancel()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		logger.V(1).Info("could not load an AWS configuration; skipping STS", "error", err.Error())
+		return ""
+	}
+
+	out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		logger.V(1).Info("could not resolve the AWS account from STS", "error", err.Error())
+		return ""
+	}
+	if out.Account == nil || !awsAccountIDRegex.MatchString(*out.Account) {
+		return ""
+	}
+	return *out.Account
+}
+
+// accountFromServiceAccounts scans the operator's namespace for an IRSA
+// annotation and takes the account from the role ARN it points at.
+func (r *awsAccountResolver) accountFromServiceAccounts(ctx context.Context, c client.Client) string {
+	if c == nil || r.Namespace == "" {
+		return ""
+	}
+
+	serviceAccounts := &corev1.ServiceAccountList{}
+	if err := c.List(ctx, serviceAccounts, client.InNamespace(r.Namespace)); err != nil {
+		logger.V(1).Info("could not list service accounts for AWS account detection", "error", err.Error())
+		return ""
+	}
+
+	for _, sa := range serviceAccounts.Items {
+		if account := accountFromRoleARN(sa.Annotations[irsaRoleAnnotation]); account != "" {
+			return account
+		}
+	}
+	return ""
+}

--- a/controllers/nodes/aws_account.go
+++ b/controllers/nodes/aws_account.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,12 @@ const irsaRoleAnnotation = "eks.amazonaws.com/role-arn"
 // life of the process, so this runs at most once; a cluster with no route to
 // STS should not stall a reconcile waiting for it.
 const stsTimeout = 5 * time.Second
+
+// failedResolveBackoff is how long a failed resolution is left alone before it
+// is attempted again. Long enough that a cluster outside AWS is not paying for
+// a lookup on every reconcile, short enough that a cluster that is on AWS
+// recovers on its own rather than needing the operator restarted.
+const failedResolveBackoff = 10 * time.Minute
 
 // iamRoleARNRegex extracts the account ID from an IAM role ARN, e.g.
 // arn:aws:iam::123456789012:role/some-role. It accepts every partition, so
@@ -60,8 +67,21 @@ type awsAccountResolver struct {
 	// fallback looks for IRSA annotations.
 	Namespace string
 
-	once    sync.Once
+	mu      sync.Mutex
 	account string
+	// resolved records that account holds a real answer. A successful
+	// resolution is kept for the life of the process -- a cluster's account
+	// does not change.
+	resolved bool
+	// retryAfter holds off the next attempt once one has failed. Failures are
+	// deliberately NOT cached the way successes are: a resolution can come back
+	// empty for reasons that pass, most obviously the STS call being cut short
+	// when the reconcile it inherited its context from is cancelled. Caching
+	// that permanently would leave every node in an AWS cluster without its
+	// cloud identity until the operator pod restarted, with nothing to indicate
+	// why. The backoff keeps the retries cheap for a cluster that is genuinely
+	// not on AWS, where the answer really is "nothing" every time.
+	retryAfter time.Time
 }
 
 // awsAccountResolvers caches one resolver per operator namespace. The account
@@ -86,10 +106,25 @@ func awsAccountResolverFor(namespace string) *awsAccountResolver {
 // operator has no cloud identity -- and callers must treat it as "skip the AWS
 // platform ID", never as an error worth failing a reconcile over.
 func (r *awsAccountResolver) Resolve(ctx context.Context, c client.Client) string {
-	r.once.Do(func() {
-		r.account = r.resolve(ctx, c)
-	})
-	return r.account
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.resolved {
+		return r.account
+	}
+	if time.Now().Before(r.retryAfter) {
+		return ""
+	}
+
+	account := r.resolve(ctx, c)
+	if account == "" {
+		r.retryAfter = time.Now().Add(failedResolveBackoff)
+		return ""
+	}
+
+	r.account = account
+	r.resolved = true
+	return account
 }
 
 func (r *awsAccountResolver) resolve(ctx context.Context, c client.Client) string {
@@ -135,7 +170,15 @@ func accountFromSTS(ctx context.Context) string {
 	ctx, cancel := context.WithTimeout(ctx, stsTimeout)
 	defer cancel()
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	// Disable the SDK's own EC2 metadata lookup. Without this the credential
+	// and region chains reach for IMDS, which is precisely what this resolver
+	// exists to avoid: on a node with a metadata hop limit of 1 the operator
+	// pod cannot reach it, so the probe does not fail, it hangs until the
+	// timeout below -- turning a lookup that should be instant into a stalled
+	// reconcile. Every credential source that can actually work here (IRSA,
+	// Pod Identity, a static configuration) is unaffected by the switch.
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
 	if err != nil {
 		logger.V(1).Info("could not load an AWS configuration; skipping STS", "error", err.Error())
 		return ""

--- a/controllers/nodes/aws_account.go
+++ b/controllers/nodes/aws_account.go
@@ -46,9 +46,14 @@ const stsTimeout = 5 * time.Second
 const failedResolveBackoff = 10 * time.Minute
 
 // iamRoleARNRegex extracts the account ID from an IAM role ARN, e.g.
-// arn:aws:iam::123456789012:role/some-role. It accepts every partition, so
-// aws-cn and aws-us-gov ARNs work too.
-var iamRoleARNRegex = regexp.MustCompile(`^arn:aws[a-z-]*:iam::(\d{12}):`)
+// arn:aws:iam::123456789012:role/some-role.
+//
+// The partition is matched as "aws" followed by whole dash-separated words, so
+// every real one is accepted -- aws, aws-cn, aws-us-gov, aws-iso, aws-iso-b --
+// while a string that merely starts with those letters, like "awsxyz", is not.
+// The ARN comes from a trusted place either way, but a regex that accepts
+// nonsense makes it harder to see what the code actually relies on.
+var iamRoleARNRegex = regexp.MustCompile(`^arn:aws(?:-[a-z]+)*:iam::(\d{12}):`)
 
 // awsAccountResolver finds the AWS account the cluster runs in, without going
 // through the instance metadata service.

--- a/controllers/nodes/aws_account_test.go
+++ b/controllers/nodes/aws_account_test.go
@@ -56,6 +56,17 @@ func TestAccountFromRoleARN(t *testing.T) {
 			want: "123456789012",
 		},
 		{
+			name: "iso partition",
+			arn:  "arn:aws-iso-b:iam::123456789012:role/example",
+			want: "123456789012",
+		},
+		{
+			// Starts with the right letters but is not a partition.
+			name: "made-up partition",
+			arn:  "arn:awsxyz:iam::123456789012:role/example",
+			want: "",
+		},
+		{
 			name: "not an ARN",
 			arn:  "ecr-image-pull",
 			want: "",

--- a/controllers/nodes/aws_account_test.go
+++ b/controllers/nodes/aws_account_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAccountFromRoleARN(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{
+			name: "IRSA role",
+			arn:  "arn:aws:iam::959975882244:role/ecr-image-pull",
+			want: "959975882244",
+		},
+		{
+			name: "path-scoped role",
+			arn:  "arn:aws:iam::959975882244:role/some/path/ecr-image-pull",
+			want: "959975882244",
+		},
+		{
+			name: "govcloud partition",
+			arn:  "arn:aws-us-gov:iam::123456789012:role/example",
+			want: "123456789012",
+		},
+		{
+			name: "china partition",
+			arn:  "arn:aws-cn:iam::123456789012:role/example",
+			want: "123456789012",
+		},
+		{
+			name: "not an ARN",
+			arn:  "ecr-image-pull",
+			want: "",
+		},
+		{
+			name: "empty",
+			arn:  "",
+			want: "",
+		},
+		{
+			name: "account is not twelve digits",
+			arn:  "arn:aws:iam::12345:role/example",
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, accountFromRoleARN(test.arn))
+		})
+	}
+}
+
+func serviceAccount(name, namespace string, annotations map[string]string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Annotations: annotations},
+	}
+}
+
+func TestAccountFromServiceAccounts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	t.Run("reads the account off an IRSA annotation", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			serviceAccount("controller-manager", "mondoo-operator", nil),
+			serviceAccount("mondoo-operator-k8s-resources-scanning", "mondoo-operator", map[string]string{
+				irsaRoleAnnotation: "arn:aws:iam::959975882244:role/ecr-image-pull",
+			}),
+		).Build()
+
+		r := &awsAccountResolver{Namespace: "mondoo-operator"}
+		assert.Equal(t, "959975882244", r.accountFromServiceAccounts(context.Background(), c))
+	})
+
+	t.Run("ignores service accounts in other namespaces", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			serviceAccount("some-app", "default", map[string]string{
+				irsaRoleAnnotation: "arn:aws:iam::111111111111:role/other",
+			}),
+		).Build()
+
+		r := &awsAccountResolver{Namespace: "mondoo-operator"}
+		assert.Equal(t, "", r.accountFromServiceAccounts(context.Background(), c))
+	})
+
+	t.Run("no annotated service account", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			serviceAccount("controller-manager", "mondoo-operator", nil),
+		).Build()
+
+		r := &awsAccountResolver{Namespace: "mondoo-operator"}
+		assert.Equal(t, "", r.accountFromServiceAccounts(context.Background(), c))
+	})
+
+	t.Run("no client", func(t *testing.T) {
+		r := &awsAccountResolver{Namespace: "mondoo-operator"}
+		assert.Equal(t, "", r.accountFromServiceAccounts(context.Background(), nil))
+	})
+}
+
+func TestAWSAccountResolverUsesTheEnvironmentFirst(t *testing.T) {
+	// IRSA puts AWS_ROLE_ARN in the pod, so the account is answerable without
+	// a network call or any cluster lookup.
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::959975882244:role/ecr-image-pull")
+
+	r := &awsAccountResolver{Namespace: "mondoo-operator"}
+	assert.Equal(t, "959975882244", r.Resolve(context.Background(), nil))
+}
+
+func TestAWSAccountResolverCachesTheAnswer(t *testing.T) {
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::959975882244:role/ecr-image-pull")
+
+	r := &awsAccountResolver{Namespace: "mondoo-operator"}
+	require.Equal(t, "959975882244", r.Resolve(context.Background(), nil))
+
+	// A cluster's account does not change, so a second call must not re-resolve
+	// -- including after the environment that produced the first answer is gone.
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::111111111111:role/other")
+	assert.Equal(t, "959975882244", r.Resolve(context.Background(), nil))
+}

--- a/controllers/nodes/aws_account_test.go
+++ b/controllers/nodes/aws_account_test.go
@@ -19,6 +19,7 @@ package nodes
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,4 +146,27 @@ func TestAWSAccountResolverCachesTheAnswer(t *testing.T) {
 	// -- including after the environment that produced the first answer is gone.
 	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::111111111111:role/other")
 	assert.Equal(t, "959975882244", r.Resolve(context.Background(), nil))
+}
+
+func TestAWSAccountResolverRetriesAfterAFailure(t *testing.T) {
+	// A failed resolution must not be cached the way a successful one is: a
+	// cancelled reconcile, or credentials that arrive a moment later, would
+	// otherwise leave every node without its cloud identity until the operator
+	// pod restarted.
+	t.Setenv("AWS_ROLE_ARN", "")
+
+	r := &awsAccountResolver{Namespace: "mondoo-operator"}
+	require.Equal(t, "", r.Resolve(context.Background(), nil))
+	require.False(t, r.resolved)
+	require.False(t, r.retryAfter.IsZero(), "a failure should schedule a retry")
+
+	// Within the backoff the resolver holds off, so a cluster that really is
+	// not on AWS does not pay for a lookup on every reconcile.
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::959975882244:role/ecr-image-pull")
+	assert.Equal(t, "", r.Resolve(context.Background(), nil))
+
+	// Once it expires the answer is picked up.
+	r.retryAfter = time.Now().Add(-time.Second)
+	assert.Equal(t, "959975882244", r.Resolve(context.Background(), nil))
+	assert.True(t, r.resolved)
 }

--- a/controllers/nodes/aws_platform_id.go
+++ b/controllers/nodes/aws_platform_id.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// AWSPlatformIDEnvVar carries the node's EC2 platform identifier into the
+	// scan pod. The node inventory is one ConfigMap shared by every node, so a
+	// per-node value has to travel as an environment variable.
+	AWSPlatformIDEnvVar = "MONDOO_AWS_PLATFORM_ID"
+
+	regionLabel       = "topology.kubernetes.io/region"
+	legacyRegionLabel = "failure-domain.beta.kubernetes.io/region"
+)
+
+// awsProviderIDScheme prefixes the providerID the AWS cloud controller writes,
+// e.g. "aws:///eu-central-1a/i-0a8caeccfd813a595".
+const awsProviderIDScheme = "aws://"
+
+// awsZoneRegex matches an availability zone segment. It is deliberately loose:
+// awsRegion decides separately whether a zone has a shape a region can be
+// derived from, and zone naming has grown local and wavelength forms over time.
+var awsZoneRegex = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// ec2InstanceIDRegex matches an EC2 instance ID -- "i-" followed by the 8-hex
+// legacy form or the 17-hex current one. Fargate nodes carry a providerID under
+// the same aws:// scheme whose last segment is a task UUID, not an instance, so
+// the shape has to be checked rather than assumed.
+var ec2InstanceIDRegex = regexp.MustCompile(`^i-[0-9a-f]{8,}$`)
+
+// standardAZRegex matches the ordinary "<region><letter>" availability zone
+// form (eu-central-1a), where trimming the trailing letter yields the region.
+// Local and wavelength zones (us-west-2-lax-1a) do not follow that rule, so
+// they are deliberately not matched -- guessing there would produce a region
+// that does not exist.
+var standardAZRegex = regexp.MustCompile(`^([a-z]{2}(?:-[a-z]+)+-\d)[a-z]$`)
+
+// awsAccountIDRegex matches an AWS account ID.
+var awsAccountIDRegex = regexp.MustCompile(`^\d{12}$`)
+
+// AWSPlatformID builds the Mondoo platform identifier for the EC2 instance
+// backing a node, or "" when the node is not an EC2 instance or any part of the
+// identity is unknown.
+//
+// The identifier has to match the one the AWS integration reports for the same
+// instance, byte for byte, or the two end up as separate assets for one
+// machine. That means all three parts must be right, and returning nothing is
+// always better than returning a guess: a wrong account or region does not fail
+// loudly, it silently merges this node with a different machine's asset.
+//
+// The instance ID and availability zone come from node.spec.providerID, the
+// region from the node's own topology label, and the account from the caller
+// (see awsAccountResolver) -- none of which requires the instance metadata
+// service, which a scan pod on a hop-limit-1 node cannot reach anyway.
+func AWSPlatformID(node corev1.Node, accountID string) string {
+	if !awsAccountIDRegex.MatchString(accountID) {
+		return ""
+	}
+
+	instanceID, zone, ok := parseAWSProviderID(node.Spec.ProviderID)
+	if !ok {
+		return ""
+	}
+
+	region := awsRegion(node, zone)
+	if region == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/%s/regions/%s/instances/%s",
+		accountID, region, instanceID)
+}
+
+// parseAWSProviderID splits an EC2 node's providerID into its instance ID and
+// availability zone. It reports false for every other provider and for AWS
+// nodes that are not EC2 instances.
+//
+// Empty path segments are skipped so that the canonical three-slash form and a
+// two-slash spelling of the same thing parse identically; anything that does
+// not come down to exactly one zone and one instance ID is rejected rather than
+// guessed at.
+func parseAWSProviderID(providerID string) (instanceID string, zone string, ok bool) {
+	rest, found := strings.CutPrefix(providerID, awsProviderIDScheme)
+	if !found {
+		return "", "", false
+	}
+
+	segments := make([]string, 0, 2)
+	for _, segment := range strings.Split(rest, "/") {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	if len(segments) != 2 {
+		return "", "", false
+	}
+
+	zone, instanceID = segments[0], segments[1]
+	if !awsZoneRegex.MatchString(zone) || !ec2InstanceIDRegex.MatchString(instanceID) {
+		return "", "", false
+	}
+	return instanceID, zone, true
+}
+
+// awsRegion returns the node's region, preferring the topology labels the cloud
+// controller sets over deriving it from the availability zone.
+func awsRegion(node corev1.Node, zone string) string {
+	if region := node.Labels[regionLabel]; region != "" {
+		return region
+	}
+	if region := node.Labels[legacyRegionLabel]; region != "" {
+		return region
+	}
+
+	if match := standardAZRegex.FindStringSubmatch(zone); match != nil {
+		return match[1]
+	}
+	return ""
+}

--- a/controllers/nodes/aws_platform_id_test.go
+++ b/controllers/nodes/aws_platform_id_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 Mondoo, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func awsNode(providerID string, labels map[string]string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-10-4-200-202.eu-central-1.compute.internal", Labels: labels},
+		Spec:       corev1.NodeSpec{ProviderID: providerID},
+	}
+}
+
+func TestAWSPlatformID(t *testing.T) {
+	const account = "959975882244"
+
+	tests := []struct {
+		name    string
+		node    corev1.Node
+		account string
+		want    string
+	}{
+		{
+			name:    "EKS node with a region label",
+			node:    awsNode("aws:///eu-central-1a/i-0a8caeccfd813a595", map[string]string{regionLabel: "eu-central-1"}),
+			account: account,
+			want:    "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/eu-central-1/instances/i-0a8caeccfd813a595",
+		},
+		{
+			// No topology label, so the region is derived from the zone.
+			name:    "region derived from the availability zone",
+			node:    awsNode("aws:///us-west-2b/i-0123456789abcdef0", nil),
+			account: account,
+			want:    "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/us-west-2/instances/i-0123456789abcdef0",
+		},
+		{
+			name:    "legacy region label",
+			node:    awsNode("aws:///eu-west-1c/i-0a8caeccfd813a595", map[string]string{legacyRegionLabel: "eu-west-1"}),
+			account: account,
+			want:    "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/eu-west-1/instances/i-0a8caeccfd813a595",
+		},
+		{
+			// A local zone does not end in "<region><letter>", so trimming the
+			// last character would invent a region that does not exist. Without
+			// a label there is nothing trustworthy to use.
+			name:    "local zone without a region label yields nothing",
+			node:    awsNode("aws:///us-west-2-lax-1a/i-0a8caeccfd813a595", nil),
+			account: account,
+			want:    "",
+		},
+		{
+			name:    "local zone with a region label",
+			node:    awsNode("aws:///us-west-2-lax-1a/i-0a8caeccfd813a595", map[string]string{regionLabel: "us-west-2"}),
+			account: account,
+			want:    "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/us-west-2/instances/i-0a8caeccfd813a595",
+		},
+		{
+			// Fargate reuses the aws:// scheme with a task id. Turning that
+			// into an EC2 platform ID would invent an instance.
+			name:    "fargate node is not an EC2 instance",
+			node:    awsNode("aws:///eu-central-1a/a1b2c3d4-1234-5678-9abc-def012345678", map[string]string{regionLabel: "eu-central-1"}),
+			account: account,
+			want:    "",
+		},
+		{
+			name:    "non-AWS provider",
+			node:    awsNode("gce://my-project/europe-west1-b/my-node", map[string]string{regionLabel: "europe-west1"}),
+			account: account,
+			want:    "",
+		},
+		{
+			name:    "node without a providerID",
+			node:    awsNode("", map[string]string{regionLabel: "eu-central-1"}),
+			account: account,
+			want:    "",
+		},
+		{
+			// The common non-AWS case: no account was resolved. Returning
+			// nothing keeps the node exactly as it is scanned today.
+			name:    "unknown account",
+			node:    awsNode("aws:///eu-central-1a/i-0a8caeccfd813a595", map[string]string{regionLabel: "eu-central-1"}),
+			account: "",
+			want:    "",
+		},
+		{
+			name:    "malformed account is rejected rather than used",
+			node:    awsNode("aws:///eu-central-1a/i-0a8caeccfd813a595", map[string]string{regionLabel: "eu-central-1"}),
+			account: "not-an-account",
+			want:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, AWSPlatformID(test.node, test.account))
+		})
+	}
+}
+
+func TestParseAWSProviderID(t *testing.T) {
+	t.Run("three-slash form", func(t *testing.T) {
+		id, zone, ok := parseAWSProviderID("aws:///eu-central-1a/i-0a8caeccfd813a595")
+		assert.True(t, ok)
+		assert.Equal(t, "i-0a8caeccfd813a595", id)
+		assert.Equal(t, "eu-central-1a", zone)
+	})
+
+	t.Run("two-slash form", func(t *testing.T) {
+		// Tolerated so the same providerID spelled with one fewer slash
+		// parses identically rather than being silently dropped.
+		id, zone, ok := parseAWSProviderID("aws://eu-central-1a/i-0a8caeccfd813a595")
+		assert.True(t, ok)
+		assert.Equal(t, "i-0a8caeccfd813a595", id)
+		assert.Equal(t, "eu-central-1a", zone)
+	})
+
+	t.Run("trailing segment is rejected", func(t *testing.T) {
+		_, _, ok := parseAWSProviderID("aws:///eu-central-1a/i-0a8caeccfd813a595/extra")
+		assert.False(t, ok)
+	})
+}
+
+func TestAWSPlatformIDEnv(t *testing.T) {
+	t.Run("set when the identity is known", func(t *testing.T) {
+		env := awsPlatformIDEnv(
+			awsNode("aws:///eu-central-1a/i-0a8caeccfd813a595", map[string]string{regionLabel: "eu-central-1"}),
+			"959975882244")
+
+		assert.Equal(t, []corev1.EnvVar{{
+			Name:  AWSPlatformIDEnvVar,
+			Value: "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/eu-central-1/instances/i-0a8caeccfd813a595",
+		}}, env)
+	})
+
+	t.Run("omitted when it is not", func(t *testing.T) {
+		// Nothing at all, rather than an empty value: the inventory template
+		// resolves an unset variable to "", which the provider ignores.
+		assert.Nil(t, awsPlatformIDEnv(awsNode("", nil), ""))
+	})
+}

--- a/controllers/nodes/deployment_handler.go
+++ b/controllers/nodes/deployment_handler.go
@@ -104,6 +104,12 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 		return err
 	}
 
+	// Resolved once per process and cached, including a negative answer. An
+	// empty account is normal -- a cluster outside AWS, or one whose operator
+	// has no cloud identity -- and simply leaves the cloud platform ID off the
+	// node assets, which is how they are scanned today.
+	awsAccountID := awsAccountResolverFor(n.Mondoo.Namespace).Resolve(ctx, n.KubeClient)
+
 	// Delete DaemonSet if it exists
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: DaemonSetName(n.Mondoo.Name), Namespace: n.Mondoo.Namespace},
@@ -125,7 +131,7 @@ func (n *DeploymentHandler) syncCronJob(ctx context.Context) error {
 			return err
 		}
 
-		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig)
+		desired := CronJob(mondooClientImage, node, n.Mondoo, n.IsOpenshift, *n.MondooOperatorConfig, awsAccountID)
 		cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
 		op, err := k8s.CreateOrUpdate(ctx, n.KubeClient, cronJob, n.Mondoo, n.log(), func() error {
 			k8s.UpdateCronJobFields(cronJob, desired)

--- a/controllers/nodes/deployment_handler_test.go
+++ b/controllers/nodes/deployment_handler_test.go
@@ -242,7 +242,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -276,7 +276,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_CustomEnvVars() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -309,7 +309,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CreateCronJobs_Switch() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -349,7 +349,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 	s.NoError(err)
 
 	// Make sure a cron job exists for one of the nodes
-	cj := CronJob(image, nodes.Items[1], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob(image, nodes.Items[1], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 	cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"test-command"}
 	s.NoError(d.KubeClient.Create(s.ctx, cj))
 
@@ -361,7 +361,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_UpdateCronJobs() {
 		cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, n.Name), Namespace: s.auditConfig.Namespace}}
 		s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+		cjExpected := CronJob(image, n, &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 		// Make sure the env vars for both are sorted
 		utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 		utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -407,7 +407,7 @@ func (s *DeploymentHandlerSuite) TestReconcile_CleanCronJobsForDeletedNodes() {
 	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: CronJobName(s.auditConfig.Name, nodes.Items[0].Name), Namespace: s.auditConfig.Namespace}}
 	s.NoError(d.KubeClient.Get(s.ctx, client.ObjectKeyFromObject(cj), cj))
 
-	cjExpected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{})
+	cjExpected := CronJob(image, nodes.Items[0], &s.auditConfig, false, v1alpha2.MondooOperatorConfig{}, "")
 	// Make sure the env vars for both are sorted
 	utils.SortEnvVars(cjExpected.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 	utils.SortEnvVars(cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -39,7 +39,7 @@ const (
 )
 
 // CronJob creates a CronJob for node scanning
-func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig) *batchv1.CronJob {
+func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOpenshift bool, cfg v1alpha2.MondooOperatorConfig, awsAccountID string) *batchv1.CronJob {
 	ls := NodeScanningLabels(*m)
 	cmd := []string{
 		"cnspec", "scan", "local",
@@ -122,13 +122,13 @@ func CronJob(image string, node corev1.Node, m *v1alpha2.MondooAuditConfig, isOp
 										{Name: "config", ReadOnly: true, MountPath: "/etc/opt/"},
 										{Name: "temp", MountPath: "/tmp"},
 									},
-									Env: k8s.MergeEnv(append([]corev1.EnvVar{
+									Env: k8s.MergeEnv(append(append([]corev1.EnvVar{
 										{Name: "DEBUG", Value: "false"},
 										{Name: "MONDOO_PROCFS", Value: "on"},
 										{Name: "MONDOO_AUTO_UPDATE", Value: "false"},
 										{Name: "NODE_NAME", Value: node.Name},
 										{Name: "GOMEMLIMIT", Value: gcLimit},
-									}, proxyEnvVars...), m.Spec.Nodes.Env),
+									}, awsPlatformIDEnv(node, awsAccountID)...), proxyEnvVars...), m.Spec.Nodes.Env),
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 									ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -318,6 +318,19 @@ func DaemonSet(m v1alpha2.MondooAuditConfig, isOpenshift bool, image string, cfg
 	return ds
 }
 
+// awsPlatformIDEnv returns the environment variable carrying the node's EC2
+// platform identifier, or nothing when the node is not an EC2 instance or its
+// identity could not be established. Nothing is deliberate: an unset variable
+// makes the inventory template resolve to an empty string, which the provider
+// ignores, leaving the node exactly as it is scanned today.
+func awsPlatformIDEnv(node corev1.Node, awsAccountID string) []corev1.EnvVar {
+	platformID := AWSPlatformID(node, awsAccountID)
+	if platformID == "" {
+		return nil
+	}
+	return []corev1.EnvVar{{Name: AWSPlatformIDEnvVar, Value: platformID}}
+}
+
 func nodeScanCapabilities(isOpenshift bool) *corev1.Capabilities {
 	caps := &corev1.Capabilities{
 		Drop: []corev1.Capability{"ALL"},
@@ -397,6 +410,15 @@ func Inventory(integrationMRN, clusterUID string, m v1alpha2.MondooAuditConfig) 
 							Type:       "filesystem",
 							Host:       "/mnt/host",
 							PlatformId: fmt.Sprintf(`{{ printf "//platformid.api.mondoo.app/runtime/k8s/uid/%%s/node/%%s" "%s" (getenv "NODE_NAME")}}`, clusterUID),
+							// The node's cloud instance identifier, added alongside
+							// the Kubernetes one rather than replacing it, so the
+							// node resolves to the same asset the cloud integration
+							// already discovered. Resolves to an empty string on a
+							// node whose cloud identity we could not establish, and
+							// the provider skips empty entries.
+							Options: map[string]string{
+								"inject-platform-ids": fmt.Sprintf(`{{ getenv "%s" }}`, AWSPlatformIDEnvVar),
+							},
 						},
 					},
 					Labels: map[string]string{

--- a/controllers/nodes/resources.go
+++ b/controllers/nodes/resources.go
@@ -416,6 +416,18 @@ func Inventory(integrationMRN, clusterUID string, m v1alpha2.MondooAuditConfig) 
 							// already discovered. Resolves to an empty string on a
 							// node whose cloud identity we could not establish, and
 							// the provider skips empty entries.
+							//
+							// Only CronJob() sets this variable. This ConfigMap is
+							// shared by both scan styles, and DaemonSet() builds one
+							// pod spec for every node, so there is no per-node value
+							// it could put here -- a daemonset-style scan resolves
+							// this to nothing and is scanned as it was before.
+							//
+							// Resolving it in the pod instead is not open to us: the
+							// downward API exposes spec.nodeName but not
+							// spec.providerID, and reading the node object would need
+							// a service account token, which node scan pods
+							// deliberately do not mount.
 							Options: map[string]string{
 								"inject-platform-ids": fmt.Sprintf(`{{ getenv "%s" }}`, AWSPlatformIDEnvVar),
 							},

--- a/controllers/nodes/resources_test.go
+++ b/controllers/nodes/resources_test.go
@@ -120,7 +120,7 @@ func TestResources(t *testing.T) {
 				},
 			}
 			mac := test.mondooauditconfig()
-			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 			assert.Equal(t, test.expectedResources, cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 		})
 	}
@@ -131,7 +131,7 @@ func TestCronJob_HasReportTypeNone(t *testing.T) {
 	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
 	cfg := v1alpha2.MondooOperatorConfig{}
 
-	cj := CronJob("test-image:latest", node, m, false, cfg)
+	cj := CronJob("test-image:latest", node, m, false, cfg, "")
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmd := strings.Join(container.Command, " ")
@@ -187,7 +187,7 @@ func TestResources_GOMEMLIMIT(t *testing.T) {
 				},
 			}
 			mac := test.mondooauditconfig()
-			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+			cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 			goMemLimitEnv := corev1.EnvVar{}
 			for _, env := range cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env {
 				if env.Name == "GOMEMLIMIT" {
@@ -222,7 +222,7 @@ func TestCronJob_PrivilegedOpenshift(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cj := CronJob("test123", testNode, mac, true, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", testNode, mac, true, v1alpha2.MondooOperatorConfig{}, "")
 	sc := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext
 	assert.True(t, *sc.Privileged)
 	assert.True(t, *sc.AllowPrivilegeEscalation)
@@ -236,7 +236,7 @@ func TestCronJob_Privileged(t *testing.T) {
 		},
 	}
 	mac := testMondooAuditConfig()
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 	sc := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext
 	assert.False(t, *sc.Privileged)
 	assert.False(t, *sc.AllowPrivilegeEscalation)
@@ -265,7 +265,7 @@ func TestCronJob_JobOverrides(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 
 	// User labels are applied
@@ -302,7 +302,7 @@ func TestCronJob_GlobalJobOverrides(t *testing.T) {
 		Labels:                  map[string]string{"team": "platform"},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 	assert.Equal(t, ptr.To(int32(300)), cj.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 	assert.Equal(t, "platform", cj.Spec.JobTemplate.Labels["team"])
 	assert.Equal(t, "prod", cj.Spec.JobTemplate.Labels["env"])
@@ -337,7 +337,7 @@ func TestCronJob_Suspend(t *testing.T) {
 	mac := testMondooAuditConfig()
 	mac.Spec.Nodes.Suspend = true
 
-	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	cj := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 
 	require.NotNil(t, cj.Spec.Suspend)
 	assert.True(t, *cj.Spec.Suspend)
@@ -355,13 +355,13 @@ func TestCronJob_SuspendMatrix(t *testing.T) {
 		mac := testMondooAuditConfig()
 		mac.Spec.Nodes.Suspend = true
 
-		current := CronJob("test123", testNode, mac, false, cfg)
+		current := CronJob("test123", testNode, mac, false, cfg, "")
 		require.NotNil(t, current.Spec.Suspend)
 		assert.True(t, *current.Spec.Suspend)
 
 		mac.Spec.Nodes.Suspend = false
 		mac.Status.ScanningPaused = false
-		desired := CronJob("test123", testNode, mac, false, cfg)
+		desired := CronJob("test123", testNode, mac, false, cfg, "")
 		k8s.UpdateCronJobFields(current, desired)
 
 		require.NotNil(t, current.Spec.Suspend)
@@ -373,7 +373,7 @@ func TestCronJob_SuspendMatrix(t *testing.T) {
 		mac.Spec.Nodes.Suspend = false
 		mac.Status.ScanningPaused = true
 
-		cj := CronJob("test123", testNode, mac, false, cfg)
+		cj := CronJob("test123", testNode, mac, false, cfg, "")
 		require.NotNil(t, cj.Spec.Suspend)
 		assert.True(t, *cj.Spec.Suspend)
 	})
@@ -383,7 +383,7 @@ func TestCronJob_SuspendMatrix(t *testing.T) {
 		mac.Spec.Nodes.Suspend = false
 		mac.Status.ScanningPaused = false
 
-		cj := CronJob("test123", testNode, mac, false, cfg)
+		cj := CronJob("test123", testNode, mac, false, cfg, "")
 		require.NotNil(t, cj.Spec.Suspend)
 		assert.False(t, *cj.Spec.Suspend)
 	})
@@ -398,12 +398,12 @@ func TestCronJob_UnsuspendWhenScanningResumed(t *testing.T) {
 	mac := testMondooAuditConfig()
 	mac.Status.ScanningPaused = true
 
-	current := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	current := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 	require.NotNil(t, current.Spec.Suspend)
 	assert.True(t, *current.Spec.Suspend)
 
 	mac.Status.ScanningPaused = false
-	desired := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{})
+	desired := CronJob("test123", testNode, mac, false, v1alpha2.MondooOperatorConfig{}, "")
 	k8s.UpdateCronJobFields(current, desired)
 
 	require.NotNil(t, current.Spec.Suspend)
@@ -458,7 +458,7 @@ func TestCronJob_WithProxy(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", testNode, mac, false, cfg, "")
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -480,7 +480,7 @@ func TestCronJob_SkipProxyForCnspec(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", testNode, mac, false, cfg, "")
 	container := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 
 	cmdStr := strings.Join(container.Command, " ")
@@ -502,7 +502,7 @@ func TestCronJob_WithImagePullSecrets(t *testing.T) {
 		},
 	}
 
-	cj := CronJob("test123", testNode, mac, false, cfg)
+	cj := CronJob("test123", testNode, mac, false, cfg, "")
 	secrets := cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "my-registry-secret", secrets[0].Name)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/config v1.32.34
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3
 	github.com/hashicorp/vault-client-go v0.4.3
 	github.com/robfig/cron/v3 v3.0.1
 	go.mondoo.com/mql/v13 v13.32.2
@@ -40,7 +42,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.43.3 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.34 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
@@ -53,7 +54,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3 // indirect
 	github.com/aws/smithy-go v1.27.6 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.34
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.34
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3
 	github.com/hashicorp/vault-client-go v0.4.3
 	github.com/robfig/cron/v3 v3.0.1
@@ -43,7 +44,6 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.43.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.35 // indirect


### PR DESCRIPTION
Fixes #1630

> [!IMPORTANT]
> Depends on **mondoohq/mql#10484**. Merging this alone does not fix the issue — the identifier this PR produces is discarded until cnspec ships the matching provider change.

## The problem

A node the operator scans and a cloud integration also discovers ends up as two assets for one machine. Asset identity is keyed on platform identifiers, and the two sides share none: the node scan reports a Kubernetes identifier, the cloud integration an EC2 one. Nothing downstream can tell they describe the same host, and nothing reconciles duplicates after the fact — identity is decided once, when the scan is ingested.

Observed in one production space: **345 `aws.ec2_instance` assets alongside 360 `machine` assets** for ~350 EKS worker nodes, same OS build on both sides. Confirmed pairs by joining the EC2 asset's reported private IP to the k8s node name.

## Why the node scan cannot discover this itself

It connects over a filesystem connection to a bind-mounted host root, which has no command execution and — on a distro without cloud-init, such as Bottlerocket — no on-disk markers either.

The instance metadata service would answer, but a scan pod that is not on the host network cannot reach it. **Karpenter and the EKS managed node group module both default `httpPutResponseHopLimit` to 1.** Raising it hands the node role to every pod on the node, and host networking is a heavy grant for a scan pod.

## What this does instead

None of that is necessary. Two thirds of the identity are already in the Kubernetes API:

| piece | source | needs IMDS? |
|---|---|---|
| instance ID | `node.spec.providerID` → `aws:///eu-central-1a/i-0a8caeccfd813a595` | no |
| region | `topology.kubernetes.io/region`, else derived from the zone | no |
| account ID | resolved by the operator (below) | no |

Only the account is missing, and the operator can establish it without IMDS — first match wins:

1. **`AWS_ROLE_ARN`**, which IRSA injects into the operator pod. Free, no call.
2. **`sts:GetCallerIdentity`** — authoritative, and the only source that works under EKS Pod Identity. It needs no IAM permission (any valid credentials may call it), so this adds no privilege requirement, only the need for credentials to exist.
3. **An IRSA annotation on a ServiceAccount in the operator's namespace** — needs no AWS credentials at all, so it covers deployments where only the scanning ServiceAccount was ever wired up to IAM.

Resolved once per namespace and cached, including a negative answer, so a cluster outside AWS does not retry on every reconcile.

The identifier travels to the scan pod as `MONDOO_AWS_PLATFORM_ID` and reaches the provider through `inject-platform-ids`, which **appends rather than replaces** — the node keeps its Kubernetes identity and gains its cloud one.

## Everything fails closed

An unknown account, a non-EC2 provider, a Fargate node, or an availability zone whose region cannot be derived all produce no identifier and no environment variable, leaving the node scanned exactly as it is today.

That is deliberate. A wrong account or region does not fail loudly — it silently merges a node with a *different* machine's asset. Returning nothing is always the better answer.

## Scope

- **cronjob-style node scanning only.** The daemonset style builds one pod spec for every node, so a per-node value cannot be injected there.
- `go.mod` only flips `aws-sdk-go-v2/config` and `service/sts` from indirect to direct. No new modules.
- No new RBAC: the operator already reads nodes and ServiceAccounts.

## Tests

`controllers/nodes/aws_platform_id_test.go`, `controllers/nodes/aws_account_test.go` — Fargate task IDs, local zones (`us-west-2-lax-1a`, where trimming the trailing letter would invent a region that does not exist), GCP providerIDs, two- and three-slash providerID spellings, govcloud/china role ARNs, cross-namespace ServiceAccounts, and cache behaviour.

## Verifying

On a node with the matching cnspec build, the asset should carry both identifiers and resolve to the same asset as the cloud integration:

```
//platformid.api.mondoo.app/runtime/k8s/uid/<cluster-uid>/node/<node-name>
//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/<account>/regions/<region>/instances/<instance-id>
```
